### PR TITLE
refactor(backend): allow aws endpoint override

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -51,6 +51,11 @@ const config = convict({
       default:  'ap-northeast-1',
       env: 'AWS_REGION',
     },
+    awsEndpoint: {
+      doc: 'The endpoint to send AWS requests to. If not specified, a default one is made with AWS_REGION',
+      default: null,
+      env: 'AWS_ENDPOINT',
+    },
     logGroupName: {
       doc: '	Name of Cloudwatch log group to write application logs to',
       default: 'postmangovsg-beanstalk-prod',

--- a/backend/src/core/loaders/cloudwatch.loader.ts
+++ b/backend/src/core/loaders/cloudwatch.loader.ts
@@ -3,6 +3,7 @@ import WinstonCloudwatch from 'winston-cloudwatch'
 import config from '@core/config'
 import logger from '@core/logger'
 import { getInstanceId } from '@core/utils/ec2'
+import { configureEndpoint } from '@core/utils/aws-endpoint'
 
 /**
  * Writes logs directly to cloudwatch instead of relying on Elastic beanstalk's Cloudwatch agent
@@ -15,7 +16,7 @@ const cloudwatchLoader = async (): Promise<void> => {
       logger.add(new WinstonCloudwatch({
         logGroupName: config.get('aws.logGroupName'),
         logStreamName: instanceId,
-        awsRegion: config.get('aws.awsRegion'),
+        awsOptions: configureEndpoint(config),
       }))
     }
   } catch (err) {

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -5,11 +5,12 @@ import logger from '@core/logger'
 import config from '@core/config'
 import { ChannelType } from '@core/constants'
 import { Credential, UserCredential, User } from '@core/models'
+import { configureEndpoint } from '@core/utils/aws-endpoint'
 
 import { TwilioCredentials } from '@sms/interfaces'
 import { UserSettings } from '@core/interfaces'
 
-const secretsManager = new AWS.SecretsManager({ region: config.get('aws.awsRegion') })
+const secretsManager = new AWS.SecretsManager(configureEndpoint(config))
 
 /**
  * Checks if the credential has been saved

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash'
 import config from '@core/config'
 import logger from '@core/logger'
 import { RecipientColumnMissing } from '@core/errors/s3.errors'
+import { configureEndpoint } from '@core/utils/aws-endpoint'
 
 type CSVParamsInterface = {[key: string]: string}
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
@@ -14,7 +15,7 @@ export default class S3Client {
   constructor(s3?: S3) {
     this.s3 = s3 || new S3({
       signatureVersion: 'v4',
-      region: config.get('aws.awsRegion'),
+      ...configureEndpoint(config),
     })
   }
 

--- a/backend/src/core/services/template.service.ts
+++ b/backend/src/core/services/template.service.ts
@@ -2,12 +2,13 @@ import { v4 as uuid } from 'uuid'
 import S3 from 'aws-sdk/clients/s3'
 import config from '@core/config'
 import logger from '@core/logger'
+import { configureEndpoint } from '@core/utils/aws-endpoint'
 import { jwtUtils } from '@core/utils/jwt'
 
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
 const s3 = new S3({
   signatureVersion: 'v4',
-  region: config.get('aws.awsRegion'),
+  ...configureEndpoint(config),
 })
 
 /**

--- a/backend/src/core/utils/aws-endpoint.ts
+++ b/backend/src/core/utils/aws-endpoint.ts
@@ -1,0 +1,19 @@
+import convict from 'convict'
+
+interface AWSEndpointConfig { aws: { awsEndpoint: any, awsRegion: any } }
+
+/**
+ * Provide an Object containing either the endpoint to send AWS requests to,
+ * or if that is absent, the region from which to generate the endpoint. 
+ * This Object is to be injected into AWS JavaScript clients.
+ * 
+ * @param config - a convict object whose schema includes AWSEndpointConfig
+ * @return an object containing either the endpoint or region field
+ */
+const configureEndpoint = <T extends AWSEndpointConfig>(config: convict.Config<T>) => {
+  const endpoint = config.get('aws.awsEndpoint')
+  const region = config.get('aws.awsRegion')
+  return endpoint ? { endpoint } : { region }
+}
+
+export { configureEndpoint } 


### PR DESCRIPTION
## Problem

To allow dev work to be self-contained, we need to remove the hard
dependency on hosted services like AWS at runtime. The first step to
this requires us to accept a parameter - an explicit RESTful endpoint -
that will be injected into Postman's AWS JavaScript clients, overriding
`AWS_REGION` in the process.

Doing so will allow developers to get Postman to connect to a specified
mock AWS service when running on their own machines, and would also
help with more invasive testing. This would also allow for external devs
to contribute, since they no longer need to have an AWS account to work
on Postman.

Note that this does not allow overrides for workers, as frameworks that
mock AWS services (eg localstack) do not have a freely available ECS API

Prep work for #284

## Solution

- Add a new parameter in config - `aws.awsEndpoint`, env `AWS_ENDPOINT`
- Create a new utility function - `configureEndpoint()` - that handles
  selection of either endpoint or region for AWS config purposes
- Make use of `configureEndpoint()` in cloudwatch, S3 and SecretsManager
  - change the way we configure WinstonCloudwatch, by specifying
    `awsOptions` instead of `awsRegion`

## Tests

Confirm functionality by running on dev machine without and with `AWS_ENDPOINT` set

## Deploy Notes

N/A - for local dev testing

**New environment variables**:

- `AWS_ENDPOINT` : if specified, overrides `AWS_REGION`. The RESTful endpoint to send all AWS requests

**New scripts**:

- @core/utils/aws-endpoint - used to choose between endpoint and region at runtime
