### PR TITLE
refactor: restore sequelizeLoader to consistent format

### DIFF
--- a/backend/src/core/loaders/index.ts
+++ b/backend/src/core/loaders/index.ts
@@ -1,16 +1,16 @@
+import { Application } from 'express'
 import securityHeadersLoader from './security-headers.loader'
 import expressLoader from './express.loader'
 import swaggerLoader from './swagger.loader'
 import sessionLoader from './session.loader'
-import SequelizeLoader from './sequelize.loader'
-import { Application } from 'express'
+import sequelizeLoader from './sequelize.loader'
 import cloudwatchLoader from './cloudwatch.loader'
 
 
 const loaders = async ({ app }: { app: Application }): Promise<void> => {
   securityHeadersLoader({ app })
   await cloudwatchLoader()
-  await SequelizeLoader.load()
+  await sequelizeLoader()
   await sessionLoader({ app })
   await expressLoader({ app })
   await swaggerLoader({ app })

--- a/backend/src/core/loaders/sequelize.loader.ts
+++ b/backend/src/core/loaders/sequelize.loader.ts
@@ -8,37 +8,29 @@ import logger from '@core/logger'
 
 const DB_URI = config.database.databaseUri
 
-class SequelizeLoader {
-  private static _sequelize: Sequelize | undefined
-  static get sequelize(): Sequelize | undefined {
-    return this._sequelize
+const sequelizeLoader = async (): Promise<void> => {
+  const dialectOptions = config.IS_PROD ? { ...config.database.dialectOptions } : {}
+  const sequelize = new Sequelize(DB_URI, {
+    dialect: 'postgres',
+    logging: false,
+    pool: config.database.poolOptions,
+    ...dialectOptions,
+  })
+
+  const coreModels = [Credential, JobQueue, Campaign, User, Worker]
+  const emailModels = [EmailMessage, EmailTemplate, EmailOp]
+  const smsModels = [SmsMessage, SmsTemplate, SmsOp]
+  sequelize.addModels([...coreModels, ...emailModels, ...smsModels])
+
+  try {
+    await sequelize.sync()
+    logger.info({ message: 'Database loaded.' })
+  } catch (err) {
+    logger.error(`Unable to connect to database: ${err}`)
+    process.exit(1)
   }
-  static async load(): Promise<void> {
-    const dialectOptions = config.IS_PROD ? { ...config.database.dialectOptions } : {}
-    const sequelize = new Sequelize(DB_URI, {
-      dialect: 'postgres',
-      logging: false,
-      pool: config.database.poolOptions,
-      ...dialectOptions,
-    })
-  
-    const coreModels = [Credential, JobQueue, Campaign, User, Worker]
-    const emailModels = [EmailMessage, EmailTemplate, EmailOp]
-    const smsModels = [SmsMessage, SmsTemplate, SmsOp]
-    sequelize.addModels([...coreModels, ...emailModels, ...smsModels])
 
-    try {
-      this._sequelize = await sequelize.sync()
-      logger.info({ message: 'Database loaded.' })
-    } catch (err) {
-      logger.error(`Unable to connect to database: ${err}`)
-      process.exit(1)
-    }
-
-    await Credential.findCreateFind({ where: { name: 'EMAIL_DEFAULT' } })
-
-  }
+  await Credential.findCreateFind({ where: { name: 'EMAIL_DEFAULT' } })
 }
 
-
-export default SequelizeLoader
+export default sequelizeLoader

--- a/backend/src/core/services/job.service.ts
+++ b/backend/src/core/services/job.service.ts
@@ -1,8 +1,8 @@
-import SequelizeLoader from '@core/loaders/sequelize.loader'
+import { Campaign } from '@core/models'
 import { QueryTypes } from 'sequelize'
 import get from 'lodash/get'
 const createJob = async ({ campaignId, rate }: {campaignId: number; rate: number}): Promise<number | undefined> => {
-  const job = await SequelizeLoader.sequelize?.query('SELECT insert_job(:campaignId, :rate);',
+  const job = await Campaign.sequelize?.query('SELECT insert_job(:campaignId, :rate);',
     {
       replacements: { campaignId, rate }, type: QueryTypes.SELECT,
     })
@@ -10,13 +10,13 @@ const createJob = async ({ campaignId, rate }: {campaignId: number; rate: number
   return jobId ? Number(jobId) : undefined
 }
 const stopCampaign = (campaignId: number): Promise<any> | undefined => {
-  return SequelizeLoader.sequelize?.query('SELECT stop_jobs(:campaignId);',
+  return Campaign.sequelize?.query('SELECT stop_jobs(:campaignId);',
     {
       replacements: { campaignId }, type: QueryTypes.SELECT,
     })
 }
 const retryCampaign = (campaignId: number): Promise<any> | undefined  => {
-  return SequelizeLoader.sequelize?.query('SELECT retry_jobs(:campaignId);',
+  return Campaign.sequelize?.query('SELECT retry_jobs(:campaignId);',
     {
       replacements: { campaignId }, type: QueryTypes.SELECT,
     })


### PR DESCRIPTION
Previously, I exposed the sequelize connection using the sequelize loader, for workers to be able to query the database. This is now unnecessary. 