### PR TITLE
chore: Improve error messaging

### DIFF
--- a/serverless/telegram-handler/src/bot/PostmanTelegramError.ts
+++ b/serverless/telegram-handler/src/bot/PostmanTelegramError.ts
@@ -1,0 +1,10 @@
+export class PostmanTelegramError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'PostmanTelegramError'
+
+    // Manually set prototype
+    // Refer: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, PostmanTelegramError.prototype)
+  }
+}

--- a/serverless/telegram-handler/src/bot/index.ts
+++ b/serverless/telegram-handler/src/bot/index.ts
@@ -24,6 +24,18 @@ export const handleUpdate = async (
   bot.on('contact', contactMessageHandler(botId, sequelize))
 
   // Handle update
-  await bot.handleUpdate(update)
-  return
+  try {
+    await bot.handleUpdate(update)
+  } catch (err) {
+    const chatId = update.message?.from?.id
+    if (chatId) {
+      await bot.telegram.sendMessage(
+        chatId,
+        'An error occurred, please try again.'
+      )
+    }
+
+    // Rethrow error
+    throw err
+  }
 }

--- a/serverless/telegram-handler/src/bot/index.ts
+++ b/serverless/telegram-handler/src/bot/index.ts
@@ -5,6 +5,7 @@ import { Sequelize } from 'sequelize-typescript'
 import { startCommandHandler } from './handlers/start'
 import { contactMessageHandler } from './handlers/contact'
 import { updatenumberCommandHandler } from './handlers/updatenumber'
+import { PostmanTelegramError } from './PostmanTelegramError'
 
 /**
  * Instantiates a Telegraf instance to handle the incoming Telegram update.
@@ -29,10 +30,11 @@ export const handleUpdate = async (
   } catch (err) {
     const chatId = update.message?.from?.id
     if (chatId) {
-      await bot.telegram.sendMessage(
-        chatId,
-        'An error occurred, please try again.'
-      )
+      const errorMessage =
+        err instanceof PostmanTelegramError
+          ? `Error: ${err.message}, please try again.`
+          : 'An error occurred, please try again.'
+      await bot.telegram.sendMessage(chatId, errorMessage)
     }
 
     // Rethrow error

--- a/serverless/telegram-handler/src/index.ts
+++ b/serverless/telegram-handler/src/index.ts
@@ -16,7 +16,7 @@ const handler = async (event: any): Promise<{ statusCode: number }> => {
     // Handle update
     await handleUpdate(botId, botToken, update, sequelize)
   } catch (err) {
-    console.error(`Error: ${err.message}`)
+    console.error(err)
   }
 
   return {


### PR DESCRIPTION
## Problem

Error messaging was unclear. 

## Solution

- Simplify response when handling contact updates
- Introduce a new `PostmanTelegramError` class to differentiate between our own errors and those thrown by libraries. This allows us to: 
  - Provide more descriptive error messages for our own errors
  - Hide details from uncaught exceptions, responding with a generic "please try again" message