### PR TITLE
fix: stop-gap measure for setting a higher email default rate

### DIFF
--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -32,7 +32,7 @@ const EmailSend = ({ numRecipients, onNext }: { numRecipients: number; onNext: F
 
 
   const onModalConfirm = async () => {
-    await sendCampaign(+campaignId, 0)
+    await sendCampaign(+campaignId, 35)
     onNext({ status: Status.Sending }, false)
   }
 


### PR DESCRIPTION
## Problem

Addresses #258 

## Solution

Call the api server with a send rate of 35. This is a mere stop gap measure because campaigns are still blocked from processing simultaneously. 