### PR TITLE
fix: add missing foreign key for statistics

### DIFF
--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -4,10 +4,11 @@ import { CampaignS3ObjectInterface } from '@core/interfaces'
 import { Credential } from './credential'
 import { User } from './user'
 import { JobQueue } from './job-queue'
+import { Statistic } from './statistic'
 import { EmailTemplate } from '@email/models'
 import { SmsTemplate } from '@sms/models'
 
-@Table({ tableName: 'campaigns' , underscored: true, timestamps: true })
+@Table({ tableName: 'campaigns', underscored: true, timestamps: true })
 export class Campaign extends Model<Campaign> {
   @HasMany(() => JobQueue, { as: 'job_queue' })
   @HasOne(() => EmailTemplate, { as: 'email_templates' })
@@ -53,4 +54,7 @@ export class Campaign extends Model<Campaign> {
     allowNull: false,
   })
   valid!: boolean
+
+  @HasOne(() => Statistic)
+  statistic?: Statistic
 }


### PR DESCRIPTION
## Problem

Foreign key missing for campaignId in statistics table 

## Solution

Add to campaign model file.

## Deploy Notes

Manually add foreign key to staging and prod db