### PR TITLE
chore: Add deploy config for Telegram branch workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,11 @@ jobs:
           on:
             branch: $PRODUCTION_BRANCH
             condition: "$DEPLOY_WORKER = true"
+        - provider: script
+          script: ./deploy.sh postmangovsg-workers telegram-sending telegram-logging
+          on:
+            branch: $TELEGRAM_BRANCH
+            condition: "$DEPLOY_WORKER = true"
     - name: frontend
       before_install:
         - cd frontend
@@ -172,7 +177,7 @@ jobs:
             - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
         - provider: lambda
           edge: true
-          function_name: telegram-handler-staging
+          function_name: telegram-test
           region: $AWS_DEFAULT_REGION
           role: $STAGING_CALLBACK_ROLE
           runtime: nodejs12.x


### PR DESCRIPTION
Update travis.yml to include deployment for Telegram workers and change function name for Telegram callback lambda. Also made the following minor changes on AWS:
1. Add missing `DB_READ_REPLICA_URI` for Elastic Beanstalk config
2. Update `STAGING_TELEGRAM_HANDLER_DB_URI` on Travis to point to new `telegram` database on staging RDS instance
3. Added `halted` column to `campaigns` table

Tested deployment on Telegram AWS environment. 

### Note
- Change `TELEGRAM_BRANCH` back to `telegram` on Travis after merge. 