### PR TITLE
chore: Improve Telegram schema

### DIFF
--- a/backend/src/telegram/models/telegram-message.ts
+++ b/backend/src/telegram/models/telegram-message.ts
@@ -19,13 +19,19 @@ export class TelegramMessage extends Model<TelegramMessage> {
   id!: number
 
   @ForeignKey(() => Campaign)
-  @Column(DataType.INTEGER)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
   campaignId!: number
 
   @BelongsTo(() => Campaign)
   campaign!: Campaign
 
-  @Column(DataType.STRING)
+  @Column({
+    type: DataType.STRING,
+    allowNull: false,
+  })
   recipient!: string
 
   @Column(DataType.JSON)

--- a/backend/src/telegram/models/telegram-message.ts
+++ b/backend/src/telegram/models/telegram-message.ts
@@ -8,6 +8,7 @@ import {
 } from 'sequelize-typescript'
 
 import { Campaign } from '@core/models'
+import { MessageStatus } from '@core/constants'
 
 @Table({ tableName: 'telegram_messages', underscored: true, timestamps: true })
 export class TelegramMessage extends Model<TelegramMessage> {
@@ -42,6 +43,12 @@ export class TelegramMessage extends Model<TelegramMessage> {
 
   @Column(DataType.STRING)
   errorCode?: string
+
+  @Column({
+    type: DataType.ENUM(...Object.values(MessageStatus)),
+    allowNull: true,
+  })
+  status?: MessageStatus
 
   @Column(DataType.DATE)
   dequeuedAt?: Date

--- a/backend/src/telegram/models/telegram-op.ts
+++ b/backend/src/telegram/models/telegram-op.ts
@@ -7,6 +7,7 @@ import {
   BelongsTo,
 } from 'sequelize-typescript'
 import { Campaign } from '@core/models/campaign'
+import { MessageStatus } from '@core/constants'
 
 @Table({ tableName: 'telegram_ops', underscored: true, timestamps: true })
 export class TelegramOp extends Model<TelegramOp> {
@@ -41,6 +42,12 @@ export class TelegramOp extends Model<TelegramOp> {
 
   @Column(DataType.STRING)
   errorCode?: string
+
+  @Column({
+    type: DataType.ENUM(...Object.values(MessageStatus)),
+    allowNull: true,
+  })
+  status?: MessageStatus
 
   @Column(DataType.DATE)
   dequeuedAt?: Date

--- a/backend/src/telegram/models/telegram-op.ts
+++ b/backend/src/telegram/models/telegram-op.ts
@@ -18,14 +18,20 @@ export class TelegramOp extends Model<TelegramOp> {
   id!: number
 
   @ForeignKey(() => Campaign)
-  @Column(DataType.INTEGER)
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+  })
   campaignId!: number
 
   @BelongsTo(() => Campaign)
   campaign!: Campaign
 
-  @Column(DataType.STRING)
-  recipient!: string
+  @Column({
+    type: DataType.BIGINT,
+    allowNull: false,
+  })
+  recipient!: number
 
   @Column(DataType.JSON)
   params!: object

--- a/backend/src/telegram/models/telegram-subscriber.ts
+++ b/backend/src/telegram/models/telegram-subscriber.ts
@@ -8,9 +8,15 @@ import { Column, Model, Table, DataType } from 'sequelize-typescript'
 export class TelegramSubscriber extends Model<TelegramSubscriber> {
   @Column({
     type: DataType.STRING,
+    primaryKey: true,
+    unique: true,
   })
   phoneNumber!: string
 
-  @Column({ type: DataType.BIGINT })
+  @Column({
+    type: DataType.BIGINT,
+    primaryKey: true,
+    unique: true,
+  })
   telegramId!: number
 }

--- a/backend/src/telegram/models/telegram-subscriber.ts
+++ b/backend/src/telegram/models/telegram-subscriber.ts
@@ -1,4 +1,5 @@
-import { Column, Model, Table, DataType } from 'sequelize-typescript'
+import { Column, Model, Table, DataType, HasMany } from 'sequelize-typescript'
+import { BotSubscriber } from '.'
 
 @Table({
   tableName: 'telegram_subscribers',
@@ -6,6 +7,7 @@ import { Column, Model, Table, DataType } from 'sequelize-typescript'
   timestamps: true,
 })
 export class TelegramSubscriber extends Model<TelegramSubscriber> {
+  @HasMany(() => BotSubscriber, { as: 'bot_subscriber' })
   @Column({
     type: DataType.STRING,
     primaryKey: true,

--- a/backend/src/telegram/models/telegram-subscriber.ts
+++ b/backend/src/telegram/models/telegram-subscriber.ts
@@ -11,13 +11,12 @@ export class TelegramSubscriber extends Model<TelegramSubscriber> {
   @Column({
     type: DataType.STRING,
     primaryKey: true,
-    unique: true,
   })
   phoneNumber!: string
 
   @Column({
     type: DataType.BIGINT,
-    primaryKey: true,
+    allowNull: false,
     unique: true,
   })
   telegramId!: number

--- a/backend/src/telegram/models/telegram-subscriber.ts
+++ b/backend/src/telegram/models/telegram-subscriber.ts
@@ -7,7 +7,10 @@ import { BotSubscriber } from '.'
   timestamps: true,
 })
 export class TelegramSubscriber extends Model<TelegramSubscriber> {
-  @HasMany(() => BotSubscriber, { as: 'bot_subscriber' })
+  @HasMany(() => BotSubscriber, {
+    as: 'bot_subscriber',
+    sourceKey: 'telegramId',
+  })
   @Column({
     type: DataType.STRING,
     primaryKey: true,


### PR DESCRIPTION
## Problem

The current Telegram schema has a couple of missing constraints and inconsistent types. 

## Solution

- `telegram_messages` and `telegram_ops`
  - Make `campaign_id` and `recipient` not null
  - Add `status` column
- `telegram_ops`
  - Change `recipient` datatype to `number / BIGINT` – this matches the datatype of `telegram_id` in `bot_subscribers` and `telegram_subscribers`
- `telegram_subscribers`
  - Set `phone_number` to primary key
  - Set unique constraint on `telegram_id` – there should never be more than one mapping for any phone number or Telegram ID