### PR TITLE
chore: fix error throwing in worker

### DIFF
--- a/worker/src/core/loaders/message-worker.loader.ts
+++ b/worker/src/core/loaders/message-worker.loader.ts
@@ -5,7 +5,12 @@ import config from '@core/config'
 
 const createMessageWorker = async (workerId: string, isLogger = false): Promise<ModuleThread<MessageWorker>> => {
   const worker = await spawn<MessageWorker>(new Worker('./message-worker'))
-  worker.init(workerId, isLogger)
+  try{
+    await worker.init(workerId, isLogger)
+  }catch(err){
+    logger.error(`Worker died. ${err.stack}`)
+    process.exit(1)
+  }
   return worker
 }
 

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -117,13 +117,13 @@ const createAndResumeWorker = (): Promise<void> => {
 }
 
   
-const init = async (index: string, isLogger = false): Promise<void> => {
+const init = async (index: string, isLogger = false): Promise<any> => {
   await ECSUtil.load()
   workerId = ECSUtil.getWorkerId(index)
   connection = createConnection()
   email = new Email(workerId, connection)
   sms = new SMS(workerId, connection)
-  try {
+  try{
     if(!isLogger){
       await createAndResumeWorker()
       for(;;){
@@ -136,11 +136,13 @@ const init = async (index: string, isLogger = false): Promise<void> => {
         await waitForMs(2000)
       }
     }
-  } catch(err) {
-    // TODO:  handle error!!!
-    // Otherwise this worker will be useless
-    logger.error(err)
   }
+  catch(err) {
+    return Promise.reject(err)
+  }
+   
+    
+  
 }
   
 const messageWorker = {


### PR DESCRIPTION
## Problem
ECS task was not respawning when worker threw an error

## Solution
Catch the error thrown by the worker thread, and kill the main thread. 