### PR TITLE
[Template Module] refactor:  test hydration

### DIFF
--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -83,4 +83,17 @@ export default class S3Client {
       throw err
     }
   }
+
+  /**
+   * Download CSV file from S3 and process it into message.
+   * The messages are formed from the template and parameters specified in the csv.
+   *
+   * @param campaignId
+   * @param s3Key
+   */
+  async getCsvFile(s3Key: string): Promise<Array<CSVParamsInterface>> {
+    const downloadStream = this.download(s3Key)
+    const fileContents = await this.parseCsv(downloadStream)
+    return fileContents
+  }
 }

--- a/backend/src/core/services/template-client.class.ts
+++ b/backend/src/core/services/template-client.class.ts
@@ -1,14 +1,9 @@
-import { difference, keys, mapKeys } from 'lodash'
+import { mapKeys } from 'lodash'
 import * as Sqrl from 'squirrelly'
 import { AstObject, TemplateObject } from 'squirrelly/dist/types/parse'
 
-import S3Client from '@core/services/s3-client.class'
 import logger from '@core/logger'
-import {
-  MissingTemplateKeysError,
-  TemplateError,
-} from '@core/errors/template.errors'
-import { isSuperSet } from '@core/utils'
+import { TemplateError } from '@core/errors/template.errors'
 
 import xss from 'xss'
 
