### PR TITLE
bugfix: credentials hash was not unique

### DIFF
--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -50,7 +50,9 @@ const getSmsBody = async (campaignId: string): Promise<string | null> => {
 }
 
 const getEncodedHash = async (secret: string): Promise<string> => {
-  const secretHash = await hashService.specifySalt(secret, config.aws.secretManagerSalt)
+  // Removes special characters as they affect the consistency of hash
+  const noSpecialChars = secret.replace(/[^\w]/gi, '')
+  const secretHash = await hashService.specifySalt(noSpecialChars, config.aws.secretManagerSalt)
   return Buffer.from(secretHash).toString('base64')
 }
 


### PR DESCRIPTION
## Problem

Hashing slightly similar credentials will result in identical hash.

Closes #121

## Solution

To be honest I don't really understand why this is happening, I could send more time in understanding the problem.

Note:
This will result in creation of all existing credentials in AWS secret manager, as we are hashing the json string without the special characters. I could add this to the version credentials PR so that it is less confusing.

old: `{"accountSid":"AC","apiKey":"a","apiSecret":"ab","messagingServiceSid":"a"}`
new: `accountSidACapiKeyaapiSecretabmessagingServiceSida`

**Bug Fixes**:

- Remove special characters from the result of `json.stringify` before hashing.

## Tests

- [ ] Hashing slightly similar strings produce different result
- [ ] Hashing same string twice give the same result
- [ ] Able to insert and retrieve from AWS secrets manager

