### PR TITLE
chore: use environments in sentry backend

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -137,7 +137,7 @@ const config = convict({
   },
   frontendUrl: {
     doc: 'CORS: accept requests from this origin. Can be a string, or regex',
-    default: 'https//postman.gov.sg', // prod only
+    default: 'https://postman.gov.sg', // prod only
     env: 'FRONTEND_URL',
   },
   session: {

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -46,7 +46,10 @@ const sentrySessionMiddleware = (
   next()
 }
 
-Sentry.init({ dsn: config.get('sentryDsn') })
+Sentry.init({
+  dsn: config.get('sentryDsn'),
+  environment: config.get('env'),
+})
 
 const expressApp = ({ app }: { app: express.Application }): void => {
   app.use(Sentry.Handlers.requestHandler())

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -78,8 +78,8 @@ const expressApp = ({ app }: { app: express.Application }): void => {
   app.use(sentrySessionMiddleware)
 
   app.use('/v1', v1Router)
-  app.use(Sentry.Handlers.errorHandler())
   app.use(celebrateErrorMiddleware())
+  app.use(Sentry.Handlers.errorHandler())
 
   app.use(
     (


### PR DESCRIPTION
## Problem

We had separate DSNs for each environment. 

## Solution

Create 1 sentry project with multiple environments

## Deploy notes

Remember to change `SENTRY_DSN` to `https://fedcd4e7d5d8480b852423c04ee2aab6@o399364.ingest.sentry.io/5272357` on prod! It's set for staging. 