### PR TITLE
chore: Stricter camelcase config

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -18,9 +18,12 @@ module.exports = {
   },
   ignorePatterns: ['build', 'dist', 'node_modules'],
   rules: {
-    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/camelcase': [
+      'error',
+      { properties: 'never', ignoreDestructuring: true },
+    ],
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [2, { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
     'no-console': [
       'warn',

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -79,12 +79,12 @@ const previewFirstMessage = async (
 
     if (!message) return res.json({})
 
-    const { body, subject, replyTo: reply_to } = message
+    const { body, subject, replyTo } = message
     return res.json({
       preview: {
         body,
         subject,
-        reply_to,
+        reply_to: replyTo,
       },
     })
   } catch (err) {

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -24,7 +24,10 @@ module.exports = {
     'react-hooks/exhaustive-deps': 'warn', // Checks effect dependencies
 
     '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
-    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/camelcase': [
+      'error',
+      { properties: 'never', ignoreDestructuring: true },
+    ],
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
 

--- a/worker/.eslintrc.js
+++ b/worker/.eslintrc.js
@@ -14,9 +14,12 @@ module.exports = {
   },
   ignorePatterns: ['build', 'dist', 'node_modules'],
   rules: {
-    '@typescript-eslint/camelcase': 'off',
+    '@typescript-eslint/camelcase': [
+      'error',
+      { properties: 'never', ignoreDestructuring: true },
+    ],
     '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [2, { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
 
     'no-console': [
       'warn',


### PR DESCRIPTION
## Problem

Our previous ESLint config had a blanket disable for the `camelcase` rule, allowing non-camelcase variables in places we didn't intend. 

## Solution

This PR makes the config stricter, only allowing `camelcase` exceptions for object properties and destructuring (input/output). 
