### PR TITLE
fix: missing param should be replaced with empty string

### DIFF
--- a/backend/__tests__/template.service.test.ts
+++ b/backend/__tests__/template.service.test.ts
@@ -15,10 +15,10 @@ describe('template', () => {
       expect(template(body, params)).toEqual('Hello test')
     })
 
-    test('missing params', () => {
+    test('missing params should be replaced with empty string', () => {
       const params = {}
       const body = 'Hello {{name}}'
-      expect(() => {template(body, params)}).toThrow(TemplateError)
+      expect(template(body, params)).toEqual('Hello ')
     })
   })
   
@@ -27,8 +27,8 @@ describe('template', () => {
       [ 'unclosed curly braces', 'Hello {{'],
       [ 'empty variable', '{{}}'],
       [ 'special character', '{{^^}}'],
-      [ 'single quote', "{{'}}"],
-      ['should not allow strings in variables', "{{'hello'}}"]
+      [ 'single quote', '{{\'}}'],
+      ['should not allow strings in variables', '{{\'hello\'}}'],
     ]
 
     test.each(table)(


### PR DESCRIPTION
## Problem
Test was failing as we changed the logic of templating.  In the past, a missing param would throw an error, now it should be replaced with an empty string.

## Solution
Modify test for missing param

