### PR TITLE
Add X-Postman-ID for email callback to update the correct record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ jobs:
           publish: true
           zip: "../log-email-sns/code.zip"
           on:
-            branch: $STAGING_BRANCH
+            branch: $PRODUCTION_BRANCH
           environment_variables:
             - DB_URI=$PRODUCTION_EMAIL_DB_URI
     - name: root

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
           edge: true
           function_name: log-twilio-callback-staging
           region: $AWS_DEFAULT_REGION
-          role: $STAGING_TWILIO_CALLBACK_ROLE
+          role: $STAGING_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -93,14 +93,14 @@ jobs:
           zip: "../log-twilio-callback/code.zip"
           environment_variables:
             - TWILIO_CALLBACK_SECRET=$STAGING_TWILIO_CALLBACK_SECRET
-            - DB_URI=$STAGING_DB_URI
+            - DB_URI=$STAGING_TWILIO_DB_URI
           on:
             branch: $STAGING_BRANCH
         - provider: lambda
           edge: true
           function_name: log-twilio-callback-production
           region: $AWS_DEFAULT_REGION
-          role: $PRODUCTION_TWILIO_CALLBACK_ROLE
+          role: $PRODUCTION_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -109,7 +109,7 @@ jobs:
           zip: "../log-twilio-callback/code.zip"
           environment_variables:
             - TWILIO_CALLBACK_SECRET=$PRODUCTION_TWILIO_CALLBACK_SECRET
-            - DB_URI=$PRODUCTION_DB_URI
+            - DB_URI=$PRODUCTION_TWILIO_DB_URI
           on:
             branch: $PRODUCTION_BRANCH
         - provider: lambda
@@ -125,9 +125,9 @@ jobs:
             branch: $PRODUCTION_BRANCH
         - provider: lambda
           edge: true
-          function_name: log-email-sns
+          function_name: log-email-callback-staging
           region: $AWS_DEFAULT_REGION
-          role: $STAGING_TWILIO_CALLBACK_ROLE
+          role: $STAGING_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -137,7 +137,22 @@ jobs:
           on:
             branch: $STAGING_BRANCH
           environment_variables:
-            - DB_URI=$SERVERLESS_EMAIL_DB_STAGING_URL
+            - DB_URI=$STAGING_EMAIL_DB_URI
+        - provider: lambda
+          edge: true
+          function_name: log-email-callback-production
+          region: $AWS_DEFAULT_REGION
+          role: $PRODUCTION_CALLBACK_ROLE
+          runtime: nodejs12.x
+          module_name: build/index
+          handler_name: handler
+          timeout: 30
+          publish: true
+          zip: "../log-email-sns/code.zip"
+          on:
+            branch: $STAGING_BRANCH
+          environment_variables:
+            - DB_URI=$PRODUCTION_EMAIL_DB_URI
     - name: root
       install:
         - npm install --ignore-scripts

