### PR TITLE
Fix: Upload timeout

### DIFF
--- a/backend/.ebextensions/00-elb-timeout.config
+++ b/backend/.ebextensions/00-elb-timeout.config
@@ -1,4 +1,4 @@
 option_settings:
   - namespace: aws:elbv2:loadbalancer
     option_name: IdleTimeout
-    value: 240
+    value: 100

--- a/backend/.ebextensions/00-elb-timeout.config
+++ b/backend/.ebextensions/00-elb-timeout.config
@@ -1,0 +1,4 @@
+option_settings:
+  - namespace: aws:elbv2:loadbalancer
+    option_name: IdleTimeout
+    value: 240

--- a/backend/.ebextensions/10-nginx-timeout.config
+++ b/backend/.ebextensions/10-nginx-timeout.config
@@ -1,0 +1,17 @@
+files:
+  "/etc/nginx/conf.d/timeout.conf" :
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+        client_header_timeout   240;
+        client_body_timeout     240;
+        keepalive_timeout       240;
+        send_timeout            240;
+        proxy_connect_timeout   240;
+        proxy_read_timeout      240;
+        proxy_send_timeout      240;
+
+container_commands:
+  01_restart_nginx:
+    command: "sudo service nginx reload"

--- a/backend/.ebextensions/10-nginx-timeout.config
+++ b/backend/.ebextensions/10-nginx-timeout.config
@@ -4,13 +4,13 @@ files:
     owner: root
     group: root
     content: |
-        client_header_timeout   240;
-        client_body_timeout     240;
-        keepalive_timeout       240;
-        send_timeout            240;
-        proxy_connect_timeout   240;
-        proxy_read_timeout      240;
-        proxy_send_timeout      240;
+        client_header_timeout   100;
+        client_body_timeout     100;
+        keepalive_timeout       100;
+        send_timeout            100;
+        proxy_connect_timeout   100;
+        proxy_read_timeout      100;
+        proxy_send_timeout      100;
 
 container_commands:
   01_restart_nginx:

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -330,8 +330,9 @@ const config = convict({
       doc: 'Custom timeout period for upload/complete handler',
       default: 240 * 1000,
       env: 'UPLOAD_COMPLETE_TIMEOUT_IN_MS',
-    }
-  }
+      format: 'int',
+    },
+  },
 })
 
 

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -328,7 +328,7 @@ const config = convict({
   express: {
     uploadCompleteTimeout: {
       doc: 'Custom timeout period for upload/complete handler',
-      default: 240 * 1000,
+      default: 100 * 1000,
       env: 'UPLOAD_COMPLETE_TIMEOUT_IN_MS',
       format: 'int',
     },

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -1,11 +1,11 @@
 /**
- * @file Configuration 
+ * @file Configuration
  * All defaults can be changed
  */
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
-const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem')) 
+const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 /**
  * To require an env var without setting a default,
  * use
@@ -20,9 +20,9 @@ convict.addFormats({
         throw new Error('Required value cannot be empty')
       }
     },
-    coerce: (val: any): any => { 
+    coerce: (val: any): any => {
       if (val === null){
-        return undefined 
+        return undefined
       }
       return val
     },
@@ -116,7 +116,7 @@ const config = convict({
         default: 600000,
         env: 'SEQUELIZE_POOL_ACQUIRE_IN_MILLISECONDS',
         format: 'int',
-      }, 
+      },
     },
   },
   jwtSecret: {
@@ -182,7 +182,7 @@ const config = convict({
         env: 'COOKIE_PATH',
       },
     },
-      
+
   },
   otp: {
     retries: {
@@ -197,7 +197,7 @@ const config = convict({
     },
     resendTimeout: {
       doc: 'Number of seconds to wait before resending otp',
-      default: 30, 
+      default: 30,
       env: 'OTP_RESEND_SECONDS',
     },
   },
@@ -315,16 +315,23 @@ const config = convict({
           p: [],
           a: ['href', 'title', 'target'],
           img: ['src', 'alt', 'title', 'width', 'height'],
-        }, 
-        stripIgnoreTag: true, 
+        },
+        stripIgnoreTag: true,
       },
       sms:
-    { 
+    {
       whiteList: { br: [] },
       stripIgnoreTag: true,
     },
     },
   },
+  express: {
+    uploadCompleteTimeout: {
+      doc: 'Custom timeout period for upload/complete handler',
+      default: 240 * 1000,
+      env: 'UPLOAD_COMPLETE_TIMEOUT_IN_MS',
+    }
+  }
 })
 
 
@@ -353,7 +360,7 @@ case 'staging':
     },
   })
   break
-case 'development':  
+case 'development':
   config.set('IS_PROD', false)
   config.load({
     frontendUrl: 'http://localhost:3000',
@@ -366,7 +373,7 @@ case 'development':
         ssl: {
           require: false, // No ssl connection needed
           rejectUnauthorized: true,
-          ca: false, 
+          ca: false,
         },
       },
     },
@@ -379,7 +386,7 @@ case 'development':
         domain:  'localhost',
         path: '/',
       },
-    }, 
+    },
   })
   break
 }

--- a/backend/src/core/utils/aws-endpoint.ts
+++ b/backend/src/core/utils/aws-endpoint.ts
@@ -1,19 +1,19 @@
 import convict from 'convict'
 
-interface AWSEndpointConfig { aws: { awsEndpoint: any, awsRegion: any } }
+interface AWSEndpointConfig { aws: { awsEndpoint: any; awsRegion: any } }
 
 /**
  * Provide an Object containing either the endpoint to send AWS requests to,
- * or if that is absent, the region from which to generate the endpoint. 
+ * or if that is absent, the region from which to generate the endpoint.
  * This Object is to be injected into AWS JavaScript clients.
- * 
+ *
  * @param config - a convict object whose schema includes AWSEndpointConfig
  * @return an object containing either the endpoint or region field
  */
-const configureEndpoint = <T extends AWSEndpointConfig>(config: convict.Config<T>) => {
+const configureEndpoint = <T extends AWSEndpointConfig>(config: convict.Config<T>): any => {
   const endpoint = config.get('aws.awsEndpoint')
   const region = config.get('aws.awsRegion')
   return endpoint ? { endpoint } : { region }
 }
 
-export { configureEndpoint } 
+export { configureEndpoint }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -124,7 +124,9 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
       const recipientCount: number = records.length
 
       // START populate template
+      logger.info(`before email.addToMessageLogs; campaignId=${campaignId}`)
       await EmailTemplateService.addToMessageLogs(+campaignId, records)
+      logger.info(`after email.addToMessageLogs; campaignId=${campaignId}`)
 
       return res.json({
         'num_recipients': recipientCount,

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -82,7 +82,7 @@ const uploadCompleteHandler = async (req: Request, res: Response): Promise<Respo
     }
     return
   })
-  
+
   try {
     const { campaignId } = req.params
 
@@ -92,7 +92,7 @@ const uploadCompleteHandler = async (req: Request, res: Response): Promise<Respo
     // extract s3Key from transactionId
     const { 'transaction_id': transactionId, filename } = req.body
     const s3Key = TemplateService.extractS3Key(transactionId)
-  
+
 
     // check if template exists
     const emailTemplate = await EmailTemplateService.getFilledTemplate(+campaignId)
@@ -133,13 +133,13 @@ const uploadCompleteHandler = async (req: Request, res: Response): Promise<Respo
         },
       })
     }
