### PR TITLE
chore: add licensing

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "type": "git",
     "url": "git+https://github.com/datagovsg/postmangovsg.git"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Open Government Products, GovTech Singapore (https://open.gov.sg)",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/datagovsg/postmangovsg/issues"
   },


### PR DESCRIPTION
## Problem

The root package.json does not list its licensing, even though we (GovTech) intend for the codebase to be available under MIT.

## Solution

Add the license entry in `package.json` 
