### PR TITLE
Display invalid stats

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -37,11 +37,15 @@ export interface CampaignDetails {
   }
 }
 
-export interface CampaignStats {
+export interface CampaignStats extends CampaignStatsCount {
+  status: string
+}
+
+export interface CampaignStatsCount {
   error: number
   unsent: number
   sent: number
-  status: string
+  invalid: number
 }
 /**
  * @swagger

--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -60,6 +60,8 @@ export interface CampaignStatsCount {
  *            type: number
  *          sent:
  *            type: number
+ *          invalid:
+ *            type: number
  *          status:
  *            $ref: '#/components/schemas/JobStatus'
  */

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -84,6 +84,7 @@ const getCurrentStats = async (
       error: opsStats.error,
       unsent: opsStats.unsent,
       sent: opsStats.sent + archivedStats.sent,
+      // this is needed when invalid might appear in ops table, e.g. telegram immediate bounce errors
       invalid: opsStats.invalid + archivedStats.invalid,
       status: job.status,
     }

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -52,12 +52,14 @@ export class CampaignStats {
   error: number
   unsent: number
   sent: number
+  invalid: number
   status: Status
 
   constructor(input: any) {
     this.error = +input['error']
     this.unsent = +input['unsent']
     this.sent = +input['sent']
+    this.invalid = input['invalid']
     this.status = input['status']
   }
 }

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -49,6 +49,10 @@
   &.green {
     color: $turquoise-green;
   }
+
+  &.grey {
+    color: $grey;
+  }
 }
 
 .progressTitle {

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -18,7 +18,7 @@ const ProgressDetails = ({
   handlePause: Function
   handleRetry: Function
 }) => {
-  const { status, error, unsent, sent } = stats
+  const { status, error, unsent, sent, invalid } = stats
   const [isSent, setIsSent] = useState(status === Status.Sent)
   const [isComplete, setIsComplete] = useState(!error && !unsent)
   useEffect(() => {
@@ -121,6 +121,16 @@ const ProgressDetails = ({
               </td>
               <td className={'md'}>Sent to recipient</td>
               <td className={'sm'}>{sent}</td>
+            </tr>
+            <tr>
+              <td className={cx(styles.status, 'md')}>
+                <i
+                  className={cx(styles.icon, styles.grey, 'bx bx-minus-circle')}
+                ></i>
+                Invalid
+              </td>
+              <td className={'md'}>Recipient does not exist</td>
+              <td className={'sm'}>{invalid}</td>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -58,11 +58,9 @@ export async function getCampaignStats(
   campaignId: number
 ): Promise<CampaignStats> {
   return axios.get(`/campaign/${campaignId}/stats`).then((response) => {
-    const { error, unsent, sent, status } = response.data
+    const { status, ...counts } = response.data
     return new CampaignStats({
-      error,
-      unsent,
-      sent,
+      ...counts,
       status: parseStatus(status),
     })
   })


### PR DESCRIPTION
## Features:
- Get unsent, sent, error and invalid count from ops table based on status column
- Display invalid recipient count on frontend

<img width="877" alt="Screenshot 2020-06-13 at 11 39 26 PM" src="https://user-images.githubusercontent.com/10072985/84572900-bf725c80-adcf-11ea-8588-c9f61df7dea6.png">
