### PR TITLE
[Template Module] chore: Deployment changes to backend & worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,14 +71,15 @@ jobs:
         - npm install
       script:
         - npm run lint-no-fix
+        - cd ../
       deploy:
         - provider: script
-          script: ./deploy.sh postmangovsg-workers staging-sending staging-logger
+          script: ./worker/deploy.sh postmangovsg-workers staging-sending staging-logger
           on:
             branch: $STAGING_BRANCH
             condition: "$DEPLOY_WORKER = true"
         - provider: script
-          script: ./deploy.sh postmangovsg-workers prod-sending prod-logger
+          script: ./worker/deploy.sh postmangovsg-workers prod-sending prod-logger
           on:
             branch: $PRODUCTION_BRANCH
             condition: "$DEPLOY_WORKER = true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,25 @@ jobs:
       script:
         - npm run lint-no-fix
         - npm run test
+      before_deploy:
+        - cd ../
+        - export TAG=travis-$TRAVIS_COMMIT-$TRAVIS_BUILD_NUMBER
+        - export ECR_REPO=$REPO-backend
+        - export PATH=$PATH:$HOME/.local/bin
+          # Install tools for deployment
+        - pip install --user awscli #For docker
+
+          # Login to AWS ECR, credentials defined in $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY
+        - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+        - docker build -f ./backend/Dockerfile -t $ECR_REPO:$TAG .
+        - docker tag $ECR_REPO:$TAG $ECR_REPO:$TRAVIS_BRANCH
+        - docker push $ECR_REPO
+          # Edit Dockerrun from Travis environment variables
+        - sed -i -e "s|@REPO|$ECR_REPO|g" ./backend/Dockerrun.aws.json
+        - sed -i -e "s|@TAG|$TAG|g" ./backend/Dockerrun.aws.json
+          #Zip file
+        - cd backend && zip "$TAG.zip" Dockerrun.aws.json
+        - export ELASTIC_BEANSTALK_LABEL="$TAG-$(env TZ=Asia/Singapore date "+%Y%m%d%H%M%S")"
       deploy:
         - provider: elasticbeanstalk
           skip_cleanup: true
@@ -32,6 +51,7 @@ jobs:
           app: "postmangovsg-backend"
           env: "postmangovsg-backend-staging"
           bucket_name: "postmangovsg-backend-elasticbeanstalk"
+          zip_file: "$TAG.zip"
           on:
             branch: $STAGING_BRANCH
         - provider: elasticbeanstalk

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,12 +4,18 @@ FROM node:12-alpine
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
   g++ make python tini
 
-WORKDIR /usr/home/postmangovsg/
-COPY ./package* ./
-RUN npm ci
+WORKDIR /usr/home/postmangovsg/backend
 
-COPY src ./src
-COPY tsconfig.json ./
+# COPY modules /usr/home/postmangovsg/modules
+
+# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm install && npm run build
+
+COPY backend/package* ./
+RUN npm install
+
+COPY backend/src ./src
+COPY backend/tsconfig.json ./
+
 RUN npm run build
 RUN npm prune --production
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,10 +8,10 @@ WORKDIR /usr/home/postmangovsg/backend
 
 # COPY modules /usr/home/postmangovsg/modules
 
-# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm install && npm run build
+# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm ci
 
 COPY backend/package* ./
-RUN npm install
+RUN npm ci
 
 COPY backend/src ./src
 COPY backend/tsconfig.json ./

--- a/backend/Dockerrun.aws.json
+++ b/backend/Dockerrun.aws.json
@@ -1,0 +1,12 @@
+{
+  "AWSEBDockerrunVersion": "1",
+  "Image": {
+    "Name": "@REPO:@TAG",
+    "Update": "true"
+  },
+  "Ports": [
+    {
+      "ContainerPort": "4000"
+    }
+  ]
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -4,12 +4,18 @@ FROM node:12-alpine
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
   g++ make python tini
 
-WORKDIR /usr/home/postmangovsg/
-COPY ./package* ./
-RUN npm ci
+WORKDIR /usr/home/postmangovsg/worker
 
-COPY src ./src
-COPY tsconfig.json ./
+# COPY modules /usr/home/postmangovsg/modules
+
+# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm install && npm run build
+
+COPY worker/package* ./
+
+RUN npm install
+
+COPY worker/src ./src
+COPY worker/tsconfig.json ./
 RUN npm run build
 RUN npm prune --production
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,11 +8,11 @@ WORKDIR /usr/home/postmangovsg/worker
 
 # COPY modules /usr/home/postmangovsg/modules
 
-# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm install && npm run build
+# RUN cd /usr/home/postmangovsg/modules/postman-templating && npm ci
 
 COPY worker/package* ./
 
-RUN npm install
+RUN npm ci
 
 COPY worker/src ./src
 COPY worker/tsconfig.json ./

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -13,7 +13,7 @@ sudo chmod +x ecs-deploy
 
 # Login to docker and push image to ECR
 eval $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-docker build -t $TAG .
+docker build -f ./worker/Dockerfile -t $TAG .
 docker push $TAG
 
 # Update ECS


### PR DESCRIPTION
## Problem

Deployment to backend/worker/frontend will have to change to accommodate the local `postman-templating` module.

## Solution

### backend:
- Build docker image on travis
- Push build to ECR (Elastic Container Registry)
- Deploy zip file with `Dockerrun.aws.json` in it to EB (Elastic Beanstalk)
- EB will pull image from ECR

### worker:
- Changes to the deploy script and builds on the root folder instead of the worker folder.