### PR TITLE
fix: log orphan ops records if they havent been updated after 20s

### DIFF
--- a/worker/src/core/resources/sql/resume-worker.sql
+++ b/worker/src/core/resources/sql/resume-worker.sql
@@ -2,29 +2,7 @@ CREATE OR REPLACE FUNCTION resume_worker(worker text)
  RETURNS void
  LANGUAGE plpgsql
 AS $$
-DECLARE selected_campaign_id int; logged_campaign_id int;
 BEGIN
-    -- Find a campaign that this worker was running
-    SELECT campaign_id INTO selected_campaign_id FROM job_queue WHERE worker_id=worker AND status IN ('ENQUEUED', 'SENDING') LIMIT 1;
-    IF selected_campaign_id IS NOT NULL THEN
-
-            -- Attempt to log that campaign
-            UPDATE job_queue q SET status = 'LOGGED', worker_id = NULL, updated_at = clock_timestamp() WHERE campaign_id = selected_campaign_id 
-            -- Should we check for existing jobs that are running for this campaign?
-            RETURNING q.campaign_id INTO logged_campaign_id;
-
-            -- If we managed to update the status
-            IF logged_campaign_id IS NOT NULL THEN 
-            -- Then do the logging
-                PERFORM 
-                    CASE WHEN type = 'EMAIL' THEN log_job_email(logged_campaign_id)
-                    WHEN type = 'SMS' THEN log_job_sms(logged_campaign_id)
-                    END
-                FROM campaigns where id = logged_campaign_id;
-            -- Set the status back to ready so that another worker can pick it up to continue sending
-                PERFORM retry_jobs(logged_campaign_id);
-            END IF;
-
-    END IF;
-    
+    -- Find a job that this worker was running and reset it so someone else can pick it up
+    UPDATE job_queue q SET status = 'READY', worker_id = NULL, updated_at = clock_timestamp() WHERE worker_id = worker;
 END $$

