### PR TITLE
fix: google fonts blocked by csp headers on certain browsers

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -45,7 +45,7 @@ frontend:
         value: "same-origin"
       - key: "Content-Security-Policy"
         value: "connect-src 'self' https://*.postman.gov.sg https://postmangovsg-dev-upload.s3.ap-northeast-1.amazonaws.com/ https://postmangovsg-prod-upload.s3.ap-northeast-1.amazonaws.com; 
-        style-src-elem 'self' https://*.postman.gov.sg https://fonts.googleapis.com;
+        style-src 'self' https://*.postman.gov.sg https://fonts.googleapis.com;
         font-src 'self' https://*.postman.gov.sg https://fonts.gstatic.com;
         default-src 'self' https://*.postman.gov.sg;
         object-src 'none'"


### PR DESCRIPTION
## Problem

`style-src-elem` CSP directive not support on firefox and safari, blocking google fonts from loading.

## Solution

Use `style-src`