@@ -160,71 +155,5 @@ export default class TemplateClient {
     // Remove extra '\' infront of single quotes and backslashes, added by Squirrelly when it escaped the csv
     const templated = parsed.tokens.join('').replace(/\\([\\'])/g, '$1')
     return xss.filterXSS(templated, this.xssOptions)
-  }
-
-  /**
-   * Ensures that the csv contains all the columns necessary to replace the attributes in the template
-   * @param csvRecord
-   * @param templateParams
-   */
-  private checkTemplateKeysMatch(
-    csvRecord: { [key: string]: string },
-    templateParams: Array<string>
-  ): void {
-    // if body exists, smsTemplate.params should also exist
-    if (!isSuperSet(keys(csvRecord), templateParams)) {
-      const missingKeys = difference(templateParams, keys(csvRecord))
-      throw new MissingTemplateKeysError(missingKeys)
-    }
-  }
-
-  /**
-   * Ensures that the csv contains all the columns necessary to replace the attributes in the template.
-   * Returns a message formed from the template and parameters specified in the csv.
-   * @param param0
-   */
-  async testHydration({
-    campaignId,
-    s3Key,
-    templateSubject,
-    templateBody,
-    templateParams,
-  }: {
-    campaignId: number
-    s3Key: string
-    templateSubject?: string
-    templateBody: string
-    templateParams: Array<string>
-  }): Promise<TestHydrationResult> {
-    const s3Client = new S3Client()
-    const downloadStream = s3Client.download(s3Key)
-    const fileContents = await s3Client.parseCsv(downloadStream)
-
-    const records: Array<MessageBulkInsertInterface> = fileContents.map(
-      (entry) => {
-        return {
-          campaignId,
-          recipient: entry['recipient'],
-          params: entry,
-        }
-      }
-    )
-
-    // attempt to hydrate
-    const firstRecord = fileContents[0]
-    this.checkTemplateKeysMatch(firstRecord, templateParams)
-
-    const hydratedRecord = {
-      body: this.template(templateBody, records[0].params),
-    } as { body: string; subject?: string }
-
-    if (templateSubject) {
-      hydratedRecord.subject = this.template(templateSubject, records[0].params)
-    }
-
-    return {
-      records,
-      hydratedRecord,
-    }
   }
 }

--- a/backend/src/core/services/template.service.ts
+++ b/backend/src/core/services/template.service.ts
@@ -1,15 +1,21 @@
 import { v4 as uuid } from 'uuid'
+import { difference, keys } from 'lodash'
+
 import S3 from 'aws-sdk/clients/s3'
 import { Transaction } from 'sequelize/types'
 
 import config from '@core/config'
 import logger from '@core/logger'
+import { isSuperSet } from '@core/utils'
+import { MissingTemplateKeysError } from '@core/errors/template.errors'
 import { configureEndpoint } from '@core/utils/aws-endpoint'
 import { jwtUtils } from '@core/utils/jwt'
 import { Campaign } from '@core/models'
 import { CsvStatusInterface } from '@core/interfaces'
 
 const MAX_PROCESSING_TIME = config.get('csvProcessingTimeout')
+type CSVParams = { [key: string]: string }
+
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
 const s3 = new S3({
   signatureVersion: 'v4',
@@ -158,6 +164,45 @@ const getCsvStatus = async (
   }
 }
 
+/*
+ * Ensures that the csv contains all the columns necessary to replace the attributes in the template
+ * @param csvContent
+ * @param templateParams
+ */
+const checkTemplateKeysMatch = (
+  csvContent: Array<CSVParams>,
+  templateParams: Array<string>
+): void => {
+  const csvRecord = csvContent[0]
+
+  if (!isSuperSet(keys(csvRecord), templateParams)) {
+    const missingKeys = difference(templateParams, keys(csvRecord))
+    throw new MissingTemplateKeysError(missingKeys)
+  }
+}
+
+/**
+ * Checks the csv for all the necessary columns.
+ * Transform the array of CSV rows into message interface
+ * @param campaignId
+ * @param fileContent
+ */
+const getRecordsFromCsv = (
+  campaignId: number,
+  fileContent: Array<CSVParams>,
+  templateParams: Array<string>
+): Array<MessageBulkInsertInterface> => {
+  checkTemplateKeysMatch(fileContent, templateParams)
+
+  return fileContent.map((entry) => {
+    return {
+      campaignId,
+      recipient: entry['recipient'],
+      params: entry,
+    }
+  })
+}
+
 export const TemplateService = {
   getUploadParameters,
   extractS3Key,
@@ -166,4 +211,5 @@ export const TemplateService = {
   storeS3Error,
   deleteS3TempKeys,
   getCsvStatus,
+  getRecordsFromCsv,
 }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -10,6 +10,7 @@ import {
 } from '@core/errors'
 import { CampaignService, TemplateService, StatsService } from '@core/services'
 import { EmailTemplateService, EmailService } from '@email/services'
+import S3Client from '@core/services/s3-client.class'
 import { StoreTemplateOutput } from '@email/interfaces'
 import { Campaign } from '@core/models'
 
@@ -152,15 +153,21 @@ const uploadCompleteHandler = async (
       throw new Error('Template does not exist, please create a template')
     }
 
-    // carry out templating / hydration
     // - download from s3
-    const { records } = await EmailTemplateService.client.testHydration({
-      campaignId: +campaignId,
-      s3Key,
-      templateSubject: emailTemplate.subject,
-      templateBody: emailTemplate.body as string,
-      templateParams: emailTemplate.params as string[],
-    })
+    const s3Client = new S3Client()
+    const fileContent = await s3Client.getCsvFile(s3Key)
+
+    const records = TemplateService.getRecordsFromCsv(
+      +campaignId,
+      fileContent,
+      emailTemplate.params as string[]
+    )
+
+    EmailTemplateService.testHydration(
+      records,
+      emailTemplate.body as string,
+      emailTemplate.subject
+    )
 
     if (EmailTemplateService.hasInvalidEmailRecipient(records)) {
       throw new InvalidRecipientError()

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -250,10 +250,30 @@ const hasInvalidEmailRecipient = (
   return records.some((record) => !validator.isEmail(record.recipient))
 }
 
+/**
+ * Attempts to hydrate the first record.
+ * @param records
+ * @param templateBody
+ * @param templateSubject - optional
+ */
+const testHydration = (
+  records: Array<MessageBulkInsertInterface>,
+  templateBody: string,
+  templateSubject?: string
+): void => {
+  const [firstRecord] = records
+  client.template(templateBody, firstRecord.params)
+
+  if (templateSubject) {
+    client.template(templateSubject, firstRecord.params)
+  }
+}
+
 export const EmailTemplateService = {
   storeTemplate,
   getFilledTemplate,
   addToMessageLogs,
   hasInvalidEmailRecipient,
+  testHydration,
   client,
 }

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -152,10 +152,7 @@ const uploadCompleteHandler = async (
       smsTemplate.params as string[]
     )
 
-    await SmsTemplateService.testHydration(
-      records,
-      smsTemplate.body as string
-    )
+    await SmsTemplateService.testHydration(records, smsTemplate.body as string)
 
     if (SmsTemplateService.hasInvalidSmsRecipient(records)) {
       throw new InvalidRecipientError()

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import logger from '@core/logger'
+import S3Client from '@core/services/s3-client.class'
 import {
   MissingTemplateKeysError,
   HydrationError,
@@ -142,14 +143,19 @@ const uploadCompleteHandler = async (
       throw new Error('Template does not exist, please create a template')
     }
 
-    // carry out templating / hydration
-    // - download from s3
-    const { records } = await SmsTemplateService.client.testHydration({
-      campaignId: +campaignId,
-      s3Key,
-      templateBody: smsTemplate.body as string,
-      templateParams: smsTemplate.params as string[],
-    })
+    const s3Client = new S3Client()
+    const fileContent = await s3Client.getCsvFile(s3Key)
+
+    const records = TemplateService.getRecordsFromCsv(
+      +campaignId,
+      fileContent,
+      smsTemplate.params as string[]
+    )
+
+    await SmsTemplateService.testHydration(
+      records,
+      smsTemplate.body as string
+    )
 
     if (SmsTemplateService.hasInvalidSmsRecipient(records)) {
       throw new InvalidRecipientError()

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -228,10 +228,24 @@ const hasInvalidSmsRecipient = (
   return records.some((record) => !re.test(record.recipient))
 }
 
+/**
+ * Attempts to hydrate the first record.
+ * @param records
+ * @param templateBody
+ */
+const testHydration = (
+  records: Array<MessageBulkInsertInterface>,
+  templateBody: string
+): void => {
+  const [firstRecord] = records
+  client.template(templateBody, firstRecord.params)
+}
+
 export const SmsTemplateService = {
   storeTemplate,
   getFilledTemplate,
   addToMessageLogs,
   hasInvalidSmsRecipient,
+  testHydration,
   client,
 }


### PR DESCRIPTION
## Problem

`testHydration` was doing too many things. Functions should ideally have a single responsibility.

## Solution

`testHydration` used to do a couple of things: 
- Download the csv file from S3
- Parse the csv file
- Checks that the csv headers have all the template keys
- Transform the file content into records
- Hydrates the first record using `template` function

All these functionalities are now achieved by three functions: 
- `s3Client.getCsvFile`: Downloads and parses the CSV file 
- `getRecordsFromCsv`: Checks csv headers  & transform file content into records
- `testHydration`: Hydrates the first record