### PR TITLE
feature: allow manually whitelisted emails

### DIFF
--- a/backend/src/core/models/user.ts
+++ b/backend/src/core/models/user.ts
@@ -1,4 +1,4 @@
-import { Column, DataType, Model, Table } from 'sequelize-typescript'
+import { Column, DataType, Model, Table, BeforeUpdate, BeforeCreate } from 'sequelize-typescript'
 
 @Table({ tableName: 'users' , underscored: true, timestamps: true })
 export class User extends Model<User> {
@@ -7,7 +7,6 @@ export class User extends Model<User> {
     allowNull: false,
     validate: {
       isEmail: true,
-      is: /^.*\.gov\.sg$/,
       isLowercase: true,
     },
   })
@@ -15,4 +14,16 @@ export class User extends Model<User> {
 
   @Column(DataType.STRING)
   apiKey?: string
+
+  // During programmatic creation of users (users signing up by themselves), emails must end in .gov.sg
+  // If we manually insert the user into the database, then this hook is bypassed.
+  // This enables us to whitelist specific non .gov.sg emails, which can sign in, but not sign up.
+  @BeforeUpdate
+  @BeforeCreate
+  static validateEmail(instance: User): void {
+    if(!/^.*\.gov\.sg$/.test(instance.email)){
+      throw new Error(`User email ${instance.email} does not end in .gov.sg`)
+    }
+  }
+
 }

--- a/backend/src/core/routes/auth.routes.ts
+++ b/backend/src/core/routes/auth.routes.ts
@@ -10,15 +10,14 @@ const getOtpValidator = {
     email: Joi.string().email()
       .options({ convert: true }) // Converts email to lowercase if it isn't
       .lowercase()
-      .regex(/^.*\.gov\.sg$/)
-      .required(), // TODO: Add other validation 
+      .required(), // validation for email ending in .gov.sg was removed as we want to support other manually whitelisted emails
   }),
 }
 
 const verifyOtpValidator = {
   [Segments.BODY]: Joi.object({
     email: Joi.string().email()
-      .required(), // TODO: Add other validation
+      .required(),
     otp: Joi.string().required(), //TODO: Add validation for 6 digit otp
   }),
 }


### PR DESCRIPTION
## Problem
We want to enable people with
1) emails ending in .gov.sg to sign up and login,
2) emails not ending in .gov.sg to not be able to sign up,
3) emails not ending in .gov.sg to be able to login if we had manually whitelisted them in the database

## Solution
Validate users' emails only on beforeCreate/beforeUpdate