-    
+
   } catch (err) {
-    if (!res.headersSent){ 
+    if (!res.headersSent){
       return res.status(400).json({ message: err.message })
     }
   }
-  
+
 }
 
 export const EmailTemplateMiddleware = {

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
+import config from '@core/config'
 import logger from '@core/logger'
 import {
   MissingTemplateKeysError,
@@ -14,21 +15,22 @@ import {
 import { SmsTemplateService } from '@sms/services'
 import { StoreTemplateOutput } from '@sms/interfaces'
 
+const uploadTimeout = Number(config.get('express.uploadCompleteTimeout'))
 
 /**
  * Store template subject and body in sms template table.
  * If an existing csv has been uploaded for this campaign but whose columns do not match the attributes provided in the new template,
  * delete the old csv, and prompt user to upload a new csv.
- * @param req 
- * @param res 
- * @param next 
+ * @param req
+ * @param res
+ * @param next
  */
 const storeTemplate = async (req: Request, res: Response, next: NextFunction): Promise<Response | void> => {
   try {
     const { campaignId } = req.params
     const { body } = req.body
     // extract params from template, save to db (this will be done with hook)
-    const { check, numRecipients, valid, updatedTemplate }: StoreTemplateOutput = 
+    const { check, numRecipients, valid, updatedTemplate }: StoreTemplateOutput =
         await SmsTemplateService.storeTemplate({ campaignId: +campaignId, body })
 
     if (check?.reupload) {
@@ -40,7 +42,7 @@ const storeTemplate = async (req: Request, res: Response, next: NextFunction): P
           valid: false,
           template: {
             body: updatedTemplate?.body,
-               
+
             params: updatedTemplate?.params,
           },
         })
@@ -63,20 +65,23 @@ const storeTemplate = async (req: Request, res: Response, next: NextFunction): P
     return next(err)
   }
 }
-  
+
 /**
  * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
  * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
- * If the template and csv do not match, prompt the user to upload a new file. 
- * @param req 
- * @param res 
- * @param next 
+ * If the template and csv do not match, prompt the user to upload a new file.
+ * @param req
+ * @param res
+ * @param next
  */
 const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunction): Promise<Response | void> => {
+  res.setTimeout(uploadTimeout, async () => {
+    res.status(408).json('Request timed out')
+  })
   try {
     const { campaignId } = req.params
     // TODO: validate if project is in editable state
-  
+
     // switch campaign to invalid - this is for the case of uploading over an existing file
     await CampaignService.setInvalid(+campaignId)
 
@@ -88,7 +93,7 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
     } catch (err) {
       return res.status(400).json(err.message)
     }
-  
+
     // check if template exists
     const smsTemplate = await SmsTemplateService.getFilledTemplate(+campaignId)
     if (smsTemplate === null){
@@ -96,10 +101,10 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
         message: 'Template does not exist, please create a template',
       })
     }
