### PR TITLE
chore: Prevent invalid files from updating s3 meta data

### DIFF
--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -24,7 +24,11 @@ const createCampaign = ({ name, type, userId }: {name: string; type: string; use
  * On file upload, save the transaction id and file name against the campaign so that we can download the file from s3 later
  * @param param0 
  */
-const updateCampaignS3Metadata = ({ key, campaignId, filename }: { key: string; campaignId: string; filename: string }, transaction?: Transaction): Promise<[number, Campaign[]]> => {
+const updateCampaignS3Metadata = (
+  key: string,
+  campaignId: string,
+  filename: string,
+  transaction: Transaction | undefined): Promise<[number, Campaign[]]> => {
   const s3Object = {
     key,
     bucket: FILE_STORAGE_BUCKET_NAME,

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -39,7 +39,7 @@ const updateCampaignS3Metadata = ({ key, campaignId, filename }: { key: string; 
           id: campaignId,
         },
         returning: true,
-        transaction
+        transaction,
       }
     )
 }

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -95,6 +95,19 @@ const setInvalid = (campaignId: number): Promise<[number, Campaign[]]> => {
   })
 }
 
+/**
+ * Helper method to set a campaign to valid 
+ * @param campaignId 
+ */
+const setValid = (campaignId: number, transaction?: Transaction): Promise<[number, Campaign[]]> => {
+  return Campaign.update({
+    valid: true,
+  }, {
+    where: { id: +campaignId },
+    transaction,
+  })
+}
+
 
 export const CampaignService = { 
   hasJobInProgress, 
@@ -102,5 +115,6 @@ export const CampaignService = {
   retrieveCampaign, 
   listCampaigns, 
   updateCampaignS3Metadata, 
-  setInvalid, 
+  setInvalid,
+  setValid,
 }

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -1,4 +1,4 @@
-import { Op, literal  } from 'sequelize'
+import { Op, literal, Transaction  } from 'sequelize'
 import config from '@core/config'
 import { JobStatus } from '@core/constants'
 import { Campaign, JobQueue } from '@core/models'
@@ -24,7 +24,7 @@ const createCampaign = ({ name, type, userId }: {name: string; type: string; use
  * On file upload, save the transaction id and file name against the campaign so that we can download the file from s3 later
  * @param param0 
  */
-const updateCampaignS3Metadata = ({ key, campaignId, filename }: { key: string; campaignId: string; filename: string }): Promise<[number, Campaign[]]> => {
+const updateCampaignS3Metadata = ({ key, campaignId, filename }: { key: string; campaignId: string; filename: string }, transaction?: Transaction): Promise<[number, Campaign[]]> => {
   const s3Object = {
     key,
     bucket: FILE_STORAGE_BUCKET_NAME,
@@ -39,6 +39,7 @@ const updateCampaignS3Metadata = ({ key, campaignId, filename }: { key: string; 
           id: campaignId,
         },
         returning: true,
+        transaction
       }
     )
 }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -122,9 +122,6 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
   try {
     const { campaignId } = req.params
 
-    // switch campaign to invalid - this is for the case of uploading over an existing file
-    await CampaignService.setInvalid(+campaignId)
-
     // extract s3Key from transactionId
     const { 'transaction_id': transactionId, filename } = req.body
     const s3Key = TemplateService.extractS3Key(transactionId)

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -146,7 +146,7 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
   
       if (EmailTemplateService.hasInvalidEmailRecipient(records)) throw new InvalidRecipientError()
       
-      const recipientCount: number = records.length
+      const recipientCount = records.length
 
       await updateCampaignAndMessages(s3Key, campaignId, filename, records)
 

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -87,7 +87,7 @@ const updateCampaignAndMessages = async (
   try {
     transaction = await Campaign.sequelize?.transaction()
     // Updates metadata in project
-    await CampaignService.updateCampaignS3Metadata({ key, campaignId, filename }, transaction)
+    await CampaignService.updateCampaignS3Metadata( key, campaignId, filename, transaction)
 
     // START populate template
     await EmailTemplateService.addToMessageLogs(+campaignId, records, transaction)

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -169,6 +169,10 @@ const updateCampaignAndMessages = async (
 
     // START populate template
     await EmailTemplateService.addToMessageLogs(+campaignId, records, transaction)
+
+    // Set campaign to valid
+    await CampaignService.setValid(+campaignId, transaction)
+    
     transaction?.commit()    
   } catch (err) {
     transaction?.rollback()

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -1,5 +1,6 @@
 import { difference, keys, chunk } from 'lodash'
 import validator from 'validator'
+import { Transaction } from 'sequelize'
 
 import config from '@core/config'
 import logger from '@core/logger'
@@ -173,12 +174,12 @@ const getFilledTemplate = async (campaignId: number): Promise<EmailTemplate | nu
    * @param campaignId
    * @param records
    */
-const addToMessageLogs = async (campaignId: number, records: Array<object>): Promise<void> => {
-  logger.info({ message: `Started populateEmailTemplate for ${campaignId}` })
-  let transaction
-  
+const addToMessageLogs = async (
+  campaignId: number,
+  records: Array<object>,
+  transaction: Transaction | undefined): Promise<void> => {
+  logger.info({ message: `Started populateEmailTemplate for ${campaignId}` })  
   try {
-    transaction = await EmailMessage.sequelize?.transaction()
     // delete message_logs entries
     await EmailMessage.destroy({
       where: { campaignId },
@@ -199,10 +200,8 @@ const addToMessageLogs = async (campaignId: number, records: Array<object>): Pro
       },
       transaction,
     })
-    await transaction?.commit()
     logger.info({ message: `Finished populateEmailTemplate for ${campaignId}` })
   } catch (err) {
-    await transaction?.rollback()
     logger.error(`EmailMessage: destroy / bulkcreate failure. ${err.stack}`)
     throw new Error('EmailMessage: destroy / bulkcreate failure')
   }

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -169,10 +169,10 @@ const getFilledTemplate = async (campaignId: number): Promise<EmailTemplate | nu
 /**
    * 1. delete existing entries
    * 2. bulk insert
-   * 3. mark campaign as valid
-   * steps 1- 3 are wrapped in txn. rollback if any fails
+   * 
    * @param campaignId
    * @param records
+   * @param transaction
    */
 const addToMessageLogs = async (
   campaignId: number,
@@ -191,15 +191,6 @@ const addToMessageLogs = async (
       const batch = chunks[idx]
       await EmailMessage.bulkCreate(batch, { transaction })
     }
-  
-    await Campaign.update({
-      valid: true,
-    }, {
-      where: {
-        id: campaignId,
-      },
-      transaction,
-    })
     logger.info({ message: `Finished populateEmailTemplate for ${campaignId}` })
   } catch (err) {
     logger.error(`EmailMessage: destroy / bulkcreate failure. ${err.stack}`)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -68,6 +68,40 @@ const storeTemplate = async (req: Request, res: Response, next: NextFunction): P
 }
 
 /**
+ * Updates the campaign and email_messages table in a transaction, rolling back when either fails.
+ * For campaign table, the s3 meta data is updated with the uploaded file, and its validity is set to true.
+ * For email_messages table, existing records are deleted and new ones are bulk inserted.
+ * @param key 
+ * @param campaignId
+ * @param filename 
+ * @param records
+ */
+const updateCampaignAndMessages = async (
+  key: string,
+  campaignId: string,
+  filename: string,
+  records: MessageBulkInsertInterface[]): Promise<void> => {
+  let transaction
+
+  try {
+    transaction = await Campaign.sequelize?.transaction()
+    // Updates metadata in project
+    await CampaignService.updateCampaignS3Metadata({ key, campaignId, filename }, transaction)
+
+    // START populate template
+    await SmsTemplateService.addToMessageLogs(+campaignId, records, transaction)
+
+    // Set campaign to valid
+    await CampaignService.setValid(+campaignId, transaction)
+    
+    transaction?.commit()    
+  } catch (err) {
+    transaction?.rollback()
+    throw(err)
+  }
+}
+  
+/**
  * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
  * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
  * If the template and csv do not match, prompt the user to upload a new file.
@@ -133,42 +167,6 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
       }
       return next(err)
     }
-  }
-}
-
-/**
- * Updates the campaign and email_messages table in a transaction, rolling back when either fails.
- * For campaign table, the s3 meta data is updated with the uploaded file, and its validity is set to true.
- * For email_messages table, existing records are deleted and new ones are bulk inserted.
- * @param key 
- * @param campaignId
- * @param filename 
- * @param records
- */
-const updateCampaignAndMessages = async (
-  key: string,
-  campaignId: string,
-  filename: string,
-  records: MessageBulkInsertInterface[]) => {
-  let transaction
-
-  try {
-    transaction = await Campaign.sequelize?.transaction()
-    // Updates metadata in project
-    await CampaignService.updateCampaignS3Metadata({ key, campaignId, filename }, transaction)
-
-    // START populate template
-    logger.info(`before sms.addToMessageLogs; campaignId=${campaignId}`)
-    await SmsTemplateService.addToMessageLogs(+campaignId, records, transaction)
-    logger.info(`after sms.addToMessageLogs; campaignId=${campaignId}`)
-
-    // Set campaign to valid
-    await CampaignService.setValid(+campaignId, transaction)
-    
-    transaction?.commit()    
-  } catch (err) {
-    transaction?.rollback()
-    throw(err)
   }
 }
 

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -86,7 +86,7 @@ const updateCampaignAndMessages = async (
   try {
     transaction = await Campaign.sequelize?.transaction()
     // Updates metadata in project
-    await CampaignService.updateCampaignS3Metadata({ key, campaignId, filename }, transaction)
+    await CampaignService.updateCampaignS3Metadata( key, campaignId, filename, transaction)
 
     // START populate template
     await SmsTemplateService.addToMessageLogs(+campaignId, records, transaction)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -162,6 +162,9 @@ const updateCampaignAndMessages = async (
     await SmsTemplateService.addToMessageLogs(+campaignId, records, transaction)
     logger.info(`after sms.addToMessageLogs; campaignId=${campaignId}`)
 
+    // Set campaign to valid
+    await CampaignService.setValid(+campaignId, transaction)
+    
     transaction?.commit()    
   } catch (err) {
     transaction?.rollback()

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -120,9 +120,6 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
     const { campaignId } = req.params
     // TODO: validate if project is in editable state
 
-    // switch campaign to invalid - this is for the case of uploading over an existing file
-    await CampaignService.setInvalid(+campaignId)
-
     // extract s3Key from transactionId
     const { 'transaction_id': transactionId, filename } = req.body
     const s3Key: string = TemplateService.extractS3Key(transactionId)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -145,7 +145,7 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
 
       if (SmsTemplateService.hasInvalidSmsRecipient(records)) throw new InvalidRecipientError()
 
-      const recipientCount: number = records.length
+      const recipientCount = records.length
 
       await updateCampaignAndMessages(s3Key, campaignId, filename, records)
 

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -163,10 +163,9 @@ const getFilledTemplate = async (campaignId: number): Promise<SmsTemplate | null
 /**
  * 1. delete existing entries
  * 2. bulk insert
- * 3. mark campaign as valid
- * steps 1- 3 are wrapped in txn. rollback if any fails
  * @param campaignId
  * @param records
+ * @param transaction
  */
 const addToMessageLogs = async (
   campaignId: number,
@@ -185,15 +184,6 @@ const addToMessageLogs = async (
       const batch = chunks[idx]
       await SmsMessage.bulkCreate(batch, { transaction })
     }
-  
-    await Campaign.update({
-      valid: true,
-    }, {
-      where: {
-        id: campaignId,
-      },
-      transaction,
-    })
     logger.info({ message: `Finished populateSmsTemplate for ${campaignId}` })
   } catch (err) {
     logger.error(`SmsMessage: destroy / bulkcreate failure. ${err.stack}`)


### PR DESCRIPTION
## Problem

Closes #268

## Solution

**Improvements**:

- Updates s3 meta data only when csv file is valid, ie after parsing and test hydrate.
- Wraps updating of `campaign` and `message_logs` tables in a transaction.
- Move updating of campaign out of `addMessageLogs` function.
