### PR TITLE
Feature/create registered campaign

### DIFF
--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -41,7 +41,7 @@ const canCreateProtectedCampaign = async (
   next: NextFunction
 ): Promise<Response | void> => {
   try {
-    const { type, protect }: { type: string; protect?: boolean } = req.body
+    const { type, protect }: { type: string; protect: boolean } = req.body
     if (protect && type !== ChannelType.Email) {
       return res.sendStatus(403)
     }
@@ -67,7 +67,7 @@ const createCampaign = async (
       name,
       type,
       protect,
-    }: { name: string; type: string; protect?: boolean } = req.body
+    }: { name: string; type: string; protect: boolean } = req.body
     const userId = req.session?.user?.id
     const campaign = await CampaignService.createCampaign({
       name,

--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -30,19 +30,19 @@ const canEditCampaign = async (
 }
 
 /**
- *  If a campaign's channel is not a supported locked channel, then it cannot be created with locked set to true
+ *  If a campaign's channel is not a supported password protected channel, then it cannot be created with protect set to true
  * @param req
  * @param res
  * @param next
  */
-const canCreateLockedCampaign = async (
+const canCreateProtectedCampaign = async (
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
   try {
-    const { type, locked }: { type: string; locked?: boolean } = req.body
-    if (locked && type !== ChannelType.Email) {
+    const { type, protect }: { type: string; protect?: boolean } = req.body
+    if (protect && type !== ChannelType.Email) {
       return res.sendStatus(403)
     }
     return next()
@@ -66,21 +66,21 @@ const createCampaign = async (
     const {
       name,
       type,
-      locked,
-    }: { name: string; type: string; locked?: boolean } = req.body
+      protect,
+    }: { name: string; type: string; protect?: boolean } = req.body
     const userId = req.session?.user?.id
     const campaign = await CampaignService.createCampaign({
       name,
       type,
       userId,
-      locked,
+      protect,
     })
     return res.status(201).json({
       id: campaign.id,
       name: campaign.name,
       created_at: campaign.createdAt,
       type: campaign.type,
-      locked: campaign.locked,
+      protect: campaign.protect,
     })
   } catch (err) {
     return next(err)
@@ -118,7 +118,7 @@ const listCampaigns = async (
 
 export const CampaignMiddleware = {
   canEditCampaign,
-  canCreateLockedCampaign,
+  canCreateProtectedCampaign,
   createCampaign,
   listCampaigns,
 }

--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -40,18 +40,24 @@ const createCampaign = async (
   next: NextFunction
 ): Promise<Response | void> => {
   try {
-    const { name, type }: { name: string; type: string } = req.body
+    const {
+      name,
+      type,
+      locked,
+    }: { name: string; type: string; locked?: boolean } = req.body
     const userId = req.session?.user?.id
     const campaign = await CampaignService.createCampaign({
       name,
       type,
       userId,
+      locked,
     })
     return res.status(201).json({
       id: campaign.id,
       name: campaign.name,
       created_at: campaign.createdAt,
       type: campaign.type,
+      locked: campaign.locked,
     })
   } catch (err) {
     return next(err)

--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
+import { ChannelType } from '@core/constants'
 import { CampaignService, TemplateService } from '@core/services'
 
 /**
@@ -23,6 +24,28 @@ const canEditCampaign = async (
     } else {
       return res.sendStatus(403)
     }
+  } catch (err) {
+    return next(err)
+  }
+}
+
+/**
+ *  If a campaign's channel is not a supported locked channel, then it cannot be created with locked set to true
+ * @param req
+ * @param res
+ * @param next
+ */
+const canCreateLockedCampaign = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  try {
+    const { type, locked }: { type: string; locked?: boolean } = req.body
+    if (locked && type !== ChannelType.Email) {
+      return res.sendStatus(403)
+    }
+    return next()
   } catch (err) {
     return next(err)
   }
@@ -95,6 +118,7 @@ const listCampaigns = async (
 
 export const CampaignMiddleware = {
   canEditCampaign,
+  canCreateLockedCampaign,
   createCampaign,
   listCampaigns,
 }

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -69,7 +69,7 @@ export class Campaign extends Model<Campaign> {
     type: DataType.BOOLEAN,
     defaultValue: false,
   })
-  locked!: boolean
+  protect!: boolean
 
   @HasOne(() => Statistic)
   statistic?: Statistic

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -68,6 +68,7 @@ export class Campaign extends Model<Campaign> {
   @Column({
     type: DataType.BOOLEAN,
     defaultValue: false,
+    allowNull: false,
   })
   protect!: boolean
 

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -65,6 +65,12 @@ export class Campaign extends Model<Campaign> {
   })
   valid!: boolean
 
+  @Column({
+    type: DataType.BOOLEAN,
+    defaultValue: false,
+  })
+  locked!: boolean
+
   @HasOne(() => Statistic)
   statistic?: Statistic
 

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -18,6 +18,7 @@ const createCampaignValidator = {
       .valid(...Object.values(ChannelType))
       .required(),
     name: Joi.string().max(255).trim().required(),
+    locked: Joi.boolean(),
   }),
 }
 

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -18,7 +18,7 @@ const createCampaignValidator = {
       .valid(...Object.values(ChannelType))
       .required(),
     name: Joi.string().max(255).trim().required(),
-    locked: Joi.boolean(),
+    protect: Joi.boolean(),
   }),
 }
 
@@ -122,7 +122,7 @@ router.get(
 router.post(
   '/',
   celebrate(createCampaignValidator),
-  CampaignMiddleware.canCreateLockedCampaign,
+  CampaignMiddleware.canCreateProtectedCampaign,
   CampaignMiddleware.createCampaign
 )
 

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -122,6 +122,7 @@ router.get(
 router.post(
   '/',
   celebrate(createCampaignValidator),
+  CampaignMiddleware.canCreateLockedCampaign,
   CampaignMiddleware.createCampaign
 )
 

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -18,7 +18,7 @@ const createCampaignValidator = {
       .valid(...Object.values(ChannelType))
       .required(),
     name: Joi.string().max(255).trim().required(),
-    protect: Joi.boolean(),
+    protect: Joi.boolean().default(false),
   }),
 }
 

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -19,14 +19,14 @@ const createCampaign = ({
   name,
   type,
   userId,
-  locked,
+  protect,
 }: {
   name: string
   type: string
   userId: number
-  locked?: boolean
+  protect?: boolean
 }): Promise<Campaign> => {
-  return Campaign.create({ name, type, userId, valid: false, locked })
+  return Campaign.create({ name, type, userId, valid: false, protect })
 }
 
 /**

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -24,7 +24,7 @@ const createCampaign = ({
   name: string
   type: string
   userId: number
-  protect?: boolean
+  protect: boolean
 }): Promise<Campaign> => {
   return Campaign.create({ name, type, userId, valid: false, protect })
 }

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -19,12 +19,14 @@ const createCampaign = ({
   name,
   type,
   userId,
+  locked,
 }: {
   name: string
   type: string
   userId: number
+  locked?: boolean
 }): Promise<Campaign> => {
-  return Campaign.create({ name, type, userId, valid: false })
+  return Campaign.create({ name, type, userId, valid: false, locked })
 }
 
 /**

--- a/backend/src/email/interfaces/email.interface.ts
+++ b/backend/src/email/interfaces/email.interface.ts
@@ -34,6 +34,8 @@ export interface StoreTemplateOutput {
  *           type: boolean
  *         valid:
  *           type: boolean
+ *         protect:
+ *           type: boolean
  *         csv_filename:
  *           type: string
  *         is_csv_processing:

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -151,6 +151,7 @@ const getCampaignDetails = async (
         'type',
         'created_at',
         'valid',
+        'protect',
         [literal('cred_name IS NOT NULL'), 'has_credential'],
         [literal("s3_object -> 'filename'"), 'csv_filename'],
         [

--- a/backend/src/sms/services/sms.service.ts
+++ b/backend/src/sms/services/sms.service.ts
@@ -133,6 +133,7 @@ const getCampaignDetails = async (
         'type',
         'created_at',
         'valid',
+        'protect',
         [literal('"cred_name" IS NOT NULL'), 'has_credential'],
         [literal("s3_object -> 'filename'"), 'csv_filename'],
         [

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -22,6 +22,7 @@ export class Campaign {
   sentAt: Date
   status: Status
   isCsvProcessing: boolean
+  protect: boolean
 
   constructor(input: any) {
     this.id = input['id']
@@ -31,6 +32,7 @@ export class Campaign {
     this.sentAt = input['sent_at']
     this.status = this.getStatus(input['job_queue'])
     this.isCsvProcessing = input['is_csv_processing']
+    this.protect = input['protect']
   }
 
   getStatus(jobs: Array<{ status: string }>): Status {

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -56,6 +56,7 @@
   @include flex-horizontal;
   margin-top: 1rem;
   padding-left: 1rem;
+  cursor: pointer;
 
   @include mobile() {
     width: 100%;
@@ -64,7 +65,6 @@
   }
 
   .icon {
-    cursor: pointer;
     margin-right: 0.2rem;
   }
 
@@ -106,5 +106,6 @@
     color: $dark-blue;
     line-height: 1.5rem;
     text-decoration: underline;
+    margin-left: 0.2rem;
   }
 }

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -49,6 +49,30 @@
   }
 }
 
+.protectedOption {
+  height: 1.5rem;
+  width: 50%;
+  align-self: flex-end;
+  @include flex-horizontal;
+  margin-top: 1rem;
+  padding-left: 1rem;
+
+  @include mobile() {
+    width: 100%;
+    padding-left: 0px;
+    align-self: stretch;
+  }
+
+  .icon {
+    cursor: pointer;
+    margin-right: 0.2rem;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
 .input {
   background-color: $light-blue;
 }
@@ -71,6 +95,7 @@
 }
 
 .subtext {
+  height: 1.5rem;
   font-size: 0.75rem;
   margin-top: 1rem;
   margin-bottom: 0;
@@ -79,6 +104,7 @@
     font-size: 0.75rem;
     font-style: italic;
     color: $dark-blue;
+    line-height: 1.5rem;
     text-decoration: underline;
   }
 }

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -3,7 +3,7 @@ import { OutboundLink } from 'react-ga'
 import { useHistory } from 'react-router-dom'
 import cx from 'classnames'
 
-import { GUIDE_CREDENTIALS_URL } from 'config'
+import { GUIDE_URL, GUIDE_CREDENTIALS_URL } from 'config'
 import { ChannelType, Campaign } from 'classes/Campaign'
 import { TextInput, PrimaryButton } from 'components/common'
 import styles from './CreateModal.module.scss'
@@ -79,7 +79,10 @@ const CreateModal = () => {
         </div>
 
         {selectedChannel === ChannelType.Email && (
-          <div className={styles.protectedOption}>
+          <div
+            className={styles.protectedOption}
+            onClick={() => setProtected(!protect)}
+          >
             <i
               className={cx(
                 'bx',
@@ -87,13 +90,13 @@ const CreateModal = () => {
                 { 'bx-checkbox': !protect },
                 { 'bxs-checkbox-checked': protect }
               )}
-              onClick={() => setProtected(!protect)}
             ></i>
             <p className={styles.subtext}>
               Password protected.
+              {/* TODO: change url to passsword protected section in guide */}
               <OutboundLink
-                eventLabel={GUIDE_CREDENTIALS_URL}
-                to={GUIDE_CREDENTIALS_URL}
+                eventLabel={GUIDE_URL}
+                to={GUIDE_URL}
                 target="_blank"
               >
                 Learn more

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import { OutboundLink } from 'react-ga'
 import { useHistory } from 'react-router-dom'
 import cx from 'classnames'
@@ -15,9 +15,19 @@ const CreateModal = () => {
   const history = useHistory()
   const [selectedChannel, setSelectedChannel] = useState(ChannelType.SMS)
   const [name, setName] = useState('')
+  const [locked, setLocked] = useState(false)
+
+  useEffect(() => {
+    setLocked(false)
+  }, [selectedChannel])
+
   async function handleCreateCampaign() {
     try {
-      const campaign: Campaign = await createCampaign(name, selectedChannel)
+      const campaign: Campaign = await createCampaign(
+        name,
+        selectedChannel,
+        locked
+      )
       // close modal and go to create view
       modalContext.setModalContent(null)
       history.push(`/campaigns/${campaign.id}`)
@@ -68,16 +78,42 @@ const CreateModal = () => {
           </PrimaryButton>
         </div>
 
-        <p className={styles.subtext}>
-          Get your credentials ready.
-          <OutboundLink
-            eventLabel={GUIDE_CREDENTIALS_URL}
-            to={GUIDE_CREDENTIALS_URL}
-            target="_blank"
-          >
-            What is this?
-          </OutboundLink>
-        </p>
+        {selectedChannel === ChannelType.Email && (
+          <div className={styles.protectedOption}>
+            <i
+              className={cx(
+                'bx',
+                styles.icon,
+                { 'bx-checkbox': !locked },
+                { 'bxs-checkbox-checked': locked }
+              )}
+              onClick={() => setLocked(!locked)}
+            ></i>
+            <p className={styles.subtext}>
+              Password protected.
+              <OutboundLink
+                eventLabel={GUIDE_CREDENTIALS_URL}
+                to={GUIDE_CREDENTIALS_URL}
+                target="_blank"
+              >
+                Learn more
+              </OutboundLink>
+            </p>
+          </div>
+        )}
+
+        {selectedChannel === ChannelType.SMS && (
+          <p className={styles.subtext}>
+            Get your credentials ready.
+            <OutboundLink
+              eventLabel={GUIDE_CREDENTIALS_URL}
+              to={GUIDE_CREDENTIALS_URL}
+              target="_blank"
+            >
+              What is this?
+            </OutboundLink>
+          </p>
+        )}
       </div>
 
       <div className="separator"></div>

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -15,10 +15,10 @@ const CreateModal = () => {
   const history = useHistory()
   const [selectedChannel, setSelectedChannel] = useState(ChannelType.SMS)
   const [name, setName] = useState('')
-  const [locked, setLocked] = useState(false)
+  const [protect, setProtected] = useState(false)
 
   useEffect(() => {
-    setLocked(false)
+    setProtected(false)
   }, [selectedChannel])
 
   async function handleCreateCampaign() {
@@ -26,7 +26,7 @@ const CreateModal = () => {
       const campaign: Campaign = await createCampaign(
         name,
         selectedChannel,
-        locked
+        protect
       )
       // close modal and go to create view
       modalContext.setModalContent(null)
@@ -84,10 +84,10 @@ const CreateModal = () => {
               className={cx(
                 'bx',
                 styles.icon,
-                { 'bx-checkbox': !locked },
-                { 'bxs-checkbox-checked': locked }
+                { 'bx-checkbox': !protect },
+                { 'bxs-checkbox-checked': protect }
               )}
-              onClick={() => setLocked(!locked)}
+              onClick={() => setProtected(!protect)}
             ></i>
             <p className={styles.subtext}>
               Password protected.

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -90,9 +90,9 @@ export async function getCampaignDetails(
 export async function createCampaign(
   name: string,
   type: ChannelType,
-  locked: boolean
+  protect: boolean
 ): Promise<Campaign> {
-  return axios.post('/campaigns', { name, type, locked }).then((response) => {
+  return axios.post('/campaigns', { name, type, protect }).then((response) => {
     return new Campaign(response.data)
   })
 }

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -89,9 +89,10 @@ export async function getCampaignDetails(
 
 export async function createCampaign(
   name: string,
-  type: ChannelType
+  type: ChannelType,
+  locked: boolean
 ): Promise<Campaign> {
-  return axios.post('/campaigns', { name, type }).then((response) => {
+  return axios.post('/campaigns', { name, type, locked }).then((response) => {
     return new Campaign(response.data)
   })
 }


### PR DESCRIPTION
## Problem

Create email campaign with password protected option.

Closes #361 

## Solution

Add support for a `protect` attribute on campaign creation.

**Features**:

- Added `protect` column in Campaign model
- middleware to check if we support protected option for a campaign channel type before creating campaign

## Before & After Screenshots

![image](https://user-images.githubusercontent.com/5744384/84111880-577fe700-aa5a-11ea-8a7f-9ea93311f4ec.png)
![image](https://user-images.githubusercontent.com/5744384/84118231-48eafd00-aa65-11ea-87e0-0ccc338b2159.png)

## Todo

- Update Postman guide url for 'learn more' link for password protected option