--- a/worker/src/email/resources/sql/log-next-job-email.sql
+++ b/worker/src/email/resources/sql/log-next-job-email.sql
@@ -11,23 +11,20 @@ WITH logged_jobs AS (
 		AND
 		c1.type = 'EMAIL'
 		AND
+		-- if status is sent or stopped, we check that  
+			-- all messages with sent_at have delivered_at
+		-- else for any status - X time has passed since the most recent sent_at (in the case that the worker died and did not write back to some records)
 		(
 			(
-				-- if status is sent, then we need to check all messages have delivered_at (meaning the sending client had responded)
-				q1.status = 'SENT' 
-				AND
-				NOT EXISTS 	
-					( SELECT 1 FROM email_ops p WHERE p.campaign_id = q1.campaign_id AND  delivered_at IS NULL LIMIT 1) 
-			
+				q1.status IN ('SENT','STOPPED')
+				AND         
+					NOT EXISTS 
+						( SELECT 1 FROM email_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT  1)
 			)
 			OR
-			(  
-				-- if status is stopped, then we need to check that all messages with sent_at, also have delivered_at.
-				q1.status = 'STOPPED'
-				AND
-				NOT EXISTS 
-					( SELECT 1 FROM email_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT  1)
-
+			(
+				-- 20 seconds has passed since the most recent sent_at (the ops table has been stuck for a while)
+				(SELECT EXTRACT(EPOCH FROM (clock_timestamp()-MAX(p.sent_at))) FROM email_ops p WHERE p.campaign_id = q1.campaign_id) > 20 
 			)
 		)
 	    FOR UPDATE SKIP LOCKED

--- a/worker/src/sms/resources/sql/log-next-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-next-job-sms.sql
@@ -11,23 +11,20 @@ WITH logged_jobs AS (
 		AND
 		c1.type = 'SMS'
 		AND
+		-- if status is sent or stopped, we check that  
+			-- all messages with sent_at have delivered_at
+		-- else for any status - X time has passed since the most recent sent_at (in the case that the worker died and did not write back to some records)
 		(
 			(
-				-- if status is sent, then we need to check all messages have delivered_at (meaning the sending client had responded)
-				q1.status = 'SENT' 
+				q1.status IN ('SENT','STOPPED')
 				AND
-				NOT EXISTS 	
-					( SELECT 1 FROM sms_ops p WHERE p.campaign_id = q1.campaign_id AND  delivered_at IS NULL LIMIT 1) 
-			
+					NOT EXISTS 
+						( SELECT 1 FROM sms_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT  1)
 			)
 			OR
-			(  
-				-- if status is stopped, then we need to check that all messages with sent_at, also have delivered_at.
-				q1.status = 'STOPPED'
-				AND
-				NOT EXISTS 
-					( SELECT 1 FROM sms_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT  1)
-
+			(
+				-- 20 seconds has passed since the most recent sent_at (the ops table has been stuck for a while)
+				(SELECT EXTRACT(EPOCH FROM (clock_timestamp()-MAX(p.sent_at))) FROM sms_ops p WHERE p.campaign_id = q1.campaign_id) > 20 
 			)
 		)
 	    FOR UPDATE SKIP LOCKED

--- a/worker/src/sms/resources/sql/log-next-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-next-job-sms.sql
@@ -11,19 +11,19 @@ WITH logged_jobs AS (
 		AND
 		c1.type = 'SMS'
 		AND
+		q1.status IN ('SENT','STOPPED')
 		-- if status is sent or stopped, we check that  
 			-- all messages with sent_at have delivered_at
-		-- else for any status - X time has passed since the most recent sent_at (in the case that the worker died and did not write back to some records)
+			-- OR X time has passed since the most recent sent_at (in the case that the worker died and did not write back to some records)
+		AND
 		(
 			(
-				q1.status IN ('SENT','STOPPED')
-				AND
 					NOT EXISTS 
-						( SELECT 1 FROM sms_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT  1)
+						( SELECT 1 FROM sms_ops p WHERE p.campaign_id = q1.campaign_id AND sent_at IS NOT NULL AND delivered_at IS NULL LIMIT 1 )
 			)
 			OR
 			(
-				-- 20 seconds has passed since the most recent sent_at (the ops table has been stuck for a while)
+				-- 20 seconds has passed since the most recent sent_at (the campaign has been stuck for a while in ops table)
 				(SELECT EXTRACT(EPOCH FROM (clock_timestamp()-MAX(p.sent_at))) FROM sms_ops p WHERE p.campaign_id = q1.campaign_id) > 20 
 			)
 		)


### PR DESCRIPTION
## Problem

Closes #254 

## Solution

For the explanation of the problem, refer to the issue above.

### 1 campaign 1 job

For job_status=SENT and job_status=STOPPED,  
- When all the ops messages that have sent_at also have delivered_at set, the job will be logged.
- Otherwise, if a worker had died, then some inflight ops messages that have sent_at will not have delivered_at set yet. After 20 seconds, the logger will assume that this job is stuck, and log it back to the messages table. 

For job_status = ENQUEUED or job_status=SENDING,
- if a worker dies, the job will not be logged. The good news is that when a respawned worker resumes the job, it will just start sending from the ops table. 

### 1 campaign multiple jobs
- If one of the workers for this campaign dies,
    - Since the live workers are still updating the ops, the job will not be logged.
    - A respawned worker will resume job for the dead worker, so send_rate should not be affected
   - Eventually, at least one of the jobs will reach SENT state, which triggers the check for whether the job is loggable. 
    - Since some of the inflight messages were not written back to when the worker died, this job will only be logged after 20s.


## Tests

```sql
-- Prepare some data
TRUNCATE campaigns, email_messages, email_ops, email_templates, job_queue, sms_messages, sms_ops, sms_templates, "statistics", workers RESTART IDENTITY CASCADE;

INSERT INTO campaigns (id, name, user_id, type, cred_name, s3_object, valid, created_at, updated_at) VALUES (1, 'name', 1, 'EMAIL', 'EMAIL_DEFAULT', '{}', true, clock_timestamp(), clock_timestamp());

INSERT INTO email_templates (campaign_id, body, subject, params, created_at, updated_at ) VALUES (1, 'text','text','{}', clock_timestamp(), clock_timestamp());

-- Insert 10 messages
INSERT INTO email_messages ("campaign_id", "recipient", "params", "created_at", "updated_at")
      SELECT t.* FROM  generate_series(1,10) num_recipient
      CROSS JOIN LATERAL ( 
      SELECT 1 as "campaign_id", concat(num_recipient, 'test@test.gov.sg') as "recipient", CAST('{}' AS json) as "params",clock_timestamp() as "created_at", clock_timestamp() as "updated_at") t;

-- Create 2 workers
INSERT into workers (id, created_at, updated_at) VALUES 
('1', clock_timestamp(), clock_timestamp()), 
('2', clock_timestamp(), clock_timestamp());

-- Create 2 jobs for the same campaign
INSERT INTO job_queue (campaign_id, worker_id, send_rate, status, created_at, updated_at) VALUES 
(1, NULL, 1, 'READY', clock_timestamp(), clock_timestamp()),
(1, NULL, 1, 'READY', clock_timestamp(), clock_timestamp());

SELECT * FROM job_queue;

-- Worker 1
SELECT get_next_job('1');
SELECT enqueue_messages_email(1);
-- Worker 2
SELECT get_next_job('2');
SELECT enqueue_messages_email(2);

-- Worker 1 picks one message.
SELECT get_messages_to_send_email(1,1); 
-- Scenario 1: Worker 1 does not return. It dies. 
SELECT EXTRACT(EPOCH FROM (clock_timestamp()-MAX(p.sent_at))) FROM email_ops p WHERE p.campaign_id = 1; -- Time elapsed
SELECT log_next_job_email(); -- Logger worker tries to log. It should fail to log campaign 1 after 20 seconds.
UPDATE job_queue SET status = 'STOPPED'; -- Artifically set the status to stopped
SELECT log_next_job_email(); -- Logger worker tries to log. It log campaign 1 after 20 seconds.

-- Scenario 2: Worker 2 keeps working on the same campaign;
DO $$
BEGIN
FOR counter IN 1..11 LOOP
    PERFORM get_messages_to_send_email(2,1); -- Worker 2 picks one message.
    PERFORM log_next_job_email();  -- This won't succeed because Worker 2 keeps setting sent_at.
END LOOP;
END; $$;

-- Scenario 3: All the sent_at have delivered_at, 
-- so the campaign should be logged immediately without waiting 20 seconds.
UPDATE email_ops SET delivered_at = clock_timestamp() WHERE campaign_id = 1; -- fake delivered at
SELECT log_next_job_email(); -- This will succeed because all the sent_at have delivered_at;


SELECT * from email_ops;

-- Resume worker: Worker X is spawned and replaces worker 1.
UPDATE workers SET id='X', updated_at=clock_timestamp() WHERE id='1';
SELECT resume_worker(

```