### PR TITLE
chore: change type of worker id from number to string

### DIFF
--- a/backend/src/core/loaders/message-worker.loader.ts
+++ b/backend/src/core/loaders/message-worker.loader.ts
@@ -3,7 +3,7 @@ import MessageWorker from './message-worker'
 import logger from '@core/logger'
 import config from '@core/config'
 
-const createMessageWorker = async (workerId: number, isLogger = false): Promise<ModuleThread<MessageWorker>> => {
+const createMessageWorker = async (workerId: string, isLogger = false): Promise<ModuleThread<MessageWorker>> => {
   const worker = await spawn<MessageWorker>(new Worker('./message-worker'))
   worker.init(workerId, isLogger)
   return worker
@@ -12,10 +12,10 @@ const createMessageWorker = async (workerId: number, isLogger = false): Promise<
 const messageWorkerLoader = async (): Promise<void> => {
   let i = 1
   for(; i <= config.messageWorker.numSender; i++){
-    createMessageWorker(i)
+    createMessageWorker(String(i))
   }
   for(; i <=  config.messageWorker.numSender + config.messageWorker.numLogger; i++){
-    createMessageWorker(i, true)
+    createMessageWorker(String(i), true)
   }
   logger.info('MessageWorker loaded')
 }

--- a/backend/src/core/loaders/message-worker/email.class.ts
+++ b/backend/src/core/loaders/message-worker/email.class.ts
@@ -8,10 +8,10 @@ import logger from '@core/logger'
 import config from '@core/config'
 
 class Email {
-    private workerId: number
+    private workerId: string
     private connection: Sequelize
     private mailService: MailService
-    constructor(workerId: number, connection: Sequelize){
+    constructor(workerId: string, connection: Sequelize){
       this.workerId = workerId
       this.connection = connection
       this.mailService = new MailService('Postman.gov.sg <donotreply@mail.postman.gov.sg>', config.mailOptions)

--- a/backend/src/core/loaders/message-worker/index.ts
+++ b/backend/src/core/loaders/message-worker/index.ts
@@ -10,7 +10,7 @@ import Email from './email.class'
 import SMS from './sms.class'
 
 let connection: Sequelize, 
-  workerId: number, 
+  workerId: string, 
   currentCampaignType: string,
   email: Email,
   sms: SMS
@@ -117,7 +117,7 @@ const createAndResumeWorker = (): Promise<void> => {
 }
 
   
-const init = async (index: number, isLogger = false): Promise<void> => {
+const init = async (index: string, isLogger = false): Promise<void> => {
   workerId = index
   connection = createConnection()
   createAndResumeWorker()

--- a/backend/src/core/loaders/message-worker/sms.class.ts
+++ b/backend/src/core/loaders/message-worker/sms.class.ts
@@ -6,10 +6,10 @@ import logger from '@core/logger'
 import { TwilioService } from '@sms/services'
 
 class SMS {
-    private workerId: number
+    private workerId: string
     private connection: Sequelize
     private twilioService: TwilioService | null
-    constructor(workerId: number, connection: Sequelize){
+    constructor(workerId: string, connection: Sequelize){
       this.workerId = workerId
       this.connection = connection
       this.twilioService = null

--- a/backend/src/core/models/job-queue.ts
+++ b/backend/src/core/models/job-queue.ts
@@ -13,8 +13,8 @@ export class JobQueue extends Model<JobQueue> {
   campaign!: Campaign
 
   @ForeignKey(() => Worker)
-  @Column(DataType.INTEGER)
-  workerId?: number
+  @Column(DataType.STRING)
+  workerId?: string
 
   @BelongsTo(() => Worker)
   worker?: Worker

--- a/backend/src/core/models/worker.ts
+++ b/backend/src/core/models/worker.ts
@@ -1,4 +1,11 @@
-import { Model, Table } from 'sequelize-typescript'
+import { Model, Table, Column, DataType } from 'sequelize-typescript'
 
 @Table({ tableName: 'workers' , underscored: true, timestamps: true })
-export class Worker extends Model<Worker> {}
+export class Worker extends Model<Worker> {
+    @Column({
+      type: DataType.STRING,
+      allowNull: false,
+      primaryKey: true,
+    })
+    id!: string
+}

--- a/backend/src/core/resources/sql/get-next-job.sql
+++ b/backend/src/core/resources/sql/get-next-job.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION get_next_job(worker int)
+CREATE OR REPLACE FUNCTION get_next_job(worker TEXT)
 RETURNS json
 LANGUAGE plpgsql AS $$
 DECLARE  

--- a/backend/src/core/resources/sql/resume-worker.sql
+++ b/backend/src/core/resources/sql/resume-worker.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION resume_worker(worker integer)
+CREATE OR REPLACE FUNCTION resume_worker(worker TEXT)
  RETURNS void
  LANGUAGE plpgsql
 AS $$


### PR DESCRIPTION
Change worker_id to string because the id will be the TaskARN of an ECS task. 

```
BEGIN;
ALTER TABLE job_queue DROP CONSTRAINT job_queue_worker_id_fkey;
ALTER TABLE workers ALTER COLUMN id TYPE VARCHAR(255);
ALTER TABLE job_queue ALTER COLUMN worker_id TYPE VARCHAR(255);
ALTER TABLE job_queue ADD CONSTRAINT job_queue_worker_id_fkey  FOREIGN KEY (worker_id) REFERENCES workers (id);
DROP FUNCTION get_next_job(int);
DROP FUNCTION resume_worker(int);
COMMIT;
```