### PR TITLE
fix: Prevent duplicate campaign creation

### DIFF
--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -15,8 +15,13 @@ const CreateModal = () => {
   const history = useHistory()
   const [selectedChannel, setSelectedChannel] = useState(ChannelType.SMS)
   const [name, setName] = useState('')
+  const [isCreating, setIsCreating] = useState(false)
+
   async function handleCreateCampaign() {
     try {
+      if (isCreating) return
+      setIsCreating(true)
+
       const campaign: Campaign = await createCampaign(name, selectedChannel)
       // close modal and go to create view
       modalContext.setModalContent(null)
@@ -85,7 +90,7 @@ const CreateModal = () => {
         <PrimaryButton
           className={styles.bottomButton}
           onClick={handleCreateCampaign}
-          disabled={!name}
+          disabled={!name || isCreating}
         >
           Create campaign
           <i className={cx('bx', styles.icon, 'bx-right-arrow-alt')}></i>


### PR DESCRIPTION
## Problem

Clicking the submit button twice (i.e. double clicking) during campaign creates duplicate campaigns.

Part of #407, not sure if we wanna tackle all in this PR?

## Solution

Disable button and event handler when a campaign creation is already in progress. 