-  
+
     // Updates metadata in project
     await CampaignService.updateCampaignS3Metadata({ key: s3Key, campaignId, filename })
-  
+
     // carry out templating / hydration
     // - download from s3
     try {
@@ -115,12 +120,12 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
       const recipientCount: number = records.length
       // START populate template
       await SmsTemplateService.addToMessageLogs(+campaignId, records)
-  
+
       return res.json({
         'num_recipients': recipientCount,
         preview: hydratedRecord,
       })
-  
+
     } catch (err) {
       logger.error(`Error parsing file for campaign ${campaignId}. ${err.stack}`)
       throw err

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -119,7 +119,9 @@ const uploadCompleteHandler = async (req: Request, res: Response, next: NextFunc
 
       const recipientCount: number = records.length
       // START populate template
+      logger.info(`before sms.addToMessageLogs; campaignId=${campaignId}`)
       await SmsTemplateService.addToMessageLogs(+campaignId, records)
+      logger.info(`after sms.addToMessageLogs; campaignId=${campaignId}`)
 
       return res.json({
         'num_recipients': recipientCount,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -29,7 +29,7 @@ if (missingEnvVars.length>0){
 // axios global defaults
 axios.defaults.baseURL = process.env.REACT_APP_BACKEND_URL as string
 axios.defaults.withCredentials = true
-axios.defaults.timeout = 240000 // 2 min
+axios.defaults.timeout = 100000 // 100 sec
 
 export const GUIDE_URL = process.env.REACT_APP_GUIDE_URL as string
 export const GUIDE_CREDENTIALS_URL = process.env.REACT_APP_GUIDE_CREDENTIALS_URL as string

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -29,7 +29,7 @@ if (missingEnvVars.length>0){
 // axios global defaults
 axios.defaults.baseURL = process.env.REACT_APP_BACKEND_URL as string
 axios.defaults.withCredentials = true
-axios.defaults.timeout = 10000 // 10s
+axios.defaults.timeout = 240000 // 2 min
 
 export const GUIDE_URL = process.env.REACT_APP_GUIDE_URL as string
 export const GUIDE_CREDENTIALS_URL = process.env.REACT_APP_GUIDE_CREDENTIALS_URL as string

--- a/frontend/src/services/upload.service.ts
+++ b/frontend/src/services/upload.service.ts
@@ -4,6 +4,7 @@ export async function uploadFileWithPresignedUrl(uploadedFile: File, presignedUr
   try {
     const s3AxiosInstance = axios.create({
       withCredentials: false,
+      timeout: 0,
     })
     await s3AxiosInstance.put(presignedUrl, uploadedFile, {
       headers: { 'Content-Type': uploadedFile.type },


### PR DESCRIPTION
## Problem

On hitting the `upload/complete` route, the handler takes quite a while to run, with the bulk of the time spent on the `addToMessageLogs` functions. For files that are large, this actually takes a significant amount of time, the connection to our API server is kept open, and our app (at various points - Axios instance on frontend [1], Express API [2], Cloudflare, ELB [3], Nginx within beakstalk [4]) times out before a response is obtained.

1. https://github.com/axios/axios#config-order-of-precedence
2. https://github.com/expressjs/express/issues/3330#issuecomment-307009713
3. https://jaxenter.com/troubleshooting-aws-elastic-beanstalk-134700.html
4. https://stackoverflow.com/a/49759065

## Solution

This is a stop gap fix. 
Since we have zero control [5] over cloudflare's timeout of 100s, we adjust all our timeouts accordingly to match 100s. 

5. https://community.cloudflare.com/t/connection-timeout-error-524-can-we-change-the-default-100-seconds-value/50446

## Tests
Upload a large enough file (intentionally cause timeout) on staging to test that all the above actually timeout within 100s

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:

- `UPLOAD_COMPLETE_TIMEOUT_IN_MS` : env var to control the timeout on the upload complete route on the backend. Not mandatory that this is set, as I've already defaulted it to 100s, but just including this option in case we want to adjust this without pushing a commit and deploy via CI.

**New scripts**:

- included under `backend/.ebextensions` to adjust ELB + Nginx timeouts
