### PR TITLE
feat(localstack): localstack CloudWatch, secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ export AWS_LOG_GROUP_NAME=postmangovsg-beanstalk-localstack
 
 cd localstack && ./init-localstack.sh && cd ..
 
+# Optional: get cw to tail Cloudwatch logs
+brew tap lucagrulla/tap
+brew install cw
+
+# Tail logs on localstack
+cw tail -r ap-northeast-1 -u $AWS_ENDPOINT -f $AWS_LOG_GROUP_NAME:`node --eval='console.log(require("os").hostname())'`
+
 ```
 
 ### Set environment variables

--- a/backend/src/core/loaders/cloudwatch.loader.ts
+++ b/backend/src/core/loaders/cloudwatch.loader.ts
@@ -1,4 +1,5 @@
 import WinstonCloudwatch from 'winston-cloudwatch'
+import { hostname } from 'os'
 
 import config from '@core/config'
 import logger from '@core/logger'
@@ -9,7 +10,9 @@ import { configureEndpoint } from '@core/utils/aws-endpoint'
  * Writes logs directly to cloudwatch instead of relying on Elastic beanstalk's Cloudwatch agent
  */
 const cloudwatchLoader = async (): Promise<void> => {
-  const instanceId = await getInstanceId()
+  const instanceId = config.get('aws.awsEndpoint')
+    ? hostname()
+    : await getInstanceId()
   try {
     if (instanceId) {
       logger.info({ message: `Detected instanceId as ${instanceId}` })

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -37,7 +37,7 @@ const storeCredential = async (name: string, secret: string): Promise<void> => {
   }
 
   // If credential doesn't exist, upload credential to secret manager, unless in development
-  if (!config.get('IS_PROD')) {
+  if (!config.get('IS_PROD') && !config.get('aws.awsEndpoint')) {
     logger.info(
       `Dev env - skip storing credential in AWS secrets manager for name=${name}`
     )
@@ -65,7 +65,7 @@ const storeCredential = async (name: string, secret: string): Promise<void> => {
 const getTwilioCredentials = async (
   name: string
 ): Promise<TwilioCredentials> => {
-  if (!config.get('IS_PROD')) {
+  if (!config.get('IS_PROD') && !config.get('aws.awsEndpoint')) {
     logger.info(
       `Dev env - getTwilioCredentials - returning default credentials for name=${name}`
     )

--- a/frontend/.env-example
+++ b/frontend/.env-example
@@ -12,5 +12,5 @@ REACT_APP_PRIVACY_URL='https://guide.postman.gov.sg/legal/privacy'
 REACT_APP_TC_URL='https://guide.postman.gov.sg/legal/t-and-c'
 REACT_APP_REPORT_BUG_URL='https://guide.postman.gov.sg/contact-us'
 REACT_APP_GA_TRACKING_ID=UA-XXX-X
-REACT_APP_SENTRY_DSN=https://123.ingest.sentry.io/456
+REACT_APP_SENTRY_DSN=https://key:secret@organization.ingest.sentry.io/456
 REACT_APP_SENTRY_RELEASE=release

--- a/localstack/init-localstack.sh
+++ b/localstack/init-localstack.sh
@@ -3,4 +3,5 @@ set -x
 # pip install awscli-local
 aws --endpoint-url $AWS_ENDPOINT s3 mb s3://$FILE_STORAGE_BUCKET_NAME
 aws --endpoint-url $AWS_ENDPOINT logs create-log-group --log-group-name $AWS_LOG_GROUP_NAME
+aws --endpoint-url $AWS_ENDPOINT logs create-log-stream --log-group-name $AWS_LOG_GROUP_NAME --log-stream-name `node --eval='console.log(require("os").hostname())'`
 aws --endpoint-url $AWS_ENDPOINT s3api put-bucket-cors --bucket $FILE_STORAGE_BUCKET_NAME --cors-configuration file://./bucket-cors.json


### PR DESCRIPTION
## Problem and Solution
As part of efforts to better replicate the dev experience as close to deployed
environments as possible, continue work to support localstack

- if `AWS_ENDPOINT` is specified, assume localstack present, and allow:
  - managing secrets from SecretManager even if not `IS_PROD`
  - configuring `machineId` to be dev machine hostname for CloudWatch

- update `localstack/init-localstack.sh` to add log stream, name taken from
  hostname

- update README with instructions to use cw to tail CloudWatch logs

- update frontend/.env-example with a properly formatted `SENTRY_DSN`

Part of work for #284 

## Tests

Run on local dev environment, localstack cloudwatch verified working as follows:

```bash
$ cw tail -r ap-northeast-1 -u $AWS_ENDPOINT -f $AWS_LOG_GROUP_NAME:`node --eval='console.log(require("os").hostname())'`
info - ::1 - 1 [2020-07-02T08:00:32.972Z] "GET /v1/auth/userinfo HTTP/1.1" 304 - "http://localhost:3000/campaigns" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36" 38.306 ms
info - ::1 - 1 [2020-07-02T08:00:33.166Z] "GET /v1/campaigns?offset=0&limit=10 HTTP/1.1" 200 171 "http://localhost:3000/campaigns" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36" 31.843 ms
```
