### PR TITLE
Feat: Switch agency out for user's name

### DIFF
--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -25,10 +25,10 @@ const Campaigns = () => {
   const [campaignsDisplayed, setCampaignsDisplayed] = useState(new Array<Campaign>())
   const [selectedPage, setSelectedPage] = useState(0)
   const history = useHistory()
-  const name = getEmailFromName(email)
+  const name = getNameFromEmail(email)
   const title = `Welcome, ${name}`
 
-  function getEmailFromName(email: string): string {
+  function getNameFromEmail(email: string): string {
     const parts = email.split('@')
     const [ nameParts ] = parts
     return nameParts.split(/[_.-]/).map((n) => capitalize(n)).join(' ')


### PR DESCRIPTION
## Solution

**Features**:

- Instead of `Welcome Agency`, derive user's name from email and display it. 

Example:
`shaowei@open.gov.sg` : `Welcome Shaowei`
`alwyn.tan@open.gov.sg`: `Welcome Alwyn Tan`
`Leonard_LOO@tech.gov.sg`: `Welcome Leonard Loo`

## Before & After Screenshots

**BEFORE**:
<img width="1680" alt="Screenshot 2020-04-27 at 12 02 33 PM" src="https://user-images.githubusercontent.com/33112945/80333338-4ac77b00-8880-11ea-8a9b-1743cdf0da38.png">


**AFTER**:
<img width="1680" alt="Screenshot 2020-04-27 at 12 01 43 PM" src="https://user-images.githubusercontent.com/33112945/80333357-56b33d00-8880-11ea-878c-e9ccb6c3fe95.png">
