### PR TITLE
fix: api key for emails with underscore

### DIFF
--- a/backend/src/core/models/user.ts
+++ b/backend/src/core/models/user.ts
@@ -33,7 +33,7 @@ export class User extends Model<User> {
   }
 
   async regenerateAndSaveApiKey(): Promise<string> {
-    const name = this.email.split('@')[0].replace(/\W/g, '')
+    const name = this.email.split('@')[0].replace(/[^a-zA-Z]/g, '')
     const apiKeyPlainText = ApiKeyService.generateApiKeyFromName(name)
     const apiKeyHash = await ApiKeyService.getApiKeyHash(apiKeyPlainText)
     this.apiKey = apiKeyHash


### PR DESCRIPTION
Closes #240 

Need to delete the api keys for users with underscore in their name