### PR TITLE
fix: do not override message logs (received_at and error_code)

### DIFF
--- a/worker/src/email/resources/sql/log-job-email.sql
+++ b/worker/src/email/resources/sql/log-job-email.sql
@@ -5,11 +5,11 @@ AS $$
 BEGIN
 	UPDATE email_messages m 
 	SET dequeued_at = p.dequeued_at,
-		error_code = p.error_code,
+		error_code = COALESCE(p.error_code, m.error_code),
 		message_id = p.message_id,
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
-		received_at = p.received_at,
+		received_at = COALESCE(p.received_at, m.received_at),
 		updated_at = clock_timestamp() 
 	FROM email_ops p WHERE 
 	p.campaign_id = selected_campaign_id 

--- a/worker/src/sms/resources/sql/log-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-job-sms.sql
@@ -5,11 +5,11 @@ AS $$
 BEGIN
 	UPDATE sms_messages m 
 	SET dequeued_at = p.dequeued_at,
-		error_code = p.error_code,
+		error_code = COALESCE(p.error_code, m.error_code),
 		message_id = p.message_id,
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
-		received_at = p.received_at,
+		received_at = COALESCE(p.received_at, m.received_at),
 		updated_at = clock_timestamp() 
 	FROM sms_ops p WHERE 
 	p.campaign_id = selected_campaign_id 


### PR DESCRIPTION
## Problem
Closes #312

## Solution

Pick the non null value to update to. 

> The COALESCE function accepts an unlimited number of arguments. It returns the first argument that is not null. If all arguments are null, the COALESCE function will return null.