### PR TITLE
chore: remove nginx reload command

### DIFF
--- a/backend/.ebextensions/10-nginx-timeout.config
+++ b/backend/.ebextensions/10-nginx-timeout.config
@@ -11,7 +11,3 @@ files:
         proxy_connect_timeout   100;
         proxy_read_timeout      100;
         proxy_send_timeout      100;
-
-container_commands:
-  01_restart_nginx:
-    command: "sudo service nginx reload"


### PR DESCRIPTION
## Problem

We were unable to deploy reliably to release.
```[Instance: i-06a69d396f01f0a76] Command failed on instance. Return code: 7 Output: container_command 01_restart_nginx in .ebextensions/10-nginx-timeout.config failed. For more detail, check /var/log/eb-activity.log using console or EB CLI.```

The nginx-timeout config was introduced in 1.4.1 

## Solution

According to https://stackoverflow.com/questions/54992337/aws-elastic-beanstalk-nginx-reload-failed , we don't need to reload nginx.

A possible explanation is that because the `/etc/nginx/conf.d/timeout.conf` file is included as part of the default `nginx.conf`, Elastic Beanstalk would automatically start nginx with the timeout configuration when it is first deployed.

## Screenshots

Timeout still occurs at 100 seconds so I presume nginx is somehow configured with the longer timeout despite not reloading. 
<img width="1436" alt="Screenshot 2020-06-05 at 12 11 55 PM" src="https://user-images.githubusercontent.com/33819199/83836455-115b1880-a726-11ea-9f75-703ce9ac8366.png">

However, we should have sent the response status 408 instead of abruptly canceling the connection. Further investigation is required.
https://github.com/opengovsg/postmangovsg/blob/1e1e151f1ac06e1cb483b6ba354dcab283bb3491/backend/src/email/middlewares/email-template.middleware.ts#L134-L140

