### PR TITLE
feat: Add invalid recipients export for Telegram

### DIFF
--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -21,7 +21,7 @@ const getStats = async (
 }
 
 /**
- * Gets invalid recipients for sms campaign
+ * Gets invalid recipients for Telegram campaign
  * @param req
  * @param res
  * @param next

--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -20,6 +20,29 @@ const getStats = async (
   }
 }
 
+/**
+ * Gets invalid recipients for sms campaign
+ * @param req
+ * @param res
+ * @param next
+ */
+const getFailedRecipients = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  const { campaignId } = req.params
+  try {
+    const recipients = await TelegramStatsService.getFailedRecipients(
+      +campaignId
+    )
+    return res.json(recipients)
+  } catch (err) {
+    next(err)
+  }
+}
+
 export const TelegramStatsMiddleware = {
   getStats,
+  getFailedRecipients,
 }

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -676,4 +676,36 @@ router.post(
  */
 router.get('/stats', TelegramStatsMiddleware.getStats)
 
+/**
+ * @swagger
+ * path:
+ *  /campaign/{campaignId}/telegram/export:
+ *    get:
+ *      tags:
+ *        - Telegram
+ *      summary: Get invalid recipients in campaign
+ *      parameters:
+ *        - name: campaignId
+ *          in: path
+ *          required: true
+ *          schema:
+ *            type: string
+ *
+ *      responses:
+ *        200:
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: array
+ *                items:
+ *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+ *        "401":
+ *           description: Unauthorized
+ *        "403":
+ *           description: Forbidden, campaign not owned by user
+ *        "500":
+ *           description: Internal Server Error
+ */
+router.get('/export', TelegramStatsMiddleware.getFailedRecipients)
+
 export default router

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -1,7 +1,7 @@
 import { StatsService } from '@core/services'
-import { CampaignStats } from '@core/interfaces'
+import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
 
-import { TelegramOp } from '@telegram/models'
+import { TelegramOp, TelegramMessage } from '@telegram/models'
 
 /**
  * Gets stats for telegram project
@@ -11,6 +11,17 @@ const getStats = async (campaignId: number): Promise<CampaignStats> => {
   return StatsService.getCurrentStats(campaignId, TelegramOp)
 }
 
+/**
+ * Gets failed recipients for sms project
+ * @param campaignId
+ */
+const getFailedRecipients = async (
+  campaignId: number
+): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+  return StatsService.getFailedRecipients(campaignId, TelegramMessage)
+}
+
 export const TelegramStatsService = {
   getStats,
+  getFailedRecipients,
 }

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -12,7 +12,7 @@ const getStats = async (campaignId: number): Promise<CampaignStats> => {
 }
 
 /**
- * Gets failed recipients for sms project
+ * Gets failed recipients for Telegram project
  * @param campaignId
  */
 const getFailedRecipients = async (


### PR DESCRIPTION
## Problem

Export of invalid recipients is not supported on Telegram. 

## Solution
- Add `/campaign/{campaignId}/telegram/export` endpoint

## Tests
- Create a new telegram campaign with a number with no subscription
- Send the campaign
- Wait for 5 minutes and download the exported list of invalid recipients either from the main campaign page or from the campaign details page.

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/86198116-7836ea80-bb89-11ea-9fb3-66840fe9f0db.png)