### PR TITLE
chore: throws 400 when double quote is misused in csv

### DIFF
--- a/backend/__tests__/s3.service.test.ts
+++ b/backend/__tests__/s3.service.test.ts
@@ -1,5 +1,8 @@
 import S3Client from '@core/services/s3-client.class'
-import { RecipientColumnMissing, UnexpectedDoubleQuoteError } from '@core/errors'
+import {
+  RecipientColumnMissing,
+  UnexpectedDoubleQuoteError,
+} from '@core/errors'
 
 import { Readable } from 'stream'
 
@@ -88,13 +91,11 @@ describe('S3 Service', () => {
 
     test('Double quotes allows escaping of special characters', async () => {
       const headers = ['message', 'recipient']
-      const values = [
-        [`"hello, this is a test"` , 'test@open.gov.sg'],
-      ]
+      const values = [[`"hello, this is a test"`, 'test@open.gov.sg']]
       const stream = await createStream(headers, values)
       const params = await s3Client.parseCsv(stream)
-      expect(params).toEqual([ 
-        { recipient: 'test@open.gov.sg', message: "hello, this is a test"},
+      expect(params).toEqual([
+        { recipient: 'test@open.gov.sg', message: 'hello, this is a test' },
       ])
     })
 
@@ -104,9 +105,9 @@ describe('S3 Service', () => {
         [`New York City,40°42'46"N,74°00'21"W`, 'test@open.gov.sg'],
       ]
       const stream = await createStream(headers, values)
-      await expect(s3Client.parseCsv(stream))
-        .rejects
-        .toThrow(UnexpectedDoubleQuoteError)
+      await expect(s3Client.parseCsv(stream)).rejects.toThrow(
+        UnexpectedDoubleQuoteError
+      )
     })
   })
 })

--- a/backend/__tests__/s3.service.test.ts
+++ b/backend/__tests__/s3.service.test.ts
@@ -1,5 +1,5 @@
 import S3Client from '@core/services/s3-client.class'
-import { RecipientColumnMissing } from '@core/errors'
+import { RecipientColumnMissing, UnexpectedDoubleQuoteError } from '@core/errors'
 
 import { Readable } from 'stream'
 
@@ -84,6 +84,29 @@ describe('S3 Service', () => {
       expect(params).toEqual([
         { recipient: 'test@open.gov.sg', name: 'Ahmad', number: '' },
       ])
+    })
+
+    test('Double quotes allows escaping of special characters', async () => {
+      const headers = ['message', 'recipient']
+      const values = [
+        [`"hello, this is a test"` , 'test@open.gov.sg'],
+      ]
+      const stream = await createStream(headers, values)
+      const params = await s3Client.parseCsv(stream)
+      expect(params).toEqual([ 
+        { recipient: 'test@open.gov.sg', message: "hello, this is a test"},
+      ])
+    })
+
+    test('throws error when double quote is used in unquoted field', async () => {
+      const headers = ['message', 'recipient']
+      const values = [
+        [`New York City,40°42'46"N,74°00'21"W`, 'test@open.gov.sg'],
+      ]
+      const stream = await createStream(headers, values)
+      await expect(s3Client.parseCsv(stream))
+        .rejects
+        .toThrow(UnexpectedDoubleQuoteError)
     })
   })
 })

--- a/backend/src/core/errors/s3.errors.ts
+++ b/backend/src/core/errors/s3.errors.ts
@@ -5,3 +5,11 @@ export class RecipientColumnMissing extends Error {
     Error.captureStackTrace(this)
   }
 }
+
+export class UnexpectedDoubleQuoteError extends Error {
+  constructor() {
+    super('Double quote should not be used in unquoted field.')
+    Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
+    Error.captureStackTrace(this)
+  }
+}