--- a/backend/src/core/interfaces/mail.interface.ts
+++ b/backend/src/core/interfaces/mail.interface.ts
@@ -3,6 +3,7 @@ export interface MailToSend {
   subject: string
   body: string
   replyTo?: string
+  referenceId?: string
 }
 
 export interface MailCredentials {

--- a/serverless/log-email-sns/src/index.ts
+++ b/serverless/log-email-sns/src/index.ts
@@ -139,16 +139,16 @@ const handleMessage = async (record: any) => {
   const timestamp = record.Sns.Timestamp
 
   console.log(`Update for notificationType = ${notificationType}`)
-
+  const metadata = { id, timestamp, messageId }
   switch (notificationType) {
     case 'Delivery':
-      await updateSuccessfulDelivery({ id, timestamp, messageId })
+      await updateSuccessfulDelivery(metadata)
       break
     case 'Bounce':
-      await updateBouncedStatus({ id, timestamp, messageId, message })
+      await updateBouncedStatus({...metadata, message})
       break
     case 'Complaint':
-      await updateComplaintStatus({ id, timestamp, messageId, message })
+      await updateComplaintStatus({...metadata, message})
       break
     default:
       console.error(

--- a/serverless/log-email-sns/src/index.ts
+++ b/serverless/log-email-sns/src/index.ts
@@ -168,7 +168,7 @@ exports.handler = async (event: any) => {
     if (sequelize === null) {
       sequelize = await sequelizeLoader()
     }
-    console.log(`Event: ${JSON.stringify(event)}`)
+    
     await Promise.all(event.Records.map(handleMessage))
 
     return {

--- a/serverless/log-email-sns/src/index.ts
+++ b/serverless/log-email-sns/src/index.ts
@@ -1,7 +1,25 @@
 import sequelizeLoader from './sequelize-loader'
 import { QueryTypes } from 'sequelize'
 import { Sequelize } from 'sequelize-typescript'
+import {
+  UpdateMessageWithErrorCode,
+  Metadata,
+  BounceMetadata,
+  ComplaintMetadata,
+} from './interfaces'
+const REFERENCE_ID_HEADER = 'X-Postman-ID' // Case sensitive
 let sequelize: Sequelize | null = null // Define the sequelize connection outside so that a warm lambda can reuse the connection
+
+/**
+ * Parses the message to find the matching email_message id
+ * @param message
+ */
+const getReferenceId = (message: any): string | undefined => {
+  const headers: Array<{ name: string; value: string }> = message?.mail?.headers
+  const referenceId = headers.find(({ name }) => name === REFERENCE_ID_HEADER)
+    ?.value
+  return referenceId
+}
 
 /**
  * Adds email to blacklist table if it does not exist
@@ -23,22 +41,16 @@ const addToBlacklist = (recipientEmail: string) => {
  * Updates email_messages with an error and error code
  *
  */
-const updateMessageWithError = ({
-  errorCode,
-  timestamp,
-  messageId,
-}: {
-  errorCode: string
-  timestamp: string
-  messageId: string
-}) => {
-  console.log('Updating email_messages table.')
+const updateMessageWithError = (opts: UpdateMessageWithErrorCode) => {
+  const { errorCode, timestamp, id } = opts
+
+  console.log(`Updating email_messages table. ${JSON.stringify(opts)}`)
   return sequelize?.query(
     `UPDATE email_messages SET error_code=:errorCode, received_at=:timestamp, status='INVALID_RECIPIENT', updated_at = clock_timestamp()
-    WHERE message_id=:messageId 
+    WHERE id=:id 
     AND (received_at IS NULL OR received_at < :timestamp);`,
     {
-      replacements: { errorCode, timestamp, messageId },
+      replacements: { errorCode, timestamp, id },
       type: QueryTypes.UPDATE,
     }
   )
@@ -50,17 +62,15 @@ const updateMessageWithError = ({
  *  @param message JSON object that contains the notification details
  *  @param timestamp ISO string from notification timestamp
  */
-const updateSuccessfulDelivery = async (message: any, timestamp: string) => {
-  const messageId = message?.mail?.commonHeaders?.messageId
-
-  console.log('Updating email_messages table.')
+const updateSuccessfulDelivery = async (metadata: Metadata) => {
+  console.log(`Updating email_messages table ${JSON.stringify(metadata)}`)
   // Since notifications for the same messageId can be interleaved, we only update that message if this notification is newer than the previous.
   await sequelize?.query(
     `UPDATE email_messages SET received_at=:timestamp, updated_at = clock_timestamp(), status='SUCCESS' 
-    WHERE message_id=:messageId 
+    WHERE id=:id 
     AND (received_at IS NULL OR received_at < :timestamp);`,
     {
-      replacements: { timestamp, messageId },
+      replacements: { timestamp: metadata.timestamp, id: metadata.id },
       type: QueryTypes.UPDATE,
     }
   )
@@ -73,22 +83,26 @@ const updateSuccessfulDelivery = async (message: any, timestamp: string) => {
  *  @param message JSON object that contains the notification details
  *  @param timestamp ISO string from notification timestamp
  */
-const updateBouncedStatus = async (message: any, timestamp: string) => {
-  const bounceType = message?.bounce?.bounceType
-  const messageId = message?.mail?.commonHeaders?.messageId
+const updateBouncedStatus = async (metadata: BounceMetadata) => {
+  const bounceType = metadata.message?.bounce?.bounceType
+  const recipients = metadata?.message?.mail?.commonHeaders?.to
   let errorCode
 
   if (bounceType === 'Permanent') {
     errorCode =
       "Hard bounce, the recipient's mail server permanently rejected the email."
     // Add to black list
-    await Promise.all(message?.mail?.commonHeaders?.to.map(addToBlacklist))
+    if (recipients) await Promise.all(recipients.map(addToBlacklist))
   } else {
     errorCode =
       'Soft bounce, Amazon SES fails to deliver the email after retrying for a period of time.'
   }
 
-  await updateMessageWithError({ errorCode, timestamp, messageId })
+  await updateMessageWithError({
+    errorCode,
+    timestamp: metadata.timestamp,
+    id: metadata.id,
+  })
 }
 
 /**
@@ -96,38 +110,45 @@ const updateBouncedStatus = async (message: any, timestamp: string) => {
  *  @param message JSON object that contains the notification details
  *  @param timestamp ISO string from notification timestamp
  */
-const updateComplaintStatus = async (message: any, timestamp: string) => {
-  const messageId = message?.mail?.commonHeaders?.messageId
-  const errorCode = message?.complaint?.complaintFeedbackType
-  await Promise.all(message?.mail?.commonHeaders?.to.map(addToBlacklist))
-  await updateMessageWithError({ errorCode, timestamp, messageId })
+const updateComplaintStatus = async (metadata: ComplaintMetadata) => {
+  const errorCode = metadata.message?.complaint?.complaintFeedbackType
+  const recipients = metadata?.message?.mail?.commonHeaders?.to
+
+  if (errorCode && recipients) {
+    await Promise.all(recipients.map(addToBlacklist))
+    await updateMessageWithError({
+      errorCode,
+      timestamp: metadata.timestamp,
+      id: metadata.id,
+    })
+  }
 }
 
 const handleMessage = async (record: any) => {
   const message = JSON.parse(record.Sns.Message)
-  const notificationType = message?.notificationType
-
-  const timestamp = record.Sns.Timestamp
+  const id = getReferenceId(message)
   const messageId = message?.mail?.commonHeaders?.messageId
-
-  if (messageId === undefined) {
-    console.error(`No messageId found for: ${JSON.stringify(message)}`)
+  if (id === undefined) {
+    console.log(
+      `No ${REFERENCE_ID_HEADER} header found for messageId ${messageId}.`
+    )
     return
   }
 
-  console.log(
-    `Updating messageId ${messageId} in respective tables, notificationType = ${notificationType}`
-  )
+  const notificationType = message?.notificationType
+  const timestamp = record.Sns.Timestamp
+
+  console.log(`Update for notificationType = ${notificationType}`)
 
   switch (notificationType) {
     case 'Delivery':
-      await updateSuccessfulDelivery(message, timestamp)
+      await updateSuccessfulDelivery({ id, timestamp, messageId })
       break
     case 'Bounce':
-      await updateBouncedStatus(message, timestamp)
+      await updateBouncedStatus({ id, timestamp, messageId, message })
       break
     case 'Complaint':
-      await updateComplaintStatus(message, timestamp)
+      await updateComplaintStatus({ id, timestamp, messageId, message })
       break
     default:
       console.error(
@@ -147,7 +168,7 @@ exports.handler = async (event: any) => {
     if (sequelize === null) {
       sequelize = await sequelizeLoader()
     }
-
+    console.log(`Event: ${JSON.stringify(event)}`)
     await Promise.all(event.Records.map(handleMessage))
 
     return {

--- a/serverless/log-email-sns/src/interfaces.ts
+++ b/serverless/log-email-sns/src/interfaces.ts
@@ -1,0 +1,35 @@
+export interface Metadata {
+  id: string
+  timestamp: string
+  messageId?: string
+}
+
+export interface BounceMetadata extends Metadata {
+  message?: {
+    bounce?: {
+      bounceType?: string
+    }
+    mail?: {
+      commonHeaders?: {
+        to?: string[]
+      }
+    }
+  }
+}
+
+export interface ComplaintMetadata extends Metadata {
+  message?: {
+    complaint?: {
+      complaintFeedbackType?: string
+    }
+    mail?: {
+      commonHeaders?: {
+        to?: string[]
+      }
+    }
+  }
+}
+
+export interface UpdateMessageWithErrorCode extends Metadata {
+  errorCode: string
+}

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -88,6 +88,7 @@ class Email {
             recipients: [recipient],
             subject,
             body: hydratedBody,
+            referenceId: String(id),
             ...(replyTo ? { replyTo } : {}),
           })
         }

--- a/worker/src/email/interfaces/index.ts
+++ b/worker/src/email/interfaces/index.ts
@@ -3,6 +3,7 @@ export interface MailToSend {
   subject: string
   body: string
   replyTo?: string
+  referenceId?: string
 }
 
 export interface MailCredentials {

--- a/worker/src/email/services/mail-client.class.ts
+++ b/worker/src/email/services/mail-client.class.ts
@@ -2,7 +2,7 @@ import nodemailer from 'nodemailer'
 import directTransport from 'nodemailer-direct-transport'
 import logger from '@core/logger'
 import { MailToSend, MailCredentials } from '@email/interfaces'
-
+const REFERENCE_ID_HEADER = 'X-Postman-ID' // Case sensitive
 export default class MailClient {
   private email: string
   private mailer: nodemailer.Transporter
@@ -38,22 +38,24 @@ export default class MailClient {
 
   public sendMail(input: MailToSend): Promise<string | void> {
     return new Promise<string | void>((resolve, reject) => {
-      this.mailer.sendMail(
-        {
-          from: this.email,
-          to: input.recipients,
-          subject: input.subject,
-          replyTo: input.replyTo,
-          html: input.body,
-        },
-        (err, info) => {
-          if (err !== null) {
-            reject(new Error(`${err}`))
-          } else {
-            resolve(info.messageId)
-          }
+      const options = {
+        from: this.email,
+        to: input.recipients,
+        subject: input.subject,
+        replyTo: input.replyTo,
+        html: input.body,
+        headers: {},
+      }
+      if (input.referenceId !== undefined) {
+        options.headers = { [REFERENCE_ID_HEADER]: input.referenceId }
+      }
+      this.mailer.sendMail(options, (err, info) => {
+        if (err !== null) {
+          reject(new Error(`${err}`))
+        } else {
+          resolve(info.messageId)
         }
-      )
+      })
     })
   }
 }


### PR DESCRIPTION
## Problem

The previous implementation updated the email_messages table using the message_id returned by an email callback event. Unfortunately, if the ops table has yet to be logged back to email_messages, no record will be updated since email_messages does not have the message_id set.

## Solution

This PR adds an header containing the id of the record in email_messages, when sending emails. The callback lambda uses this id to update email_messages, instead of message_id. 

The SES event then returns it as a header.
Sample event
```
{
    "Records": [
        {
            "EventSource": "aws:sns",
            "EventVersion": "1.0",
            "EventSubscriptionArn": "arn:aws:sns:us-east-1:306667300165:postmangovsg-staging-ses:bb96353e-13fa-4ddb-91e7-46f0c7bbdb51",
            "Sns": {
                "Type": "Notification",
                "MessageId": "5151f7fb-e0ec-5ff2-ba78-a0a4f47d7933",
                "TopicArn": "arn:aws:sns:us-east-1:306667300165:postmangovsg-staging-ses",
                "Subject": null,
                "Message": "{\"notificationType\":\"Delivery\",\"mail\":{\"timestamp\":\"2020-06-13T17:52:17.423Z\",\"source\":\"donotreply@mail.postman.gov.sg\",\"sourceArn\":\"arn:aws:ses:us-east-1:306667300165:identity/postman.gov.sg\",\"sourceIp\":\"18.180.227.204\",\"sendingAccountId\":\"306667300165\",\"messageId\":\"01000172aecf8e0f-96ff7326-bbf2-4315-8b1b-988213dbdd47-000000\",\"destination\":[\"success@simulator.amazonses.com\"],\"headersTruncated\":false,\"headers\":[{\"name\":\"Received\",\"value\":\"from ip-10-102-2-174.ap-northeast-1.compute.internal (ec2-18-180-227-204.ap-northeast-1.compute.amazonaws.com [18.180.227.204]) by email-smtp.amazonaws.com with SMTP (SimpleEmailService-d-VY74RSUY3) id kUeUqu26Ue9zdPG9vsFj for success@simulator.amazonses.com; Sat, 13 Jun 2020 17:52:17 +0000 (UTC)\"},{\"name\":\"Content-Type\",\"value\":\"text/html\"},{\"name\":\"X-Postman-ID\",\"value\":\"1550110\"},{\"name\":\"From\",\"value\":\"\\\"Postman.gov.sg\\\" <donotreply@mail.postman.gov.sg>\"},{\"name\":\"To\",\"value\":\"success@simulator.amazonses.com\"},{\"name\":\"Subject\",\"value\":\"x\"},{\"name\":\"Message-ID\",\"value\":\"<0e6afa9c-9004-7718-d83a-2060a1cd519e@mail.postman.gov.sg>\"},{\"name\":\"Content-Transfer-Encoding\",\"value\":\"7bit\"},{\"name\":\"Date\",\"value\":\"Sat, 13 Jun 2020 17:52:15 +0000\"},{\"name\":\"MIME-Version\",\"value\":\"1.0\"}],\"commonHeaders\":{\"from\":[\"\\\"Postman.gov.sg\\\" <donotreply@mail.postman.gov.sg>\"],\"date\":\"Sat, 13 Jun 2020 17:52:15 +0000\",\"to\":[\"success@simulator.amazonses.com\"],\"messageId\":\"<0e6afa9c-9004-7718-d83a-2060a1cd519e@mail.postman.gov.sg>\",\"subject\":\"x\"}},\"delivery\":{\"timestamp\":\"2020-06-13T17:52:17.799Z\",\"processingTimeMillis\":376,\"recipients\":[\"success@simulator.amazonses.com\"],\"smtpResponse\":\"250 2.6.0 Message received\",\"remoteMtaIp\":\"3.218.196.166\",\"reportingMTA\":\"a8-98.smtp-out.amazonses.com\"}}",
                "Timestamp": "2020-06-13T17:52:17.866Z",
                "SignatureVersion": "1",
                "Signature": "I33FPz8cJoDzRmzyjv+06T7XQVnZZXRE2d+A9K3ZXmRSo15e+ut9STYpbOnRPVu6ZbFK/19vLladH89YxYAR/LVmPRUEDWXhAhKdN/bUmSl0Byi0xH1QraZ9+m5jD3SFU4wMBqRFtguf7zzcLgKwV7PzqyLKLi46UIOPk6RkX9is4HLeRr7NnGgKn4rkArFRHhMVPQq9/P/R+K+Q7JP/PmAPuvKNdvDJ8gShrRR3L87t80MLetDZeusWjJIjnteZvBHMmzIp9X5jNZbkoUUUnyISOiCha9VDtIdgf9wycAgw1SAt35nPjmJH0uW2/8nyAomCJ32tMYb/nOrJkhUxUA==",
                "SigningCertUrl": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",
                "UnsubscribeUrl": "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:306667300165:postmangovsg-staging-ses:bb96353e-13fa-4ddb-91e7-46f0c7bbdb51",
                "MessageAttributes": {}
            }
        }
    ]
}
```

Logs for that event: 
```
2020-06-13T17:52:18.276Z	2c422c8f-0d00-41da-9301-22b5bd0d6585	INFO	Update for notificationType = Delivery
2020-06-13T17:52:18.276Z	2c422c8f-0d00-41da-9301-22b5bd0d6585	INFO	Updating email_messages table 
{
    "id": "1550110",
    "timestamp": "2020-06-13T17:52:17.866Z",
    "messageId": "<0e6afa9c-9004-7718-d83a-2060a1cd519e@mail.postman.gov.sg>"
}
```

Reference: https://nodemailer.com/message/#header-options

## Tests
Given the following sample csv:
```
recipient,text
success@simulator.amazonses.com,Successful delivery
bounce@simulator.amazonses.com, bounce email
ooto@simulator.amazonses.com, automatic response
complaint@simulator.amazonses.com, email marked as spam
suppressionlist@simulator.amazonses.com, suppressionlist email
```
### When email_blacklist is empty
- The worker should attempt to send all 5 messages. This means all 5 of them should have message_id
- The `status` of `success@simulator.amazonses.com` should change from `SENDING` to `SUCCESS`.
- The rest should change from `SENDING` to `INVALID_RECIPIENT`
- These should be added to `email_blacklist`: `bounce@simulator.amazonses.com`,`complaint@simulator.amazonses.com`,`suppressionlist@simulator.amazonses.com`

### When email_blacklist is not empty
- Try to send a campaign with these 5 recipients again.
- The worker should not attempt to send messages to the recipients in the blacklist. Only `success@simulator.amazonses.com` and `ooto@simulator.amazonses.com` should have message_id.
- The `status` of `success@simulator.amazonses.com` should change from `SENDING` to `SUCCESS`.
The `status` of `ooto@simulator.amazonses.com` should change from `SENDING` to `INVALID_RECIPIENT`.
- The rest should be set to `INVALID_RECIPIENT` immediately. 