### PR TITLE
fix: Worker templating

### DIFF
--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -5,6 +5,7 @@
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
+import xss from 'xss'
 
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 
@@ -204,6 +205,32 @@ const config = convict({
       },
       sms: {
         whiteList: { br: [] },
+        stripIgnoreTag: true,
+      },
+      telegram: {
+        whiteList: {
+          b: [],
+          i: [],
+          u: [],
+          s: [],
+          strike: [],
+          del: [],
+          p: [],
+          code: ['class'],
+          pre: [],
+          a: ['href'],
+        },
+        safeAttrValue: (
+          tag: string,
+          name: string,
+          value: string
+        ): string | void => {
+          // Handle Telegram mention as xss-js does not recognize it as a valid url.
+          if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
+            return value
+          }
+          return xss.safeAttrValue(tag, name, value, xss.cssFilter)
+        },
         stripIgnoreTag: true,
       },
     },

--- a/worker/src/core/loaders/message-worker/telegram.class.ts
+++ b/worker/src/core/loaders/message-worker/telegram.class.ts
@@ -6,8 +6,9 @@ import TemplateClient from '@core/services/template-client.class'
 import logger from '@core/logger'
 import TelegramClient from '@telegram/services/telegram-client.class'
 import { CredentialService } from '@core/services/credential.service'
+import config from '@core/config'
 
-const templateClient = new TemplateClient()
+const templateClient = new TemplateClient(config.get('xssOptions.telegram'))
 
 class Telegram {
   private workerId: string

--- a/worker/src/core/services/template-client.class.ts
+++ b/worker/src/core/services/template-client.class.ts
@@ -132,8 +132,12 @@ export default class TemplateClient {
 
   template(templateBody: string, params: { [key: string]: string }): string {
     const parsed = this.parseTemplate(templateBody, params)
-    // Remove extra '\' infront of single quotes and backslashes
-    const templated = parsed.tokens.join('').replace(/\\([\\'])/g, '$1')
+    // Remove extra '\' infront of single quotes and backslashes, added by Squirrelly when it escaped the csv.
+    // Remove extra '\' infront of \n added by Squirrelly when it escaped the message body.
+    const templated = parsed.tokens
+      .join('')
+      .replace(/\\([\\'])/g, '$1')
+      .replace(/\\n/g, '\n')
     return xss.filterXSS(templated, this.xssOptions)
   }
 }

--- a/worker/src/telegram/services/telegram-client.class.ts
+++ b/worker/src/telegram/services/telegram-client.class.ts
@@ -7,7 +7,9 @@ export default class TelegramClient {
   }
 
   async send(recipient: string, message: string): Promise<number> {
-    const response = await this.client.sendMessage(recipient, message)
+    const response = await this.client.sendMessage(recipient, message, {
+      parse_mode: 'HTML',
+    })
     return response.message_id
   }
 }


### PR DESCRIPTION
This PR: 

- Sets Telegram `parse_mode` to HTML
- Adds missing XSS options for Telegram workers
- Strip extra backslash from newline character

Closes #466 #464.
