### PR TITLE
fix: redirect if any axios requests return unauthorized

### DIFF
--- a/frontend/src/contexts/auth.context.tsx
+++ b/frontend/src/contexts/auth.context.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useState, useEffect, SetStateAction, Dispatch } from 'react'
-import { getUserEmail } from 'services/auth.service'
+import axios from 'axios'
+import { getUserEmail, logout } from 'services/auth.service'
 
 interface ContextProps {
   isAuthenticated: boolean;
@@ -24,6 +25,18 @@ const AuthContextProvider = ({ children }: { children: React.ReactNode }) => {
       // is unauthorized
     }
     setLoaded(true)
+
+    // Set up axios interceptor to redirect to login if any axios requests are unauthorized
+    axios.interceptors.response.use(
+      function (response){ return response } ,
+      async function (error) {
+        if (error.response && error.response.status === 401){
+          await logout()
+          setAuthenticated(false)
+        }
+        return Promise.reject(error)
+      }
+    )
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

When a user's cookie has expired, making any requests that require authorization will display a stuck spinner. 
<img width="968" alt="Screenshot 2020-05-21 at 7 44 07 PM" src="https://user-images.githubusercontent.com/33819199/82556105-aa712780-9b9b-11ea-8550-2591b0846d47.png">

## Solution

Intercept requests so that any requests that return 401 will redirect the user back to the public page. 
