### PR TITLE
chore: log if api key is used

### DIFF
--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -97,6 +97,7 @@ const isCookieOrApiKeyAuthenticated = async (
       // Practically, we have to check multiple places for the user id when we want to retrieve the id
       // To avoid these checks, we assign the user id to the session property instead so that downstream middlewares can use it
       req.session.user = user
+      req.session.apiKey = true
       return next()
     }
 

--- a/backend/src/core/utils/morgan.ts
+++ b/backend/src/core/utils/morgan.ts
@@ -16,7 +16,9 @@ const clientIp = (req: Request, _res: Response): string => {
 }
 
 const userId = (req: Request, _res: Response): string | undefined => {
-  return req?.session?.user?.id
+  const apiKey = req?.session?.apiKey
+  const userId = req?.session?.user?.id
+  return userId ? `${userId}${apiKey ? '-api' : ''}` : undefined
 }
 
 export { clientIp, userId }


### PR DESCRIPTION
## Problem

We are not tracking whether api-keys are being used.

## Solution

Append `-api` to the userId if the API key is being used to authenticate against the APIs instead of a session created via otp login.