### PR TITLE
fix: standardise channel apecific message type to 'message'

### DIFF
--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -73,7 +73,7 @@ const ProgressDetails = ({ sentAt, numRecipients, stats, handlePause, handleRetr
             <tr>
               <th className={styles.md}>Status</th>
               <th className={styles.md}>Description</th>
-              <th className={styles.sm}>SMS count</th>
+              <th className={styles.sm}>Message count</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
## Problem

One of the headers in the progress details component was hard-coded to be 'SMS Count'. It should reflect a channel specific or general word to denote 'message count'.

## Solution

Use the word 'Message' for all channel types to simplify issue. As discussed with Petty and Sarah.

