### PR TITLE
fix: Minimum height for SideNav

### DIFF
--- a/frontend/src/components/common/side-nav/SideNav.module.scss
+++ b/frontend/src/components/common/side-nav/SideNav.module.scss
@@ -8,6 +8,7 @@ $nav-item-height: 5rem;
   width: $side-nav-width;
   min-width: $side-nav-width;
   border-right: 1px solid $indigo-blue;
+  min-height: calc(100vh - 4rem - 5rem);
 
   @include mobile() {
     display: none;

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
@@ -15,12 +15,17 @@ table.credTable {
   width: 100%;
 
   .actionColumn {
-    text-align: right;
+    display: flex;
+    justify-content: center;
   }
 
   .icon {
     @include icon;
-    margin-left: 1rem;
+    margin-right: 2rem;
+
+    &:last-child {
+      margin-right: 0rem;
+    }
 
     &.deleteButton {
       cursor: pointer;

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
@@ -67,7 +67,7 @@ const Credentials = ({
       <>
         {creds.map(({ label }) => (
           <tr key={label}>
-            <td className="md">{label}</td>
+            <td className="lg">{label}</td>
             <td className={cx('sm', styles.actionColumn)}>
               <i
                 className={cx(
@@ -110,7 +110,7 @@ const Credentials = ({
         <table className={styles.credTable}>
           <tbody>
             <tr>
-              <th className="md">Label</th>
+              <th className="lg">Label</th>
               <th className={cx('sm', styles.actionColumn)}></th>
             </tr>
             {renderCredentials()}


### PR DESCRIPTION
## Problem

SideNav was not filling the entire height of the Settings page.

Closes #463 

## Solution

**Bug Fixes**:

- Added `min-height` to SideNav component's style (similar to ProgressPane) 
- Updated Credentials table style to more closely match design on Zeplin

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/3666479/86267817-dd2a2900-bbf9-11ea-9166-6f23bd09a15e.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/3666479/86267783-d13e6700-bbf9-11ea-83ba-876387e9f34a.png)