### PR TITLE
Fix exceptionally large italics text in InfoBlock component

### DIFF
--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -127,7 +127,7 @@ $widescreen: 1216px;
     }
   }
 
-  i {
+  :global(i.bx) {
     margin-top: 0.2rem;
     margin-right: 1rem;
     font-size: 1.3rem;


### PR DESCRIPTION
## Problem

The italics text in email template previews are larger than expected.

InfoBlock styling has a css style targeting `i` boxicon elements. The target element was defined as `i` which includes all elements with the `<i>` html tag - boxicon elements and italic text. 

Closes #444

## Solution

Modify the css style to target only `i` elements with the global style `.bx` which identifies it to be a boxicon. This removes the unwanted styling on the `<i>` tag for italic text.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/5744384/85660100-ccece800-b6e7-11ea-9a0d-1606cd053e14.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/5744384/85660047-bba3db80-b6e7-11ea-8527-64bf4364cbd9.png)
