### PR TITLE
fix: messages with message_id and error_code double counted

### DIFF
--- a/worker/src/email/resources/sql/enqueue-messages-email.sql
+++ b/worker/src/email/resources/sql/enqueue-messages-email.sql
@@ -9,7 +9,7 @@ BEGIN
 	WITH messages AS 
   (
     UPDATE email_messages m 
-    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL
+    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL, received_at = NULL
     WHERE m.campaign_id = selected_campaign_id
     -- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
     AND m.dequeued_at IS NULL

--- a/worker/src/email/resources/sql/enqueue-messages-email.sql
+++ b/worker/src/email/resources/sql/enqueue-messages-email.sql
@@ -7,20 +7,23 @@ BEGIN
 	RETURNING campaign_id INTO selected_campaign_id;
 
 	WITH messages AS 
-	(UPDATE email_messages m SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp() 
-	WHERE m.campaign_id = selected_campaign_id
-	-- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
-	AND m.dequeued_at IS NULL
-	-- check for message_id is null because we dont want to enqueue messages that have already been sent
-	AND m.message_id is NULL
-	RETURNING 
-	id,
-	campaign_id, 
-	recipient, 
-	params, 
-	dequeued_at,
-	created_at,
-	updated_at )
+  (
+    UPDATE email_messages m 
+    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL
+    WHERE m.campaign_id = selected_campaign_id
+    -- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
+    AND m.dequeued_at IS NULL
+    -- check for message_id is null because we dont want to enqueue messages that have already been sent
+    AND m.message_id is NULL
+    RETURNING 
+    id,
+    campaign_id, 
+    recipient, 
+    params, 
+    dequeued_at,
+    created_at,
+    updated_at
+  )
 
 	INSERT INTO email_ops 
 	(id,

--- a/worker/src/email/resources/sql/update-stats-email.sql
+++ b/worker/src/email/resources/sql/update-stats-email.sql
@@ -7,6 +7,8 @@ BEGIN
 WITH stats AS (
   SELECT
     COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
+    -- a row could have both error_code and message_id if a message is processed by the
+    -- messaging service but a status callback indicates an error downstream
     COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
     COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
   FROM email_messages

--- a/worker/src/email/resources/sql/update-stats-email.sql
+++ b/worker/src/email/resources/sql/update-stats-email.sql
@@ -7,7 +7,7 @@ BEGIN
 WITH stats AS (
   SELECT
     COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
-    COUNT(*) FILTER (WHERE error_code IS NOT NULL) AS errored,
+    COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
     COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
   FROM email_messages
   WHERE campaign_id = selected_campaign_id

--- a/worker/src/sms/resources/sql/enqueue-messages-sms.sql
+++ b/worker/src/sms/resources/sql/enqueue-messages-sms.sql
@@ -7,20 +7,23 @@ BEGIN
 	RETURNING campaign_id INTO selected_campaign_id;
 
 	WITH messages AS 
-	(UPDATE sms_messages m SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp()
-	WHERE m.campaign_id = selected_campaign_id
-	-- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
-	AND m.dequeued_at IS NULL
-	-- check for message_id is null because we dont want to enqueue messages that have already been sent
-	AND m.message_id is NULL
-	RETURNING 
-	id,
-	campaign_id, 
-	recipient, 
-	params, 
-	dequeued_at,
-	created_at,
-	updated_at )
+	(
+    UPDATE sms_messages m 
+    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL
+    WHERE m.campaign_id = selected_campaign_id
+    -- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
+    AND m.dequeued_at IS NULL
+    -- check for message_id is null because we dont want to enqueue messages that have already been sent
+    AND m.message_id is NULL
+    RETURNING 
+    id,
+    campaign_id, 
+    recipient, 
+    params, 
+    dequeued_at,
+    created_at,
+    updated_at
+  )
 
 	INSERT INTO sms_ops 
 	(id,

--- a/worker/src/sms/resources/sql/enqueue-messages-sms.sql
+++ b/worker/src/sms/resources/sql/enqueue-messages-sms.sql
@@ -9,7 +9,7 @@ BEGIN
 	WITH messages AS 
 	(
     UPDATE sms_messages m 
-    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL
+    SET dequeued_at = clock_timestamp(), updated_at = clock_timestamp(), error_code = NULL, delivered_at = NULL, sent_at = NULL, received_at = NULL
     WHERE m.campaign_id = selected_campaign_id
     -- enqueue only those that have not been enqueued - this means that when we retry, we will have to set dequeued_at to null
     AND m.dequeued_at IS NULL

--- a/worker/src/sms/resources/sql/update-stats-sms.sql
+++ b/worker/src/sms/resources/sql/update-stats-sms.sql
@@ -7,6 +7,8 @@ BEGIN
 WITH stats AS (
   SELECT
     COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
+    -- a row could have both error_code and message_id if a message is processed by the
+    -- messaging service but a status callback indicates an error downstream
     COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
     COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
   FROM sms_messages

--- a/worker/src/sms/resources/sql/update-stats-sms.sql
+++ b/worker/src/sms/resources/sql/update-stats-sms.sql
@@ -7,7 +7,7 @@ BEGIN
 WITH stats AS (
   SELECT
     COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
-    COUNT(*) FILTER (WHERE error_code IS NOT NULL) AS errored,
+    COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
     COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
   FROM sms_messages
   WHERE campaign_id = selected_campaign_id


### PR DESCRIPTION
## Problem

The `error_code` column is not overwritten on successful retry, due to coalescing of error_code from ops and message table. This means that successfully retried messages adds to the errored count as well.

## Solution
- Set `error_code`, `delivered_at` and `sent_at` on enqueue
- Errored count should not include message with `message_id`
