### PR TITLE
Fix normal links in Telegram templates

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -5,6 +5,7 @@
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
+import xss from 'xss'
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 /**
  * To require an env var without setting a default,
@@ -362,21 +363,16 @@ const config = convict({
           pre: [],
           a: ['href'],
         },
-        onTagAttr: (
+        safeAttrValue: (
           tag: string,
           name: string,
-          value: string,
-          isWhiteAttr: boolean
+          value: string
         ): string | void => {
           // Handle Telegram mention as xss-js does not recognize it as a valid url.
-          if (
-            isWhiteAttr &&
-            tag === 'a' &&
-            name === 'href' &&
-            value.startsWith('tg://')
-          ) {
-            return `href="${value}"`
+          if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
+            return value
           }
+          return xss.safeAttrValue(tag, name, value, xss.cssFilter)
         },
         stripIgnoreTag: true,
       },

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -362,14 +362,20 @@ const config = convict({
           pre: [],
           a: ['href'],
         },
-        safeAttrValue: (
+        onTagAttr: (
           tag: string,
           name: string,
-          value: string
+          value: string,
+          isWhiteAttr: boolean
         ): string | void => {
           // Handle Telegram mention as xss-js does not recognize it as a valid url.
-          if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
-            return value
+          if (
+            isWhiteAttr &&
+            tag === 'a' &&
+            name === 'href' &&
+            value.startsWith('tg://')
+          ) {
+            return `href="${value}"`
           }
         },
         stripIgnoreTag: true,

--- a/frontend/src/components/common/preview-block/PreviewBlock.module.scss
+++ b/frontend/src/components/common/preview-block/PreviewBlock.module.scss
@@ -8,4 +8,10 @@
       margin-top: 0;
     }
   }
+
+  code,
+  pre {
+    white-space: pre-wrap;
+    font-family: monospace;
+  }
 }

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -144,7 +144,9 @@ const TelegramRecipients = ({
       {!isCsvProcessing && numRecipients > 0 && (
         <>
           <p className={styles.greyText}>Message preview</p>
-          <PreviewBlock body={preview.body}></PreviewBlock>
+          <PreviewBlock
+            body={preview.body?.replace(/\n/g, '<br />')}
+          ></PreviewBlock>
           <div className="separator"></div>
         </>
       )}


### PR DESCRIPTION
## Problem

Normal links were being stripped by the previous xss options for Telegram. 

Closes #465 

## Solution
**Bug Fixes**:
- Use `onTagAttr` instead of `safeAttrValue`. I wrongly assumed previously that `safeAttrValue` default behaviour will just use the default `safeAttrValue` function when nothing is returned. 
    - Reference: [docs](https://github.com/leizongmin/js-xss/tree/v1.0.6#customize-the-handler-function-for-attributes-of-matched-tags) for `onTagAttr`
- Add CSS to show styles for `pre` and `code` blocks. 
- Replace `\n` with `<br />` in recipients page preview to show line breaks in preview. 

## Tests
Create a Telegram campaign and send a test message with this template to try out all the supported tags:
```
<b>bold</b>, bold
<i>italic</i>, italic
<u>underline</u>, underline
<s>strikethrough</s>, <strike>strikethrough</strike>, <del>strikethrough</del>
<b>bold <i>italic bold <s>italic bold strikethrough</s> <u>underline italic bold</u></i> bold</b>
<a href="https://www.google.com/">inline URL</a>
<a href="tg://user?id=837238105">inline mention of a user</a>
<code>inline fixed-width code</code>
<pre>pre-formatted fixed-width code block</pre>
<pre><code class="language-python">pre-formatted fixed-width code block written in the Python programming language</code></pre>
```
