### PR TITLE
fix: fix highlight broken when text wraps

### DIFF
--- a/frontend/src/components/common/text-area/TextArea.module.scss
+++ b/frontend/src/components/common/text-area/TextArea.module.scss
@@ -36,7 +36,7 @@
     border-color: transparent;
     pointer-events: none;
     z-index: -1;
-    white-space: pre;
+    white-space: pre-wrap;
     p {
       color: transparent;
       font-size: 1rem;


### PR DESCRIPTION
## Problem

- highlighting doesnt wrap with the text

Closes #119

## Solution

- set `white-space` to `pre-wrap` instead of `pre`

**BEFORE**:
![Annotation 2020-04-30 0048142](https://user-images.githubusercontent.com/10072985/80623202-6e571500-8a7c-11ea-8f12-9ef3b5da2e55.jpg)


**AFTER**:
![Annotation 2020-04-30 004814](https://user-images.githubusercontent.com/10072985/80623096-4b2c6580-8a7c-11ea-833a-a70945e140de.jpg)
