### PR TITLE
fix: singlerow textarea scrolls with multiple lines

### DIFF
--- a/frontend/src/components/common/text-area/TextArea.module.scss
+++ b/frontend/src/components/common/text-area/TextArea.module.scss
@@ -17,7 +17,6 @@
     background: transparent;
 
     &.single {
-      max-height: 3rem;
       padding-top: 0.7rem;
       padding-bottom: 0.7rem;
     }

--- a/frontend/src/components/common/text-area/TextArea.tsx
+++ b/frontend/src/components/common/text-area/TextArea.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import cx from 'classnames'
 import TextareaAutosize from 'react-textarea-autosize'
 import escapeHTML from 'escape-html'
@@ -11,6 +11,23 @@ const TextArea = ({ highlight, singleRow, placeholder, value, onChange }:
   { highlight: boolean; singleRow?: boolean; placeholder: string; value: string; onChange: Function }) => {
 
   const minRows = singleRow ? 1 : 5
+  const textAreaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    // ignores Enter key presses as it triggers a resize on textarea
+    if (singleRow && textAreaRef.current) {
+      textAreaRef.current.onkeydown = (e) => {
+        if (e.keyCode === 13) {
+          e.preventDefault()
+        }
+      }
+    }
+  }, [textAreaRef.current, singleRow])
+
+  // Remove line breaks for singleRow textarea
+  function onTextChange(text: string) {
+    onChange(singleRow ? text.replace(/(\r\n|\r|\n)/g, '') : text)
+  }
 
   return (
     <div className={styles.textAreaContainer}>
@@ -22,9 +39,10 @@ const TextArea = ({ highlight, singleRow, placeholder, value, onChange }:
       <TextareaAutosize
         placeholder={placeholder}
         value={value}
-        onChange={e => onChange(e.target.value)}
+        onChange={e => onTextChange(e.target.value)}
         minRows={minRows}
         className={cx(styles.textArea, { [styles.single]: singleRow })}
+        inputRef={r => textAreaRef.current = r}
       />
     </div >
   )


### PR DESCRIPTION
## Problem

TextArea component with singleRow flag shows ugly scrollbar when user presses enter or text wraps.

## Solution

Allow TextArea to resize when text wraps but prevent line breaks and `Enter` keypress.

![Screenshot 2020-05-21 at 5 52 11 PM](https://user-images.githubusercontent.com/10072985/82547243-fc11b600-9b8b-11ea-85f7-d33f1617da8e.png)
