### PR TITLE
feat: Use offset and limit for campaign pagination

### DIFF
--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -68,13 +68,16 @@ const listCampaigns = async (
   try {
     const { offset, limit } = req.query
     const userId = req.session?.user?.id
-    const campaigns = await CampaignService.listCampaigns({
+    const { rows, count } = await CampaignService.listCampaigns({
       offset,
       limit,
       userId,
     })
 
-    return res.json(campaigns)
+    return res.json({
+      campaigns: rows,
+      total_count: count,
+    })
   } catch (err) {
     return next(err)
   }

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -7,8 +7,8 @@ const router = Router()
 // validators
 const listCampaignsValidator = {
   [Segments.QUERY]: Joi.object({
-    limit: Joi.number().integer().min(1).optional(),
-    offset: Joi.number().integer().min(0).optional(),
+    limit: Joi.number().integer().min(1).max(100).default(10),
+    offset: Joi.number().integer().min(0).default(0),
   }),
 }
 
@@ -39,6 +39,8 @@ const createCampaignValidator = {
  *          schema:
  *            type: integer
  *            minimum: 1
+ *            maximum: 100
+ *            default: 10
  *        - in: query
  *          name: offset
  *          description: offset to begin returning campaigns from
@@ -46,14 +48,21 @@ const createCampaignValidator = {
  *          schema:
  *            type: integer
  *            minimum: 0
+ *            default: 0
  *      responses:
  *        "200":
  *          content:
  *            application/json:
  *              schema:
- *                type: array
- *                items:
- *                  $ref: '#/components/schemas/CampaignMeta'
+ *                type: object
+ *                properties:
+ *                  campaigns:
+ *                    type: array
+ *                    items:
+ *                      $ref: '#/components/schemas/CampaignMeta'
+ *                  total_count:
+ *                    type: integer
+ *
  *        "401":
  *           description: Unauthorized
  *        "500":

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -77,7 +77,7 @@ const listCampaigns = ({
   userId: number
   offset: number
   limit: number
-}): Promise<Array<Campaign>> => {
+}): Promise<{ rows: Array<Campaign>; count: number }> => {
   const options: {
     where: any
     attributes: any
@@ -115,7 +115,7 @@ const listCampaigns = ({
     options.limit = +limit
   }
 
-  return Campaign.findAll(options)
+  return Campaign.findAndCountAll(options)
 }
 
 /**

--- a/frontend/src/components/common/pagination/Pagination.tsx
+++ b/frontend/src/components/common/pagination/Pagination.tsx
@@ -7,7 +7,7 @@ const PAGE_RANGE_DISPLAYED = 5 // range of pages displayed
 const MARGIN_PAGES_DISPLAYED = 2 // number of pages displayed after ellipsis
 
 const Pagination = (props: any) => {
-  const { itemsCount, setSelectedPage, itemsPerPage } = props
+  const { itemsCount, selectedPage, setSelectedPage, itemsPerPage } = props
 
   const pageCount = itemsCount / itemsPerPage
 
@@ -34,6 +34,7 @@ const Pagination = (props: any) => {
       nextLabel={nextButton}
       breakLabel={'...'}
       pageCount={pageCount}
+      forcePage={selectedPage}
       marginPagesDisplayed={MARGIN_PAGES_DISPLAYED}
       pageRangeDisplayed={PAGE_RANGE_DISPLAYED}
       onPageChange={handlePageClick}

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -21,11 +21,11 @@ const Campaigns = () => {
   const { email } = useContext(AuthContext)
   const modalContext = useContext(ModalContext)
   const [isLoading, setLoading] = useState(true)
-  const [campaigns, setCampaigns] = useState(new Array<Campaign>())
   const [campaignsDisplayed, setCampaignsDisplayed] = useState(
     new Array<Campaign>()
   )
   const [selectedPage, setSelectedPage] = useState(0)
+  const [campaignCount, setCampaignCount] = useState(0)
   const history = useHistory()
   const name = getNameFromEmail(email)
   const title = `Welcome, ${name}`
@@ -39,20 +39,20 @@ const Campaigns = () => {
       .join(' ')
   }
 
-  async function fetchCampaigns() {
-    const campaigns = await getCampaigns()
-    setCampaigns(campaigns)
+  async function fetchCampaigns(selectedPage: number) {
+    setLoading(true)
+    const { campaigns, totalCount } = await getCampaigns({
+      offset: selectedPage * ITEMS_PER_PAGE,
+      limit: ITEMS_PER_PAGE,
+    })
+    setCampaignCount(totalCount)
+    setCampaignsDisplayed(campaigns)
     setLoading(false)
   }
 
   useEffect(() => {
-    fetchCampaigns()
-  }, [])
-
-  useEffect(() => {
-    const offset = selectedPage * ITEMS_PER_PAGE
-    setCampaignsDisplayed(campaigns.slice(offset, offset + ITEMS_PER_PAGE))
-  }, [campaigns, selectedPage])
+    fetchCampaigns(selectedPage)
+  }, [selectedPage])
 
   /* eslint-disable react/display-name */
   const headers = [
@@ -135,7 +135,7 @@ const Campaigns = () => {
   function renderCampaignList() {
     return (
       <>
-        <h2 className={styles.header}>{campaigns.length} past campaigns</h2>
+        <h2 className={styles.header}>{campaignCount} past campaigns</h2>
         <div className={styles.tableContainer}>
           <table className={styles.campaignTable}>
             <thead>
@@ -152,7 +152,8 @@ const Campaigns = () => {
         </div>
 
         <Pagination
-          itemsCount={campaigns.length}
+          itemsCount={campaignCount}
+          selectedPage={selectedPage}
           setSelectedPage={setSelectedPage}
           itemsPerPage={ITEMS_PER_PAGE}
         ></Pagination>
@@ -180,7 +181,7 @@ const Campaigns = () => {
               'bx bx-loader-alt bx-spin'
             )}
           ></i>
-        ) : campaigns.length > 0 ? (
+        ) : campaignCount > 0 ? (
           renderCampaignList()
         ) : (
           renderEmptyDashboard()

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -22,7 +22,8 @@ export async function getCampaigns(params: {
   totalCount: number
 }> {
   return axios.get('/campaigns', { params }).then((response) => {
-    const campaigns: Campaign[] = response.data.campaigns.map((data: any) => {
+    const { campaigns, total_count } = response.data
+    const campaignList: Campaign[] = campaigns.map((data: any) => {
       const details = {
         ...data,
         sent_at: getSentAt(data.job_queue),
@@ -32,8 +33,8 @@ export async function getCampaigns(params: {
     })
 
     return {
-      campaigns,
-      totalCount: response.data.total_count,
+      campaigns: campaignList,
+      totalCount: total_count,
     }
   })
 }

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -14,9 +14,15 @@ function getSentAt(jobs: Array<{ sent_at: Date }>): Date {
   return jobsSentAt[0]
 }
 
-export async function getCampaigns(): Promise<Array<Campaign>> {
-  return axios.get('/campaigns').then((response) => {
-    const campaigns: Campaign[] = response.data.map((data: any) => {
+export async function getCampaigns(params: {
+  offset: number
+  limit: number
+}): Promise<{
+  campaigns: Array<Campaign>
+  totalCount: number
+}> {
+  return axios.get('/campaigns', { params }).then((response) => {
+    const campaigns: Campaign[] = response.data.campaigns.map((data: any) => {
       const details = {
         ...data,
         sent_at: getSentAt(data.job_queue),
@@ -24,7 +30,11 @@ export async function getCampaigns(): Promise<Array<Campaign>> {
 
       return new Campaign(details)
     })
-    return campaigns
+
+    return {
+      campaigns,
+      totalCount: response.data.total_count,
+    }
   })
 }
 


### PR DESCRIPTION
## Problem

Offset and limit were not used for pagination on the frontend. 

Closes #317 

## Solution

**Improvements**:

- Make use of offset and limit on the frontend API calls
- Return a `total_count` on the response for pagination component. 
- Set `loading` to true on page change to give user a visual indicator that the page is being fetched. 

## Before & After Screenshots
Tests with 1000 campaigns in database.

**BEFORE**:
![Screenshot 2020-06-03 at 1 57 48 PM](https://user-images.githubusercontent.com/3666479/83600937-42124500-a5a2-11ea-80b2-a33317bf114e.png)

**AFTER**:
![Screenshot 2020-06-03 at 1 57 19 PM](https://user-images.githubusercontent.com/3666479/83600944-476f8f80-a5a2-11ea-90f0-365be43cc77b.png)

## Tests
**Regression tests:**
- Make sure that empty placeholder is still shown when there are no campaigns.
- Ensure that title still shows the correct total campaign count. 

**Functional tests:**
- Navigate between pages.
- Observe the following through Chrome dev tools:
    - `offset` and `limit` are being used.
    - Only the campaigns in the current page are loaded.
- Throttle network to "Slow 3G" and observe spinner being loaded between page changes.