--- a/backend/src/core/errors/s3.errors.ts
+++ b/backend/src/core/errors/s3.errors.ts
@@ -8,7 +8,7 @@ export class RecipientColumnMissing extends Error {
 
 export class UnexpectedDoubleQuoteError extends Error {
   constructor() {
-    super('Double quote should not be used in unquoted field.')
+    super(`Double quote is misused, it should only use to quote a field.\nCorrect :"Hi how are you?" \nIncorrect : 40"N`)
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
   }

--- a/backend/src/core/errors/s3.errors.ts
+++ b/backend/src/core/errors/s3.errors.ts
@@ -8,7 +8,9 @@ export class RecipientColumnMissing extends Error {
 
 export class UnexpectedDoubleQuoteError extends Error {
   constructor() {
-    super(`Double quote is misused, it should only use to quote a field.\nCorrect :"Hi how are you?" \nIncorrect : 40"N`)
+    super(
+      `Double quote is misused, it should only use to quote a field.\nCorrect :"Hi how are you?" \nIncorrect : 40"N`
+    )
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
   }

--- a/backend/src/core/errors/template.errors.ts
+++ b/backend/src/core/errors/template.errors.ts
@@ -26,7 +26,7 @@ export class TemplateError extends Error {
 
 export class InvalidRecipientError extends Error {
   constructor() {
-    super('There are invalid recipient(s) in the uploaded recipient list.')
+    super('There are invalid recipient(s) in the uploaded recipient list.\nPlease check the recipient column in your csv file.')
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
   }

--- a/backend/src/core/errors/template.errors.ts
+++ b/backend/src/core/errors/template.errors.ts
@@ -1,9 +1,7 @@
 export class MissingTemplateKeysError extends Error {
   public readonly missingKeys: string[]
   constructor(missingKeys: string[]) {
-    super(
-      `The attribute(s) { ${missingKeys} } are not present in uploaded recipient list.`
-    )
+    super(`The keyword(s) { ${missingKeys} } are not present in uploaded recipient list.`)
     this.missingKeys = missingKeys
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)

--- a/backend/src/core/errors/template.errors.ts
+++ b/backend/src/core/errors/template.errors.ts
@@ -1,7 +1,9 @@
 export class MissingTemplateKeysError extends Error {
   public readonly missingKeys: string[]
   constructor(missingKeys: string[]) {
-    super(`The keyword(s) { ${missingKeys} } are not present in uploaded recipient list.`)
+    super(
+      `The keyword(s) { ${missingKeys} } are not present in uploaded recipient list.`
+    )
     this.missingKeys = missingKeys
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
@@ -26,7 +28,9 @@ export class TemplateError extends Error {
 
 export class InvalidRecipientError extends Error {
   constructor() {
-    super('There are invalid recipient(s) in the uploaded recipient list.\nPlease check the recipient column in your csv file.')
+    super(
+      'There are invalid recipient(s) in the uploaded recipient list.\nPlease check the recipient column in your csv file.'
+    )
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
   }

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -71,6 +71,7 @@ export default class S3Client {
     }
     catch (err) {
       if (err.message.includes('Invalid Opening Quote')) throw new UnexpectedDoubleQuoteError()
+      if (err.message.includes('Invalid Closing Quote')) throw new UnexpectedDoubleQuoteError()
       throw err
     }
   }

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -5,7 +5,10 @@ import { isEmpty } from 'lodash'
 import config from '@core/config'
 import logger from '@core/logger'
 import { configureEndpoint } from '@core/utils/aws-endpoint'
-import { RecipientColumnMissing, UnexpectedDoubleQuoteError } from '@core/errors/s3.errors'
+import {
+  RecipientColumnMissing,
+  UnexpectedDoubleQuoteError,
+} from '@core/errors/s3.errors'
 
 type CSVParamsInterface = { [key: string]: string }
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
@@ -67,11 +70,12 @@ export default class S3Client {
         }
       }
       logger.info({ message: 'Parsing complete' })
-      return Array.from(params.values()) 
-    }
-    catch (err) {
-      if (err.message.includes('Invalid Opening Quote')) throw new UnexpectedDoubleQuoteError()
-      if (err.message.includes('Invalid Closing Quote')) throw new UnexpectedDoubleQuoteError()
+      return Array.from(params.values())
+    } catch (err) {
+      if (err.message.includes('Invalid Opening Quote'))
+        throw new UnexpectedDoubleQuoteError()
+      if (err.message.includes('Invalid Closing Quote'))
+        throw new UnexpectedDoubleQuoteError()
       throw err
     }
   }

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -4,8 +4,8 @@ import { isEmpty } from 'lodash'
 
 import config from '@core/config'
 import logger from '@core/logger'
-import { RecipientColumnMissing } from '@core/errors/s3.errors'
 import { configureEndpoint } from '@core/utils/aws-endpoint'
+import { RecipientColumnMissing, UnexpectedDoubleQuoteError } from '@core/errors/s3.errors'
 
 type CSVParamsInterface = { [key: string]: string }
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
@@ -42,30 +42,36 @@ export default class S3Client {
       trim: true,
       skip_empty_lines: true,
     })
-    readStream.pipe(parser)
-    let headers: string[] = []
-    let recipientIndex: number
-    const params: Map<string, CSVParamsInterface> = new Map()
-    for await (const row of parser) {
-      if (isEmpty(headers)) {
-        // @see https://stackoverflow.com/questions/11305797/remove-zero-width-space-characters-from-a-javascript-string
-        const lowercaseHeaders = row.map((col: string) =>
-          col.toLowerCase().replace(/[\u200B-\u200D\uFEFF]/g, '')
-        )
-        recipientIndex = lowercaseHeaders.indexOf('recipient')
-        if (recipientIndex === -1) throw new RecipientColumnMissing()
-        headers = lowercaseHeaders
-      } else {
-        const rowWithHeaders: CSVParamsInterface = {}
-        row.forEach((col: any, index: number) => {
-          rowWithHeaders[headers[index]] = col
-        })
-        // produces {header1: value1, header2: value2, ...}
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        params.set(row[recipientIndex!], rowWithHeaders) // Deduplication
+    try {
+      readStream.pipe(parser)
+      let headers: string[] = []
+      let recipientIndex: number
+      const params: Map<string, CSVParamsInterface> = new Map()
+      for await (const row of parser) {
+        if (isEmpty(headers)) {
+          // @see https://stackoverflow.com/questions/11305797/remove-zero-width-space-characters-from-a-javascript-string
+          const lowercaseHeaders = row.map((col: string) =>
+            col.toLowerCase().replace(/[\u200B-\u200D\uFEFF]/g, '')
+          )
+          recipientIndex = lowercaseHeaders.indexOf('recipient')
+          if (recipientIndex === -1) throw new RecipientColumnMissing()
+          headers = lowercaseHeaders
+        } else {
+          const rowWithHeaders: CSVParamsInterface = {}
+          row.forEach((col: any, index: number) => {
+            rowWithHeaders[headers[index]] = col
+          })
+          // produces {header1: value1, header2: value2, ...}
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          params.set(row[recipientIndex!], rowWithHeaders) // Deduplication
+        }
       }
+      logger.info({ message: 'Parsing complete' })
+      return Array.from(params.values()) 
     }
-    logger.info({ message: 'Parsing complete' })
-    return Array.from(params.values())
+    catch (err) {
+      if (err.message.includes('Invalid Opening Quote')) throw new UnexpectedDoubleQuoteError()
+      throw err
+    }
   }
 }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -8,8 +8,6 @@ import {
   TemplateError,
   InvalidRecipientError,
   UnexpectedDoubleQuoteError,
-  MissingTemplateKeysError,
-  RecipientColumnMissing,
 } from '@core/errors'
 import { CampaignService, TemplateService } from '@core/services'
 import { EmailTemplateService } from '@email/services'
@@ -131,8 +129,7 @@ const updateCampaignAndMessages = async (
  */
 const uploadCompleteHandler = async (
   req: Request,
-  res: Response,
-  next: NextFunction
+  res: Response
 ): Promise<Response | void> => {
   res.setTimeout(config.get('express.uploadCompleteTimeout'), () => {
     if (!res.headersSent) {
@@ -194,12 +191,13 @@ const uploadCompleteHandler = async (
       throw err
     }
   } catch (err) {
-    if (!res.headersSent){
+    if (!res.headersSent) {
       const userErrors = [
         RecipientColumnMissing,
         MissingTemplateKeysError,
         InvalidRecipientError,
-        UnexpectedDoubleQuoteError]
+        UnexpectedDoubleQuoteError,
+      ]
 
       if (userErrors.some((errType) => err instanceof errType)) {
         return res.status(400).json({ message: err.message })

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -7,6 +7,9 @@ import {
   RecipientColumnMissing,
   TemplateError,
   InvalidRecipientError,
+  UnexpectedDoubleQuoteError,
+  MissingTemplateKeysError,
+  RecipientColumnMissing,
 } from '@core/errors'
 import { CampaignService, TemplateService } from '@core/services'
 import { EmailTemplateService } from '@email/services'
@@ -191,15 +194,16 @@ const uploadCompleteHandler = async (
       throw err
     }
   } catch (err) {
-    if (!res.headersSent) {
-      if (
-        err instanceof RecipientColumnMissing ||
-        err instanceof MissingTemplateKeysError ||
-        err instanceof InvalidRecipientError
-      ) {
+    if (!res.headersSent){
+      const userErrors = [
+        RecipientColumnMissing,
+        MissingTemplateKeysError,
+        InvalidRecipientError,
+        UnexpectedDoubleQuoteError]
+
+      if (userErrors.some((errType) => err instanceof errType)) {
         return res.status(400).json({ message: err.message })
       }
-      return next(err)
     }
   }
 }

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -7,6 +7,7 @@ import {
   RecipientColumnMissing,
   TemplateError,
   InvalidRecipientError,
+  UnexpectedDoubleQuoteError,
 } from '@core/errors'
 import { CampaignService, TemplateService } from '@core/services'
 import { SmsTemplateService } from '@sms/services'
@@ -181,11 +182,13 @@ const uploadCompleteHandler = async (
     }
   } catch (err) {
     if (!res.headersSent) {
-      if (
-        err instanceof RecipientColumnMissing ||
-        err instanceof MissingTemplateKeysError ||
-        err instanceof InvalidRecipientError
-      ) {
+      const userErrors = [
+        RecipientColumnMissing,
+        MissingTemplateKeysError,
+        InvalidRecipientError,
+        UnexpectedDoubleQuoteError]
+
+      if (userErrors.some((errType) => err instanceof errType)) {
         return res.status(400).json({ message: err.message })
       }
       return next(err)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -186,7 +186,8 @@ const uploadCompleteHandler = async (
         RecipientColumnMissing,
         MissingTemplateKeysError,
         InvalidRecipientError,
-        UnexpectedDoubleQuoteError]
+        UnexpectedDoubleQuoteError,
+      ]
 
       if (userErrors.some((errType) => err instanceof errType)) {
         return res.status(400).json({ message: err.message })


### PR DESCRIPTION
## Problem

The error occurs when a user has double quote that are not being used as `quotes`. 

In a CSV file, double quotes are used as `quotes`.

For example, `hi,my name is` will be separated into two fields. If we want it to be in one field, we have to use the double quotes: `"hi,my name is". 

However, when a unquoted field has double quotes, it results in an error because the parser doesn't know how to handle it.

Error: `404246"N` 
No error: `"404246"N"`

Closes #274.

## Solution

Initially, what I wanted to do was to silence the double quote, meaning `"hello, Tom"` will end up being `"hello, Tom"` instead of `hello, Tom`.

However, this can be confusing to users and it probably creates alot of edge cases that we have to handle.

Instead, what we will throw a 400 and display a meaningful error message.

Im currently not sure what's a good error message and whether we should display examples.

**Improvements**:

- Throws 400 when double quote is misused in a csv field

## Before & After Screenshots

**BEFORE**:
<img width="1680" alt="Screenshot 2020-05-21 at 12 13 24 PM" src="https://user-images.githubusercontent.com/33112945/82522602-86dabc80-9b5c-11ea-813a-bb34517bc1a4.png">


**AFTER**:
<img width="1680" alt="Screenshot 2020-05-21 at 12 14 40 PM" src="https://user-images.githubusercontent.com/33112945/82522665-affb4d00-9b5c-11ea-92b1-e228a9718d10.png">


## Tests

- [x] `"hello"` does not throw an error
- [x] `hell"o` throws an error 