### PR TITLE
fix: sql updating and returning more rows than limit

### DIFF
--- a/worker/src/email/resources/sql/get-messages-to-send-email.sql
+++ b/worker/src/email/resources/sql/get-messages-to-send-email.sql
@@ -4,19 +4,22 @@ LANGUAGE plpgsql AS $$
 BEGIN
 	RETURN QUERY
 	-- Set sent_at for messages belonging to a job that is in SENDING state only (it will not pick up any other states like STOPPED or LOGGED)
-	WITH messages AS (
-		UPDATE email_ops SET sent_at=clock_timestamp() WHERE 
-		id in (
-			SELECT id FROM email_ops WHERE
+	WITH
+    selected_ids AS (
+      SELECT id FROM email_ops WHERE
 			campaign_id = (SELECT q.campaign_id FROM job_queue q WHERE q.id = jid AND status = 'SENDING')
 			AND sent_at IS NULL
 			LIMIT lim
 			FOR UPDATE SKIP LOCKED
-		)
-		RETURNING id, recipient, params, campaign_id
-	) SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body, 'subject', t.subject, 'replyTo', t.reply_to)
-	 FROM messages m, email_templates t
-	 WHERE m.campaign_id = t.campaign_id;
+    ),
+    messages AS (
+      UPDATE email_ops SET sent_at=clock_timestamp() WHERE 
+      id in (SELECT * from selected_ids)
+      RETURNING id, recipient, params, campaign_id
+    )
+    SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body, 'subject', t.subject, 'replyTo', t.reply_to)
+    FROM messages m, email_templates t
+    WHERE m.campaign_id = t.campaign_id;
 		
 	-- If there are no messages found, we assume the job is done
 	-- This is only correct because enqueue and send are serialized. All messages are enqueued before sending occurs

--- a/worker/src/email/resources/sql/log-next-job-email.sql
+++ b/worker/src/email/resources/sql/log-next-job-email.sql
@@ -4,7 +4,7 @@ AS $$
 BEGIN
 WITH logged_jobs AS ( 
 	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL
-	WHERE campaign_id IN ( SELECT q1.campaign_id
+	WHERE campaign_id = ( SELECT q1.campaign_id
 	    FROM job_queue q1, campaigns c1
 	    WHERE
 		c1.id = q1.campaign_id

--- a/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
+++ b/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
@@ -4,19 +4,22 @@ LANGUAGE plpgsql AS $$
 BEGIN
 	RETURN QUERY
 	-- Set sent_at for messages belonging to a job that is in SENDING state only (it will not pick up any other states like STOPPED or LOGGED)
-	WITH messages AS (
-		UPDATE sms_ops SET sent_at=clock_timestamp() WHERE 
-		id in (
-			SELECT id FROM sms_ops WHERE
+  WITH
+    selected_ids AS (
+      SELECT id FROM sms_ops WHERE
 			campaign_id = (SELECT q.campaign_id FROM job_queue q WHERE q.id = jid AND status = 'SENDING')
 			AND sent_at IS NULL
 			LIMIT lim
 			FOR UPDATE SKIP LOCKED
-		)
-		RETURNING id, recipient, params, campaign_id
-	) SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body)
-	 FROM messages m, sms_templates t
-	 WHERE m.campaign_id = t.campaign_id;
+    ),
+    messages AS (
+      UPDATE sms_ops SET sent_at=clock_timestamp() WHERE 
+      id in (SELECT * from selected_ids)
+      RETURNING id, recipient, params, campaign_id
+    )
+    SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body)
+    FROM messages m, sms_templates t
+    WHERE m.campaign_id = t.campaign_id;
 		
 	-- If there are no messages found, we assume the job is done
 	-- This is only correct because enqueue and send are serialized. All messages are enqueued before sending occurs

--- a/worker/src/sms/resources/sql/log-next-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-next-job-sms.sql
@@ -4,7 +4,7 @@ AS $$
 BEGIN
 WITH logged_jobs AS ( 
 	UPDATE job_queue SET status = 'LOGGED', worker_id = NULL
-	WHERE campaign_id IN ( SELECT q1.campaign_id
+	WHERE campaign_id = ( SELECT q1.campaign_id
 	    FROM job_queue q1, campaigns c1
 	    WHERE
 		c1.id = q1.campaign_id


### PR DESCRIPTION
## Problem

Nested select queries with limit are being looped and returning more rows than expected.

Closes #269 

## Solution

Use `WITH` clause to prevent subquery from being executed multiple times.
For sql queries with hardcoded LIMIT 1, use `=` instead of `IN` for comparison.

ref: https://dba.stackexchange.com/questions/69471/postgres-update-limit-1

**Bug Fixes**:

- Fixes `get_messages_to_send` and `log_next_job` functions

