### PR TITLE
feat: Allow user to verify their credentials after creation

### DIFF
--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -201,34 +201,6 @@ const previewFirstMessage = async (
   }
 }
 
-/**
- * Verify user sms credentials with specific label
- * @param req
- * @param res
- */
-const verifyUserCredential = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  try {
-    const { recipient, label } = req.body
-    const userId = req.session?.user?.id
-    const credential = await CredentialService.getUserCredential(userId, label)
-    if (!credential) {
-      throw new Error('Invalid credentials.')
-    }
-
-    const twilioCred = await CredentialService.getTwilioCredentials(
-      credential.credName
-    )
-    await SmsService.sendValidationMessage(recipient, twilioCred)
-
-    return res.json({ message: 'OK' })
-  } catch (err) {
-    return res.status(400).json({ message: `${err}` })
-  }
-}
-
 export const SmsMiddleware = {
   getCredentialsFromBody,
   getCredentialsFromLabel,
@@ -237,5 +209,4 @@ export const SmsMiddleware = {
   setCampaignCredential,
   getCampaignDetails,
   previewFirstMessage,
-  verifyUserCredential,
 }

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -201,6 +201,34 @@ const previewFirstMessage = async (
   }
 }
 
+/**
+ * Verify user sms credentials with specific label
+ * @param req
+ * @param res
+ */
+const verifyUserCredential = async (
+  req: Request,
+  res: Response
+): Promise<Response | void> => {
+  try {
+    const { recipient, label } = req.body
+    const userId = req.session?.user?.id
+    const credential = await CredentialService.getUserCredential(userId, label)
+    if (!credential) {
+      throw new Error('Invalid credentials.')
+    }
+
+    const twilioCred = await CredentialService.getTwilioCredentials(
+      credential.credName
+    )
+    await SmsService.sendValidationMessage(recipient, twilioCred)
+
+    return res.json({ message: 'OK' })
+  } catch (err) {
+    return res.status(400).json({ message: `${err}` })
+  }
+}
+
 export const SmsMiddleware = {
   getCredentialsFromBody,
   getCredentialsFromLabel,
@@ -209,4 +237,5 @@ export const SmsMiddleware = {
   setCampaignCredential,
   getCampaignDetails,
   previewFirstMessage,
+  verifyUserCredential,
 }

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from 'express'
 import { Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 
@@ -132,7 +133,9 @@ router.get(
 router.post(
   '/credentials/verify',
   celebrate(verifyCredentialValidator),
-  SmsMiddleware.verifyUserCredential
+  SmsMiddleware.getCredentialsFromLabel,
+  SmsMiddleware.validateAndStoreCredentials,
+  (_req: Request, res: Response) => res.sendStatus(200)
 )
 
 export default router

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -25,6 +25,13 @@ const getCredentialsValidator = {
   [Segments.QUERY]: Joi.object({}),
 }
 
+const verifyCredentialValidator = {
+  [Segments.BODY]: Joi.object({
+    recipient: Joi.string().trim().required(),
+    label: Joi.string().required(),
+  }),
+}
+
 /**
  * @swagger
  * path:
@@ -93,6 +100,41 @@ router.get(
   '/credentials',
   celebrate(getCredentialsValidator),
   SettingsMiddleware.getChannelSpecificCredentials
+)
+
+/**
+ * @swagger
+ * path:
+ *  /settings/sms/credentials/verify:
+ *    post:
+ *      summary: Verify stored credential for user
+ *      tags:
+ *        - Settings
+ *      requestBody:
+ *        required: true
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                recipient:
+ *                  type: string
+ *                label:
+ *                  type: string
+ *
+ *      responses:
+ *        200:
+ *          description: OK
+ *        400:
+ *          description: Bad Request (invalid credentials, malformed request)
+ *        404:
+ *          description: Not Found
+ *
+ */
+router.post(
+  '/credentials/verify',
+  celebrate(verifyCredentialValidator),
+  SmsMiddleware.verifyUserCredential
 )
 
 export default router

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -127,8 +127,6 @@ router.get(
  *          description: OK
  *        400:
  *          description: Bad Request (invalid credentials, malformed request)
- *        404:
- *          description: Not Found
  *
  */
 router.post(

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
@@ -19,11 +19,19 @@ table.credTable {
 
   .icon {
     @include icon;
+    margin-left: 1rem;
 
     &.deleteButton {
       cursor: pointer;
       &:hover {
         color: $red;
+      }
+    }
+
+    &.verifyButton {
+      cursor: pointer;
+      &:hover {
+        color: $light-grey;
       }
     }
   }

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react'
 import cx from 'classnames'
 
+import { ChannelType } from 'classes'
 import { PrimaryButton, ConfirmModal } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'
 import { UserCredential, deleteCredential } from 'services/settings.service'
@@ -8,6 +9,7 @@ import { channelIcons } from 'classes'
 
 import AddCredentialModal from '../add-credential-modal'
 import EmptyCredentialsImage from 'assets/img/credentials.svg'
+import VerifyCredentialModal from '../verify-credential-modal'
 import styles from './Credentials.module.scss'
 
 const Credentials = ({
@@ -46,6 +48,15 @@ const Credentials = ({
     refresh()
   }
 
+  async function onVerifyCredClicked(label: string, type: ChannelType) {
+    modalContext.setModalContent(
+      <VerifyCredentialModal
+        label={label}
+        credType={type}
+      ></VerifyCredentialModal>
+    )
+  }
+
   function renderCredentials() {
     return (
       <>
@@ -56,6 +67,15 @@ const Credentials = ({
             </td>
             <td className="md">{label}</td>
             <td className={cx('sm', styles.actionColumn)}>
+              <i
+                className={cx(
+                  'bx',
+                  'bx-message-check',
+                  styles.icon,
+                  styles.verifyButton
+                )}
+                onClick={() => onVerifyCredClicked(label, type)}
+              ></i>
               <i
                 className={cx(
                   'bx',

--- a/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.module.scss
+++ b/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.module.scss
@@ -1,5 +1,3 @@
-@import 'styles/_mixins';
-
 .container {
   padding: 1rem 0;
 

--- a/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.module.scss
+++ b/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.module.scss
@@ -1,0 +1,20 @@
+@import 'styles/_mixins';
+
+.container {
+  padding: 1rem 0;
+
+  .centerAlign {
+    text-align: center;
+  }
+
+  .padTop {
+    margin-top: 1rem;
+  }
+
+  img {
+    height: 30vh;
+    max-height: 200px;
+    margin: 5vh auto;
+    display: block;
+  }
+}

--- a/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.tsx
+++ b/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useContext } from 'react'
+
+import { ChannelType } from 'classes'
+import { PrimaryButton, ErrorBlock } from 'components/common'
+import SMSValidationInput from 'components/dashboard/create/sms/SMSValidationInput'
+import EmailValidationInput from 'components/dashboard/create/email/EmailValidationInput'
+import { ModalContext } from 'contexts/modal.context'
+import { verifyUserCredentials as VerifyUserSmsCredentials } from 'services/sms.service'
+
+import ConfirmImage from 'assets/img/confirm-modal.svg'
+import FailureImage from 'assets/img/failure.png'
+import SuccessImage from 'assets/img/success.png'
+import styles from './VerifyCredentialModal.module.scss'
+
+enum VerifyCredentialStep {
+  Verify,
+  Success,
+  Failure,
+}
+
+const VerifyCredentialModal = ({
+  label,
+  credType,
+}: {
+  label: string
+  credType: ChannelType
+}) => {
+  const [credStep, setCredStep] = useState(VerifyCredentialStep.Verify)
+  const [errorMessage, setErrorMessage] = useState('')
+  const modalContext = useContext(ModalContext)
+
+  async function verifyCredential(recipient: string) {
+    setErrorMessage('')
+    try {
+      switch (credType) {
+        case ChannelType.SMS:
+          await VerifyUserSmsCredentials({ recipient, label })
+          break
+        case ChannelType.Email:
+          throw new Error('not implemented')
+      }
+      setCredStep(VerifyCredentialStep.Success)
+    } catch (e) {
+      console.error(e)
+      setErrorMessage(e.message)
+      setCredStep(VerifyCredentialStep.Failure)
+    }
+  }
+
+  function renderValidate() {
+    let validateInput
+    switch (credType) {
+      case ChannelType.SMS:
+        validateInput = (
+          <SMSValidationInput onClick={verifyCredential}></SMSValidationInput>
+        )
+        break
+      case ChannelType.Email:
+        validateInput = (
+          <EmailValidationInput
+            onClick={verifyCredential}
+          ></EmailValidationInput>
+        )
+        break
+    }
+
+    return (
+      <>
+        <img src={ConfirmImage}></img>
+        <h2>Verify {label} credentials</h2>
+        <p>
+          To verify that your credentials are still working perfectly, please
+          enter an available mobile number to receive a validation message.
+        </p>
+        {validateInput}
+      </>
+    )
+  }
+
+  function renderVerifyCredStep() {
+    switch (credStep) {
+      // Verify credential step
+      case VerifyCredentialStep.Verify:
+        return renderValidate()
+      // Credential verification succeeded
+      case VerifyCredentialStep.Success:
+        return (
+          <div className={styles.centerAlign}>
+            <img src={SuccessImage} />
+            <h3>Your credentials are working well.</h3>
+            <PrimaryButton
+              className={styles.padTop}
+              onClick={() => modalContext.setModalContent(null)}
+            >
+              Done
+            </PrimaryButton>
+          </div>
+        )
+      // Credentials failed to store
+      case VerifyCredentialStep.Failure:
+        return (
+          <div className={styles.centerAlign}>
+            <img src={FailureImage} />
+            <h3>Sorry, something went wrong.</h3>
+            <ErrorBlock>{errorMessage}</ErrorBlock>
+          </div>
+        )
+    }
+  }
+
+  return <div className={styles.container}>{renderVerifyCredStep()}</div>
+}
+
+export default VerifyCredentialModal

--- a/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.tsx
+++ b/frontend/src/components/dashboard/settings/verify-credential-modal/VerifyCredentialModal.tsx
@@ -70,7 +70,7 @@ const VerifyCredentialModal = ({
         <h2>Verify {label} credentials</h2>
         <p>
           To verify that your credentials are still working perfectly, please
-          enter an available mobile number to receive a validation message.
+          enter an available recipient to receive a validation message.
         </p>
         {validateInput}
       </>

--- a/frontend/src/components/dashboard/settings/verify-credential-modal/index.ts
+++ b/frontend/src/components/dashboard/settings/verify-credential-modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './VerifyCredentialModal'

--- a/frontend/src/services/sms.service.ts
+++ b/frontend/src/services/sms.service.ts
@@ -79,6 +79,23 @@ export async function validateStoredCredentials({
   }
 }
 
+export async function verifyUserCredentials({
+  recipient,
+  label,
+}: {
+  label: string
+  recipient: string
+}): Promise<void> {
+  try {
+    await axios.post(`/settings/sms/credentials/verify`, {
+      recipient,
+      label,
+    })
+  } catch (e) {
+    errorHandler(e, 'Error verifying credentials.')
+  }
+}
+
 export async function storeCredentials({
   label,
   accountSid,


### PR DESCRIPTION
## Problem

Users were not able to verify their credentials after they have added it in on the Settings page. 

Closes #221 

## Solution

**Features**:

- Implemented an endpoint (`/settings/sms/credentials/verify`) to allow for verification of user sms credentials.
- Implemented a modal to allow user to trigger a verification message on the Settings page.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2020-06-02 at 2 02 49 PM](https://user-images.githubusercontent.com/3666479/83485488-c4830200-a4d9-11ea-8b94-d0198a46772f.png)

**AFTER**:
![Screenshot 2020-06-02 at 2 01 11 PM](https://user-images.githubusercontent.com/3666479/83485395-8a196500-a4d9-11ea-94de-3754e776335d.png)
![Screenshot 2020-06-02 at 1 55 55 PM](https://user-images.githubusercontent.com/3666479/83485095-df08ab80-a4d8-11ea-855b-56c4d8ea7795.png)
![Screenshot 2020-06-02 at 1 56 11 PM](https://user-images.githubusercontent.com/3666479/83485099-e16b0580-a4d8-11ea-9bb9-ca5eb306121b.png)
![Screenshot 2020-06-02 at 2 01 57 PM](https://user-images.githubusercontent.com/3666479/83485434-a87f6080-a4d9-11ea-9c05-b8a5b053742b.png)

## Tests

**Successful Verification Test**
1. Ensure there is an existing set of credentials on the Settings page
2. Verify the credentials by entering phone number
3. Modal should show a success message + sms 

**Failed Verification Test**
1. Ensure there is an existing set of credentials on the Settings page
2. Modify Twilio credentials in .env file to be invalid
3. Verify the credentials by entering phone number
4. Modal should show a error message + no sms received 
