### PR TITLE
fix: remove BeforeUpdate hook for user model, uncaught error for api gen

### DIFF
--- a/backend/src/core/models/user.ts
+++ b/backend/src/core/models/user.ts
@@ -1,4 +1,4 @@
-import { Column, DataType, Model, Table, BeforeUpdate, BeforeCreate, HasMany } from 'sequelize-typescript'
+import { Column, DataType, Model, Table, BeforeCreate, HasMany } from 'sequelize-typescript'
 import { UserCredential } from './user-credential'
 import { ApiKeyService } from '@core/services'
 import { validateDomain } from '@core/utils/validate-domain'
@@ -25,7 +25,7 @@ export class User extends Model<User> {
   // During programmatic creation of users (users signing up by themselves), emails must end in a whitelisted domain
   // If we manually insert the user into the database, then this hook is bypassed.
   // This enables us to whitelist specific emails that do not end in a whitelisted domain, which can sign in, but not sign up.
-  @BeforeUpdate
+  // Since updating of email is never done programtically, we are not adding this as a BeforeUpdate hook
   @BeforeCreate
   static validateEmail(instance: User): void {
     if (!validateDomain(instance.email)) {
@@ -38,7 +38,7 @@ export class User extends Model<User> {
     const apiKeyPlainText = ApiKeyService.generateApiKeyFromName(name)
     const apiKeyHash = await ApiKeyService.getApiKeyHash(apiKeyPlainText)
     this.apiKey = apiKeyHash
-    this.save()
+    await this.save()
     return apiKeyPlainText
   }
 }


### PR DESCRIPTION
## Problem

Manually whitelisted users cannot create api key.
Error uncaught on server side and client side.

## Solution

Remove BeforeUpdate hook and handle errors.

## Screenshots
![Screenshot 2020-05-22 at 6 00 47 PM](https://user-images.githubusercontent.com/10072985/82657039-4318ad80-9c57-11ea-9490-a94305a9700d.png)
