### PR TITLE
feat: log statuses, count stats based on statuses

### DIFF
--- a/worker/src/email/resources/sql/log-job-email.sql
+++ b/worker/src/email/resources/sql/log-job-email.sql
@@ -5,11 +5,14 @@ AS $$
 BEGIN
 	UPDATE email_messages m 
 	SET dequeued_at = p.dequeued_at,
-		error_code = COALESCE(p.error_code, m.error_code),
+    -- coalesced fields should prioritise message table over ops table 
+    -- because callbacks might arrive before logging
+		error_code = COALESCE(m.error_code, p.error_code),
+    status = COALESCE(m.status, p.status),
 		message_id = p.message_id,
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
-		received_at = COALESCE(p.received_at, m.received_at),
+		received_at = COALESCE(m.received_at, p.received_at),
 		updated_at = clock_timestamp() 
 	FROM email_ops p WHERE 
 	p.campaign_id = selected_campaign_id 

--- a/worker/src/email/resources/sql/update-stats-email.sql
+++ b/worker/src/email/resources/sql/update-stats-email.sql
@@ -6,21 +6,21 @@ BEGIN
 -- Archive number of unsent, errored and sent email messages in statistics table
 WITH stats AS (
   SELECT
-    COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
-    -- a row could have both error_code and message_id if a message is processed by the
-    -- messaging service but a status callback indicates an error downstream
-    COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
-    COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
+    COUNT(*) FILTER (WHERE status IS NULL) AS unsent,
+    COUNT(*) FILTER (WHERE status = 'ERROR') AS errored,
+    COUNT(*) FILTER (WHERE status = 'SENDING' OR status = 'SUCCESS') AS sent,
+    COUNT(*) FILTER (WHERE status = 'INVALID_RECIPIENT') AS invalid
   FROM email_messages
   WHERE campaign_id = selected_campaign_id
 )
-INSERT INTO statistics (campaign_id, unsent, errored, sent, updated_at, created_at)
-SELECT selected_campaign_id, unsent, errored, sent, now(), now() FROM stats
+INSERT INTO statistics (campaign_id, unsent, errored, invalid, sent, updated_at, created_at)
+SELECT selected_campaign_id, unsent, errored, invalid, sent, now(), now() FROM stats
 ON CONFLICT (campaign_id) DO UPDATE
 SET
   unsent = excluded.unsent,
   errored = excluded.errored,
   sent = excluded.sent,
+  invalid = excluded.invalid,
   updated_at = excluded.updated_at;
 
 END $$

--- a/worker/src/sms/resources/sql/log-job-sms.sql
+++ b/worker/src/sms/resources/sql/log-job-sms.sql
@@ -5,11 +5,14 @@ AS $$
 BEGIN
 	UPDATE sms_messages m 
 	SET dequeued_at = p.dequeued_at,
-		error_code = COALESCE(p.error_code, m.error_code),
+    -- coalesced fields should prioritise message table over ops table 
+    -- because callbacks might arrive before logging
+		error_code = COALESCE(m.error_code, p.error_code),
+    status = COALESCE(m.status, p.status),
 		message_id = p.message_id,
 		sent_at = p.sent_at,
 		delivered_at = p.delivered_at,
-		received_at = COALESCE(p.received_at, m.received_at),
+		received_at = COALESCE(m.received_at, p.received_at),
 		updated_at = clock_timestamp() 
 	FROM sms_ops p WHERE 
 	p.campaign_id = selected_campaign_id 

--- a/worker/src/sms/resources/sql/update-stats-sms.sql
+++ b/worker/src/sms/resources/sql/update-stats-sms.sql
@@ -6,21 +6,21 @@ BEGIN
 -- Archive number of unsent, errored and sent sms messages in statistics table
 WITH stats AS (
   SELECT
-    COUNT(*) FILTER (WHERE delivered_at IS NULL) AS unsent,
-    -- a row could have both error_code and message_id if a message is processed by the
-    -- messaging service but a status callback indicates an error downstream
-    COUNT(*) FILTER (WHERE error_code IS NOT NULL AND message_id IS NULL) AS errored,
-    COUNT(*) FILTER (WHERE message_id IS NOT NULL) AS sent
+    COUNT(*) FILTER (WHERE status IS NULL) AS unsent,
+    COUNT(*) FILTER (WHERE status = 'ERROR') AS errored,
+    COUNT(*) FILTER (WHERE status = 'SENDING' OR status = 'SUCCESS') AS sent,
+    COUNT(*) FILTER (WHERE status = 'INVALID_RECIPIENT') AS invalid
   FROM sms_messages
   WHERE campaign_id = selected_campaign_id
 )
-INSERT INTO statistics (campaign_id, unsent, errored, sent, updated_at, created_at)
-SELECT selected_campaign_id, unsent, errored, sent, now(), now() FROM stats
+INSERT INTO statistics (campaign_id, unsent, errored, invalid, sent, updated_at, created_at)
+SELECT selected_campaign_id, unsent, errored, invalid, sent, now(), now() FROM stats
 ON CONFLICT (campaign_id) DO UPDATE
 SET
   unsent = excluded.unsent,
   errored = excluded.errored,
   sent = excluded.sent,
+  invalid = excluded.invalid,
   updated_at = excluded.updated_at;
 
 END $$


### PR DESCRIPTION
PG function changes:
log-job:
- log statuses from ops table to message
- also fix coalescing order
update-stats:
- counts are now based on statuses
- new invalid count