### PR TITLE
feat(localstack): handle S3 calls on localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export AWS_ENDPOINT=http://localhost:4566
 export FILE_STORAGE_BUCKET_NAME=localstack-upload
 export AWS_LOG_GROUP_NAME=postmangovsg-beanstalk-localstack
 
-cd localstack && ./init-localstack.sh cd ..
+cd localstack && ./init-localstack.sh && cd ..
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ brew services start redis
 
 # Check that redis is running
 redis-cli ping
+
+# Have localstack running
+docker pull localstack/localstack
+
+# Run localstack
+docker run -d -p 4566:4566 -p 8080:8080 --name localstack localstack/localstack
+
+# Seed localstack with S3 bucket and Cloudwatch Log group
+# Assumes installed aws-cli
+export AWS_ENDPOINT=http://localhost:4566
+export FILE_STORAGE_BUCKET_NAME=localstack-upload
+export AWS_LOG_GROUP_NAME=postmangovsg-beanstalk-localstack
+
+cd localstack && ./init-localstack.sh cd ..
+
 ```
 
 ### Set environment variables

--- a/backend/.env-example
+++ b/backend/.env-example
@@ -21,8 +21,13 @@ API_KEY_SALT_V1=$2b$10$5CuueB/CRZq8/JgmkzAK1e
 # TWILIO_API_KEY=SKXXX
 # TWILIO_ACCOUNT_SID=ACXXX
 
+# Use either AWS credentials or localstack endpoint
 # AWS_ACCESS_KEY_ID=YOURAWSACCESSKEYID
 # AWS_SECRET_ACCESS_KEY=YOURAWSSECRETACCESSKEY
+
+# AWS_ENDPOINT=http://localhost:4566
+# FILE_STORAGE_BUCKET_NAME=localstack-upload
+# AWS_LOG_GROUP_NAME=postmangovsg-beanstalk-localstack
 
 # SENTRY_DSN=https://123.ingest.sentry.io/456
 

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -53,6 +53,7 @@ const config = convict({
     awsEndpoint: {
       doc:
         'The endpoint to send AWS requests to. If not specified, a default one is made with AWS_REGION',
+      format: '*',
       default: null,
       env: 'AWS_ENDPOINT',
     },

--- a/backend/src/core/utils/aws-endpoint.ts
+++ b/backend/src/core/utils/aws-endpoint.ts
@@ -7,17 +7,22 @@ interface AWSEndpointConfig {
 /**
  * Provide an Object containing either the endpoint to send AWS requests to,
  * or if that is absent, the region from which to generate the endpoint.
- * This Object is to be injected into AWS JavaScript clients.
+ * This Object is to be injected into AWS JavaScript clients, and is meant
+ * to allow switching between AWS and localstack. The latter only supports
+ * path-style S3 requests, and will need clients to generate S3 path-style URLs
  *
  * @param config - a convict object whose schema includes AWSEndpointConfig
- * @return an object containing either the endpoint or region field
+ * @return an object containing either:
+ *   - region and endpoint and s3ForcePathStyle true if aws.awsEndpoint
+ *     present in convict, or;
+ *   - the region field alone otherwise
  */
 const configureEndpoint = <T extends AWSEndpointConfig>(
   config: convict.Config<T>
 ): any => {
   const endpoint = config.get('aws.awsEndpoint')
   const region = config.get('aws.awsRegion')
-  return endpoint ? { endpoint } : { region }
+  return endpoint ? { region, endpoint, s3ForcePathStyle: true } : { region }
 }
 
 export { configureEndpoint }

--- a/localstack/bucket-cors.json
+++ b/localstack/bucket-cors.json
@@ -1,0 +1,10 @@
+{
+  "CORSRules": [
+    {
+      "AllowedHeaders": ["*"],
+      "AllowedMethods": ["GET", "PUT", "POST"],
+      "AllowedOrigins": ["*"],
+      "ExposeHeaders": ["ETag"]
+    }
+  ] 
+}

--- a/localstack/init-localstack.sh
+++ b/localstack/init-localstack.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+# pip install awscli-local
+aws --endpoint-url $AWS_ENDPOINT s3 mb s3://$FILE_STORAGE_BUCKET_NAME
+aws --endpoint-url $AWS_ENDPOINT logs create-log-group --log-group-name $AWS_LOG_GROUP_NAME
+aws --endpoint-url $AWS_ENDPOINT s3api put-bucket-cors --bucket $FILE_STORAGE_BUCKET_NAME --cors-configuration file://./bucket-cors.json


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10572368/84912188-bcd37800-b0eb-11ea-856e-34e5f5a9a97d.png)

## Problem
Fixes #284 - currently, anybody who wishes to work on the postman
codebase needs to have an AWS account with an S3 bucket to exercise
the uploading of recipient lists. This can be tedious to set up, and 
places avoidable burden on the developer, especially if only contributing
casually.

## Solution

To facilitate local development, make code changes, add support
scripts and provide documentation to allow the running of postman
against the S3 module in localstack. This would allow developers
to exercise the uploading of recipient lists over S3, without the
need for an AWS account.

[backend]
- `core/config` - change `aws.awsEndpoint` to have any format, to
  allow a null default or user-specified string
- `core/utils/aws-endpoint` - if `aws.awsEndpoint` specified, provide:
  - a boolean flag that forces generation of S3 path-style URLs, to
    facilitate talking to localstack, and;
  - the region, to properly initialise SecretsManager and CloudWatch
    clients from aws-sdk

[scripts]
- add `localstack/init-localstack.sh`, based partly on the equivalent
  at GoGovSG, to bootstrap localstack
  - this also configures the CORS policy for the S3 bucket, specified
    in `localstack/bucket-cors.json`

[docs]
- `backend/.env-example` - add env vars that would initialise postman
  to use localstack
- `README` - provide documentation for the preparation and running of
  localstack for postman

**Features**
When env vars `AWS_ENDPOINT` and `FILE_STORAGE_BUCKET_NAME` are updated to
point to localstack and its S3 bucket respectively, postman will be able to make
use of localstack, allowing developers to run the application on their local machines
without the need for an AWS account
