### PR TITLE
chore: set updated_at in sql scripts

### DIFF
--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -49,11 +49,11 @@ class Email {
           })
         })
         .then((messageId) => {
-          return this.connection.query('UPDATE email_ops SET delivered_at=clock_timestamp(), message_id=:messageId WHERE id=:id;',
+          return this.connection.query('UPDATE email_ops SET delivered_at=clock_timestamp(), message_id=:messageId, updated_at=clock_timestamp() WHERE id=:id;',
             { replacements: { id, messageId }, type: QueryTypes.UPDATE })
         })
         .catch((error: Error) => {
-          return this.connection.query('UPDATE email_ops SET delivered_at=clock_timestamp(), error_code=:error WHERE id=:id;',
+          return this.connection.query('UPDATE email_ops SET delivered_at=clock_timestamp(), error_code=:error, updated_at=clock_timestamp() WHERE id=:id;',
             { replacements: { id, error: error.message.substring(0,255) }, type: QueryTypes.UPDATE })
         })
         .then(() => {

--- a/worker/src/core/loaders/message-worker/sms.class.ts
+++ b/worker/src/core/loaders/message-worker/sms.class.ts
@@ -39,11 +39,11 @@ class SMS {
           return this.twilioClient?.send(recipient, templateClient.template(body, params))
         })
         .then((messageId) => {
-          return this.connection.query('UPDATE sms_ops SET delivered_at=clock_timestamp(), message_id=:messageId WHERE id=:id;',
+          return this.connection.query('UPDATE sms_ops SET delivered_at=clock_timestamp(), message_id=:messageId, updated_at=clock_timestamp() WHERE id=:id;',
             { replacements: { id, messageId }, type: QueryTypes.UPDATE })
         })
         .catch((error: Error) => {
-          return this.connection.query('UPDATE sms_ops SET delivered_at=clock_timestamp(), error_code=:error WHERE id=:id;',
+          return this.connection.query('UPDATE sms_ops SET delivered_at=clock_timestamp(), error_code=:error, updated_at=clock_timestamp() WHERE id=:id;',
             { replacements: { id,  error: error.message.substring(0,255) }, type: QueryTypes.UPDATE })
         })
         .then(() => {

--- a/worker/src/core/resources/sql/get-next-job.sql
+++ b/worker/src/core/resources/sql/get-next-job.sql
@@ -9,7 +9,7 @@ result json;
 BEGIN
 
 UPDATE job_queue
-SET worker_id = worker, status = 'ENQUEUED'
+SET worker_id = worker, status = 'ENQUEUED', updated_at = clock_timestamp()
 WHERE 
 -- worker is not already operating on a job 
 NOT EXISTS (SELECT 1 FROM job_queue q WHERE q.worker_id = worker LIMIT 1)

--- a/worker/src/core/resources/sql/resume-worker.sql
+++ b/worker/src/core/resources/sql/resume-worker.sql
@@ -9,7 +9,7 @@ BEGIN
     IF selected_campaign_id IS NOT NULL THEN
 
             -- Attempt to log that campaign
-            UPDATE job_queue q SET status = 'LOGGED', worker_id = NULL WHERE campaign_id = selected_campaign_id 
+            UPDATE job_queue q SET status = 'LOGGED', worker_id = NULL, updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id 
             -- Should we check for existing jobs that are running for this campaign?
             RETURNING q.campaign_id INTO logged_campaign_id;
 

--- a/worker/src/core/resources/sql/retry-jobs.sql
+++ b/worker/src/core/resources/sql/retry-jobs.sql
@@ -15,7 +15,7 @@ IF retry_disabled IS NULL THEN
 	    END
     FROM campaigns where id = selected_campaign_id;
 
-    UPDATE job_queue SET status = 'READY', worker_id = NULL WHERE campaign_id = selected_campaign_id;
+    UPDATE job_queue SET status = 'READY', worker_id = NULL, updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id;
 
 END IF;
 

--- a/worker/src/core/resources/sql/stop-jobs.sql
+++ b/worker/src/core/resources/sql/stop-jobs.sql
@@ -2,5 +2,5 @@ CREATE OR REPLACE FUNCTION stop_jobs(selected_campaign_id int) RETURNS VOID
 LANGUAGE plpgsql
 AS $$
 BEGIN
-UPDATE job_queue SET status = 'STOPPED' WHERE campaign_id = selected_campaign_id AND status <> 'LOGGED';
+UPDATE job_queue SET status = 'STOPPED', updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id AND status <> 'LOGGED';
 END $$

--- a/worker/src/email/resources/sql/enqueue-messages-email.sql
+++ b/worker/src/email/resources/sql/enqueue-messages-email.sql
@@ -3,7 +3,7 @@ DECLARE
     selected_campaign_id int;
 BEGIN
 	-- only one worker will be able to set this job's status
-	UPDATE job_queue SET status = 'SENDING' WHERE id = jid AND status = 'ENQUEUED'
+	UPDATE job_queue SET status = 'SENDING', updated_at = clock_timestamp() WHERE id = jid AND status = 'ENQUEUED'
 	RETURNING campaign_id INTO selected_campaign_id;
 
 	WITH messages AS 

--- a/worker/src/email/resources/sql/enqueue-messages-email.sql
+++ b/worker/src/email/resources/sql/enqueue-messages-email.sql
@@ -7,7 +7,7 @@ BEGIN
 	RETURNING campaign_id INTO selected_campaign_id;
 
 	WITH messages AS 
-	(UPDATE email_messages m SET dequeued_at = clock_timestamp() 
+	(UPDATE email_messages m SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp() 
 	WHERE m.campaign_id = selected_campaign_id
 	-- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
 	AND m.dequeued_at IS NULL

--- a/worker/src/email/resources/sql/get-messages-to-send-email.sql
+++ b/worker/src/email/resources/sql/get-messages-to-send-email.sql
@@ -13,7 +13,7 @@ BEGIN
 			FOR UPDATE SKIP LOCKED
     ),
     messages AS (
-      UPDATE email_ops SET sent_at=clock_timestamp() WHERE 
+      UPDATE email_ops SET sent_at=clock_timestamp(), updated_at = clock_timestamp() WHERE 
       id in (SELECT * from selected_ids)
       RETURNING id, recipient, params, campaign_id
     )
@@ -28,6 +28,6 @@ BEGIN
 	-- In that case, finalization of the job has to be deferred, so that the response can be updated in the ops table
 	-- The check for this edge case is carried out in the log_next_job function. 
 	IF NOT FOUND THEN
-		UPDATE job_queue SET status = 'SENT' where id = jid AND status = 'SENDING';
+		UPDATE job_queue SET status = 'SENT', updated_at = clock_timestamp() where id = jid AND status = 'SENDING';
 	END IF;
 END $$;

--- a/worker/src/email/resources/sql/log-job-email.sql
+++ b/worker/src/email/resources/sql/log-job-email.sql
@@ -10,7 +10,7 @@ BEGIN
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
 		received_at = p.received_at,
-		updated_at = p.updated_at
+		updated_at = clock_timestamp() 
 	FROM email_ops p WHERE 
 	p.campaign_id = selected_campaign_id 
 	AND m.campaign_id = p.campaign_id

--- a/worker/src/email/resources/sql/log-next-job-email.sql
+++ b/worker/src/email/resources/sql/log-next-job-email.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION log_next_job_email(out selected_campaign_id int)
 AS $$
 BEGIN
 WITH logged_jobs AS ( 
-	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL
+	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL, updated_at = clock_timestamp()
 	WHERE campaign_id = ( SELECT q1.campaign_id
 	    FROM job_queue q1, campaigns c1
 	    WHERE

--- a/worker/src/email/resources/sql/retry-jobs-email.sql
+++ b/worker/src/email/resources/sql/retry-jobs-email.sql
@@ -3,6 +3,6 @@ CREATE OR REPLACE FUNCTION retry_jobs_email(selected_campaign_id int) RETURNS VO
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    UPDATE email_messages SET dequeued_at = NULL WHERE campaign_id = selected_campaign_id AND message_id IS NULL;
+    UPDATE email_messages SET dequeued_at = NULL, updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id AND message_id IS NULL;
 END $$
 

--- a/worker/src/sms/resources/sql/enqueue-messages-sms.sql
+++ b/worker/src/sms/resources/sql/enqueue-messages-sms.sql
@@ -3,11 +3,11 @@ DECLARE
     selected_campaign_id int;
 BEGIN
 	-- only one worker will be able to set this job's status
-	UPDATE job_queue SET status = 'SENDING' WHERE id = jid AND status = 'ENQUEUED'
+	UPDATE job_queue SET status = 'SENDING', updated_at = clock_timestamp() WHERE id = jid AND status = 'ENQUEUED'
 	RETURNING campaign_id INTO selected_campaign_id;
 
 	WITH messages AS 
-	(UPDATE sms_messages m SET dequeued_at = clock_timestamp() 
+	(UPDATE sms_messages m SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp()
 	WHERE m.campaign_id = selected_campaign_id
 	-- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
 	AND m.dequeued_at IS NULL

--- a/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
+++ b/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
@@ -13,7 +13,7 @@ BEGIN
 			FOR UPDATE SKIP LOCKED
     ),
     messages AS (
-      UPDATE sms_ops SET sent_at=clock_timestamp() WHERE 
+      UPDATE sms_ops SET sent_at=clock_timestamp(), updated_at = clock_timestamp() WHERE 
       id in (SELECT * from selected_ids)
       RETURNING id, recipient, params, campaign_id
     )
@@ -28,6 +28,6 @@ BEGIN
 	-- In that case, finalization of the job has to be deferred, so that the response can be updated in the ops table
 	-- The check for this edge case is carried out in the log_job_<channel> function. 
 	IF NOT FOUND THEN
-		UPDATE job_queue SET status = 'SENT' where id = jid AND status = 'SENDING';
+		UPDATE job_queue SET status = 'SENT', updated_at = clock_timestamp() where id = jid AND status = 'SENDING';
 	END IF;
 END $$;

--- a/worker/src/sms/resources/sql/log-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-job-sms.sql
@@ -10,7 +10,7 @@ BEGIN
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
 		received_at = p.received_at,
-		updated_at = p.updated_at
+		updated_at = clock_timestamp() 
 	FROM sms_ops p WHERE 
 	p.campaign_id = selected_campaign_id 
 	AND m.campaign_id = p.campaign_id

--- a/worker/src/sms/resources/sql/log-next-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-next-job-sms.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE FUNCTION log_next_job_sms(out selected_campaign_id int)
 AS $$
 BEGIN
 WITH logged_jobs AS ( 
-	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL
+	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL, updated_at = clock_timestamp()
 	WHERE campaign_id = ( SELECT q1.campaign_id
 	    FROM job_queue q1, campaigns c1
 	    WHERE

--- a/worker/src/sms/resources/sql/retry-jobs-sms.sql
+++ b/worker/src/sms/resources/sql/retry-jobs-sms.sql
@@ -3,6 +3,6 @@ CREATE OR REPLACE FUNCTION retry_jobs_sms(selected_campaign_id int) RETURNS VOID
 LANGUAGE plpgsql
 AS $$
 BEGIN
-    UPDATE sms_messages SET dequeued_at = NULL WHERE campaign_id = selected_campaign_id AND message_id IS NULL;
+    UPDATE sms_messages SET dequeued_at = NULL, updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id AND message_id IS NULL;
 END $$
 


### PR DESCRIPTION
## Problem

Closes #255

## Solution

Although sequelize helps to set the `updated_at`, if we decide to not use sequelize in the future the columns will not be set at all.