### PR TITLE
chore: override halting

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -50,7 +50,7 @@ export interface CampaignDetails {
 export interface CampaignStats extends CampaignStatsCount {
   status: string
   updated_at: Date
-  halted: boolean
+  halted?: boolean
 }
 
 export interface CampaignStatsCount {

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -71,7 +71,7 @@ export class Campaign extends Model<Campaign> {
   @Default(false)
   @Column({
     type: DataType.BOOLEAN,
-    allowNull: false,
+    allowNull: true,
   })
   halted!: boolean
 

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -73,7 +73,7 @@ export class Campaign extends Model<Campaign> {
     type: DataType.BOOLEAN,
     allowNull: true,
   })
-  halted!: boolean
+  halted?: boolean
 
   // Sets key in s3Object json
   static async updateS3ObjectKey(

--- a/backend/src/core/services/job.service.ts
+++ b/backend/src/core/services/job.service.ts
@@ -36,7 +36,7 @@ const canSendCampaign = async (campaignId: number): Promise<boolean> => {
       id: campaignId,
       valid: true,
       credName: { [Op.ne]: null },
-      halted: false,
+      [Op.or]: [{ halted: { [Op.eq]: null } }, { halted: false }],
     },
   })
   return campaign !== null

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -62,7 +62,7 @@ export class CampaignStats {
   invalid: number
   status: Status
   updatedAt: Date
-  halted: boolean
+  halted?: boolean
 
   constructor(input: any) {
     this.error = +input['error']

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -34,12 +34,12 @@ const ProgressDetails = ({
   const [isSent, setIsSent] = useState(status === Status.Sent)
   const [isComplete, setIsComplete] = useState(!error && !unsent)
   const [displayExportButton, setDisplayExportButton] = useState(false)
-  const [isHalted, setIsHalted] = useState(halted)
+  const [isHalted, setIsHalted] = useState(!!halted)
 
   useEffect(() => {
     setIsComplete(!error && !unsent)
     setIsSent(status === Status.Sent)
-    setIsHalted(halted)
+    setIsHalted(!!halted)
   }, [status, error, unsent, halted])
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

We could not reliably enable the resumption of a campaign which had been halted because it probably would halt again on the next retry. 

## Solution

A campaign can only be halted if `halted` is `false`.
To unhalt, that is, forcefully override the halting mechanism, set `halted` to `null`. 

## Tests
- Delete the bounce email from blacklist 
- Insert some records (check the min number and min percentage required by the log-email-callback-staging lambda)
```sql
DELETE FROM email_blacklist WHERE recipient='bounce@simulator.amazonses.com';

-- Example for campaign 178
INSERT INTO email_messages ("campaign_id", "recipient", "params", "created_at", "updated_at")
      SELECT t.* FROM  generate_series(1,10) num_recipient
      CROSS JOIN LATERAL ( 
      SELECT 178 as "campaign_id", 'success@simulator.amazonses.com' as "recipient", CAST('{}' AS json) as "params",clock_timestamp() as "created_at", clock_timestamp() as "updated_at") t; 

INSERT INTO email_messages ("campaign_id", "recipient", "params", "created_at", "updated_at")
      SELECT t.* FROM  generate_series(1,3) num_recipient
      CROSS JOIN LATERAL ( 
      SELECT 178 as "campaign_id", 'bounce@simulator.amazonses.com' as "recipient", CAST('{}' AS json) as "params",clock_timestamp() as "created_at", clock_timestamp() as "updated_at") t;
```
- Send the campaign with `halted` defaulted to `false`, and watch the campaign halt. `halted` will be updated to `true`.
- Repeat the deletion and insertion.
- Set `halted` to null. Send the campaign (I do so with the same campaign, so I just click retry). The campaign will not be halted. 

## Deploy Notes

```ALTER TABLE campaigns ALTER COLUMN halted DROP NOT NULL;```
