### PR TITLE
feat: Automatic input and button disabling when executing async functions

### DIFF
--- a/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
@@ -23,18 +23,15 @@ const ConfirmModal = ({
   onConfirm: () => Promise<any>
 }) => {
   const modalContext = useContext(ModalContext)
-  const [disabled, setDisabled] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
 
   async function onConfirmedClicked(): Promise<void> {
     try {
-      setDisabled(true)
       await onConfirm()
       // Closes the modal
       modalContext.setModalContent(null)
     } catch (err) {
       setErrorMessage(err.message)
-      setDisabled(false)
     }
   }
   return (
@@ -47,7 +44,6 @@ const ConfirmModal = ({
       <PrimaryButton
         className={destructive ? styles.redButton : styles.greenButton}
         onClick={onConfirmedClicked}
-        disabled={disabled}
       >
         {buttonText}
         {buttonIcon && <i className={cx('bx', styles.icon, buttonIcon)}></i>}

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -1,10 +1,42 @@
-import React from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import cx from 'classnames'
 
 import styles from './PrimaryButton.module.scss'
 
-const PrimaryButton = (props: any) => {
-  const { className, children, alignRight, ...otherProps } = props
+interface PrimaryButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  alignRight?: boolean
+  onClick?: (...args: any[]) => void | Promise<void>
+}
+
+const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
+  alignRight,
+  className,
+  disabled,
+  onClick,
+  children,
+  ...otherProps
+}) => {
+  const [asyncDisabled, setAsyncDisabled] = useState(false)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const asyncOnClick = onClick
+    ? async () => {
+        setAsyncDisabled(true)
+        await Promise.resolve(onClick())
+        // Only enable if button is still mounted
+        if (isMounted.current) {
+          setAsyncDisabled(false)
+        }
+      }
+    : undefined
+
   return (
     <button
       className={cx(
@@ -12,6 +44,8 @@ const PrimaryButton = (props: any) => {
         { [styles.alignRight]: alignRight },
         className
       )}
+      disabled={disabled || asyncDisabled}
+      onClick={asyncOnClick}
       {...otherProps}
     >
       {children}

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -31,7 +31,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
       onClick
         ? async () => {
             setAsyncLoading(true)
-            await Promise.resolve(onClick())
+            await onClick()
             // Only enable if button is still mounted
             if (isMounted.current) {
               setAsyncLoading(false)

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useMemo } from 'react'
 import cx from 'classnames'
 
 import styles from './PrimaryButton.module.scss'
@@ -26,16 +26,20 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
     }
   }, [])
 
-  const asyncOnClick = onClick
-    ? async () => {
-        setAsyncLoading(true)
-        await Promise.resolve(onClick())
-        // Only enable if button is still mounted
-        if (isMounted.current) {
-          setAsyncLoading(false)
-        }
-      }
-    : undefined
+  const asyncOnClick = useMemo(
+    () =>
+      onClick
+        ? async () => {
+            setAsyncLoading(true)
+            await Promise.resolve(onClick())
+            // Only enable if button is still mounted
+            if (isMounted.current) {
+              setAsyncLoading(false)
+            }
+          }
+        : undefined,
+    [onClick]
+  )
 
   return (
     <button

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -17,7 +17,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
   children,
   ...otherProps
 }) => {
-  const [asyncDisabled, setAsyncDisabled] = useState(false)
+  const [asyncLoading, setAsyncLoading] = useState(false)
   const isMounted = useRef(true)
 
   useEffect(() => {
@@ -28,11 +28,11 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
 
   const asyncOnClick = onClick
     ? async () => {
-        setAsyncDisabled(true)
+        setAsyncLoading(true)
         await Promise.resolve(onClick())
         // Only enable if button is still mounted
         if (isMounted.current) {
-          setAsyncDisabled(false)
+          setAsyncLoading(false)
         }
       }
     : undefined
@@ -44,7 +44,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
         { [styles.alignRight]: alignRight },
         className
       )}
-      disabled={disabled || asyncDisabled}
+      disabled={disabled || asyncLoading}
       onClick={asyncOnClick}
       {...otherProps}
     >

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -31,10 +31,13 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
       onClick
         ? async () => {
             setAsyncLoading(true)
-            await onClick()
-            // Only enable if button is still mounted
-            if (isMounted.current) {
-              setAsyncLoading(false)
+            try {
+              await onClick()
+            } finally {
+              // Only enable if button is still mounted
+              if (isMounted.current) {
+                setAsyncLoading(false)
+              }
             }
           }
         : undefined,

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -15,8 +15,8 @@ const ProgressDetails = ({
   sentAt: Date
   numRecipients: number
   stats: CampaignStats
-  handlePause: Function
-  handleRetry: Function
+  handlePause: () => Promise<void>
+  handleRetry: () => Promise<void>
 }) => {
   const { status, error, unsent, sent, invalid } = stats
   const [isSent, setIsSent] = useState(status === Status.Sent)

--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
@@ -1,56 +1,69 @@
-import React from 'react'
+import React, { useState, useRef, useEffect, MutableRefObject } from 'react'
 import cx from 'classnames'
 import styles from './TextInputWithButton.module.scss'
 import { PrimaryButton, TextInput } from '../'
 
-const TextInputWithButton = (props: {
-  value: string
-  onChange: Function
-  onClick: Function
-  children: React.ReactNode
-  type?: string
+interface TextInputWithButtonProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  onChange: (value: string) => void
+  onClick: () => void | Promise<void>
   buttonDisabled?: boolean
   inputDisabled?: boolean
-  placeholder?: string
-  className?: string
-  textRef?: any
-}) => {
-  const {
-    value,
-    onChange,
-    onClick,
-    children,
-    type,
-    buttonDisabled,
-    inputDisabled,
-    placeholder,
-    className,
-    textRef,
-  } = props
+  textRef?: MutableRefObject<HTMLInputElement | undefined>
+  buttonLabel?: React.ReactNode
+  loadingButtonLabel?: React.ReactNode
+}
 
-  function onFormSubmit(e: React.FormEvent) {
-    onClick()
-    // prevents page reload
+const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = ({
+  value,
+  onChange,
+  onClick,
+  type,
+  buttonDisabled,
+  inputDisabled,
+  placeholder,
+  className,
+  textRef,
+  buttonLabel,
+  loadingButtonLabel,
+}) => {
+  const [asyncLoading, setAsyncLoading] = useState(false)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const asyncSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+
+    setAsyncLoading(true)
+    await Promise.resolve(onClick())
+    // Only enable if still mounted
+    if (isMounted.current) {
+      setAsyncLoading(false)
+    }
   }
 
   return (
-    <form className={styles.inputWithButton} onSubmit={onFormSubmit}>
+    <form className={styles.inputWithButton} onSubmit={asyncSubmit}>
       <TextInput
         className={styles.textInput}
         value={value}
         onChange={onChange}
         type={type}
-        disabled={inputDisabled}
+        disabled={inputDisabled || asyncLoading}
         placeholder={placeholder}
         ref={textRef}
       />
       <PrimaryButton
         className={cx(styles.inputButton, className)}
-        disabled={buttonDisabled}
+        disabled={buttonDisabled || asyncLoading}
         type="submit"
       >
-        {children}
+        {asyncLoading ? loadingButtonLabel : buttonLabel}
       </PrimaryButton>
     </form>
   )

--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
@@ -40,10 +40,13 @@ const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = (
     e.preventDefault()
 
     setAsyncLoading(true)
-    await onClick()
-    // Only enable if still mounted
-    if (isMounted.current) {
-      setAsyncLoading(false)
+    try {
+      await onClick()
+    } finally {
+      // Only enable if still mounted
+      if (isMounted.current) {
+        setAsyncLoading(false)
+      }
     }
   }
 

--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
@@ -40,7 +40,7 @@ const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = (
     e.preventDefault()
 
     setAsyncLoading(true)
-    await Promise.resolve(onClick())
+    await onClick()
     // Only enable if still mounted
     if (isMounted.current) {
       setAsyncLoading(false)

--- a/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
@@ -5,22 +5,17 @@ import { TextInputWithButton } from 'components/common'
 
 const EmailValidationInput = ({
   onClick,
-  buttonDisabled,
 }: {
   onClick: (recipient: string) => any
-  buttonDisabled?: boolean
 }) => {
   const [recipient, setRecipient] = useState('')
-  const [isValidating, setIsValidating] = useState(false)
 
   function isInvalidRecipient() {
     return !isEmail(recipient)
   }
 
   async function onClickHandler() {
-    setIsValidating(true)
     await onClick(recipient)
-    setIsValidating(false)
     setRecipient('')
   }
 
@@ -30,18 +25,15 @@ const EmailValidationInput = ({
       value={recipient}
       onChange={setRecipient}
       onClick={onClickHandler}
-      inputDisabled={isValidating}
-      buttonDisabled={isInvalidRecipient() || isValidating || buttonDisabled}
-    >
-      {isValidating ? (
-        'Sending...'
-      ) : (
+      buttonDisabled={isInvalidRecipient()}
+      buttonLabel={
         <>
           Send test email
           <i className="bx bx-envelope-open"></i>
         </>
-      )}
-    </TextInputWithButton>
+      }
+      loadingButtonLabel="Sending..."
+    />
   )
 }
 

--- a/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
@@ -10,16 +10,13 @@ const EmailValidationInput = ({
   buttonDisabled?: boolean
 }) => {
   const [recipient, setRecipient] = useState('')
-  const [isValidating, setIsValidating] = useState(false)
 
   function isInvalidRecipient() {
     return !/^\+?\d+$/g.test(recipient)
   }
 
   async function onClickHandler() {
-    setIsValidating(true)
     await onClick(recipient)
-    setIsValidating(false)
     setRecipient('')
   }
 
@@ -29,19 +26,16 @@ const EmailValidationInput = ({
       value={recipient}
       onChange={setRecipient}
       onClick={onClickHandler}
-      inputDisabled={isValidating}
-      buttonDisabled={isInvalidRecipient() || isValidating || buttonDisabled}
+      buttonDisabled={isInvalidRecipient() || buttonDisabled}
       placeholder="Enter test mobile number"
-    >
-      {isValidating ? (
-        'Sending...'
-      ) : (
+      buttonLabel={
         <>
           Send test SMS
           <i className="bx bx-envelope-open"></i>
         </>
-      )}
-    </TextInputWithButton>
+      }
+      loadingButtonLabel="Sending..."
+    />
   )
 }
 

--- a/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
+++ b/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
@@ -26,7 +26,6 @@ enum ApiKeyState {
 
 const ApiKey: React.FunctionComponent<ApiKeyProps> = ({ hasApiKey }) => {
   const [apiKey, setApiKey] = useState('')
-  const [isGeneratingApiKey, setIsRegeneratingApiKey] = useState(false)
   const [errorMsg, setErrorMsg] = useState(null)
   const [apiKeyState, setApiKeyState] = useState<ApiKeyState>(
     ApiKeyState.GENERATE
@@ -81,7 +80,6 @@ const ApiKey: React.FunctionComponent<ApiKeyProps> = ({ hasApiKey }) => {
 
   async function onGenerateConfirm() {
     setErrorMsg(null)
-    setIsRegeneratingApiKey(true)
     try {
       const newApiKey = await regenerateApiKey()
       setApiKey(newApiKey)
@@ -89,7 +87,6 @@ const ApiKey: React.FunctionComponent<ApiKeyProps> = ({ hasApiKey }) => {
     } catch (e) {
       setErrorMsg(e.message)
     }
-    setIsRegeneratingApiKey(false)
   }
 
   let buttonLabel = ''
@@ -139,11 +136,13 @@ const ApiKey: React.FunctionComponent<ApiKeyProps> = ({ hasApiKey }) => {
         onClick={onButtonClick}
         className={buttonClass}
         textRef={apiKeyRef}
-        buttonDisabled={isGeneratingApiKey}
-      >
-        {buttonLabel} API key
-        <i className={cx('bx', buttonIcon)} />
-      </TextInputWithButton>
+        buttonLabel={
+          <>
+            {buttonLabel} API key
+            <i className={cx('bx', buttonIcon)} />
+          </>
+        }
+      />
       <ErrorBlock>{errorMsg}</ErrorBlock>
     </>
   )

--- a/frontend/src/components/login/login-input/LoginInput.tsx
+++ b/frontend/src/components/login/login-input/LoginInput.tsx
@@ -32,7 +32,6 @@ const Login = () => {
   )
 
   const [otpSent, setOtpSent] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
   const [email, setEmail] = useState('')
   const [otp, setOtp] = useState('')
   const [errorMsg, setErrorMsg] = useState(null)
@@ -51,7 +50,6 @@ const Login = () => {
       setErrorMsg(err.message)
       sendException(err.message)
     }
-    setIsLoading(false)
   }
 
   async function login() {
@@ -66,11 +64,9 @@ const Login = () => {
       setErrorMsg(err.message)
       sendException(err.message)
     }
-    setIsLoading(false)
   }
 
   function resetButton() {
-    setIsLoading(true)
     setErrorMsg(null)
     setCanResend(false)
   }
@@ -84,8 +80,8 @@ const Login = () => {
   function render(
     mainText: string,
     value: string,
-    onChange: Function,
-    onClick: Function,
+    onChange: (value: string) => void,
+    onClick: () => Promise<void>,
     buttonText: string[],
     placeholder: string,
     inputType?: string
@@ -105,12 +101,11 @@ const Login = () => {
           type={inputType}
           placeholder={placeholder}
           onChange={onChange}
-          buttonDisabled={!value || isLoading}
-          inputDisabled={isLoading}
+          buttonDisabled={!value}
           onClick={onClick}
-        >
-          {isLoading ? buttonText[1] : buttonText[0]}
-        </TextInputWithButton>
+          buttonLabel={buttonText[0]}
+          loadingButtonLabel={buttonText[1]}
+        />
         <ErrorBlock absolute={true}>{errorMsg}</ErrorBlock>
       </>
     )


### PR DESCRIPTION
## Problem

Some of our inputs and buttons are not disabled when an async function call is fired, allowing unwanted duplicate calls to be made (e.g. by double-clicking a button). 

Closes #407.

## Solution

This PR introduces a local state variable `asyncLoading` in `PrimaryButton` and `TextInputWithButton` that signifies if an async function execution is ongoing. The input and button are disabled based on `asyncLoading` to prevent unwanted user interaction while waiting for a response. 

The default behavior is to re-enable the input/button after the async function execution completes, but there are quite a few cases where the component is unmounted right after the response is received – for example when navigating away after clicking a button. Trying to re-enable an unmounted component would throw an exception. I've introduced a ref `isMounted` that is set to `false` during unmount, ensuring that we try to re-enable the component only if it's still mounted. 

This "disable-while-awaiting" behavior was previously implemented in several parent components throughout the app and are now not necessary – these have been removed. 

## Tests

1. Turn on network throttling in devtools and set it to `Slow 3G`
2. Go through the usual flows, ensuring that any async operation triggered by `PrimaryButton` or `TextInputWithButton` cannot be fired more than once
