### PR TITLE
fix: Avoid double + prefix

### DIFF
--- a/serverless/telegram-handler/src/bot/handlers/contact.ts
+++ b/serverless/telegram-handler/src/bot/handlers/contact.ts
@@ -17,7 +17,10 @@ const upsertTelegramSubscriber = async (
   telegramId: number,
   sequelize: Sequelize
 ): Promise<boolean> => {
-  phoneNumber = `+${phoneNumber}`
+  // Some Telegram clients send pre-prefixed phone numbers
+  if (!phoneNumber.startsWith('+')) {
+    phoneNumber = `+${phoneNumber}`
+  }
 
   logger.log(`Upserting Telegram subscriber: ${phoneNumber} -> ${telegramId}`)
   const affectedRows = (


### PR DESCRIPTION
## Problem

Some Telegram clients send contact objects with `+` already prefixed to the phone number.

## Solution

Detect and avoid double-prefixing.
