### PR TITLE
fix: catch s3 error

### DIFF
--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -38,6 +38,10 @@ export default class S3Client {
       // eslint-disable-next-line @typescript-eslint/camelcase
       skip_empty_lines: true,
     })
+    readStream.on('error', (err) => {
+      // Pass error from s3 to csv parser
+      parser.emit('error', err)
+    })
     readStream.pipe(parser)
     let headers: string[] = []
     let recipientIndex: number


### PR DESCRIPTION
## Problem
The following error was crashing our server. To reproduce consistently, upload a file to the presigned url, then delete the file from the s3 bucket, then call /upload/complete 

```
NoSuchKey: The specified key does not exist.
    at Request.extractError (/usr/home/postmangovsg/node_modules/aws-sdk/lib/services/s3.js:835:35)
    at Request.callListeners (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/usr/home/postmangovsg/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /usr/home/postmangovsg/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
    at Request.emit (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/usr/home/postmangovsg/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /usr/home/postmangovsg/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/usr/home/postmangovsg/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
    at callNextListener (/usr/home/postmangovsg/node_modules/aws-sdk/lib/sequential_executor.js:96:12)
    at IncomingMessage.onEnd (/usr/home/postmangovsg/node_modules/aws-sdk/lib/event_listeners.js:307:13)
    at IncomingMessage.emit (events.js:327:22)
    at IncomingMessage.EventEmitter.emit (domain.js:482:12)
```

## Solution

Propagate the error out of the read stream so that it can be caught. 

<img width="1198" alt="Screenshot 2020-06-04 at 11 09 25 AM" src="https://user-images.githubusercontent.com/33819199/83710698-ea341680-a653-11ea-9798-a4252a242b89.png">
<img width="949" alt="Screenshot 2020-06-04 at 11 08 54 AM" src="https://user-images.githubusercontent.com/33819199/83710712-ed2f0700-a653-11ea-8929-2e4075ba4d66.png">
