### PR TITLE
chore: remove slashes in amplify

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 /frontend
 /worker
 /serverless
+amplify.yml

--- a/amplify.yml
+++ b/amplify.yml
@@ -59,11 +59,11 @@ frontend:
         - key: "Referrer-Policy"
           value: "same-origin"
         - key: "Content-Security-Policy"
-          value: "connect-src 'self' \
-            https://*.postman.gov.sg https://postmangovsg-dev-upload.s3.ap-northeast-1.amazonaws.com/ \
-            https://postmangovsg-prod-upload.s3.ap-northeast-1.amazonaws.com \
-            https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/ \
-            https://s3.ap-southeast-1.amazonaws.com/file-production.postman.gov.sg/ \
+          value: "connect-src 'self' 
+            https://*.postman.gov.sg https://postmangovsg-dev-upload.s3.ap-northeast-1.amazonaws.com/ 
+            https://postmangovsg-prod-upload.s3.ap-northeast-1.amazonaws.com 
+            https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/ 
+            https://s3.ap-southeast-1.amazonaws.com/file-production.postman.gov.sg/ 
             https://o399364.ingest.sentry.io/;
             style-src 'self' https://*.postman.gov.sg https://fonts.googleapis.com;
             font-src 'self' https://*.postman.gov.sg https://fonts.gstatic.com;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^3.8.3"
   },
   "lint-staged": {
-    "*.{yml,md},!amplify.yml": "prettier --write"
+    "*.{yml,md}": "prettier --write"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^3.8.3"
   },
   "lint-staged": {
-    "*.{yml,md}": "prettier --write"
+    "*.{yml,md},!amplify.yml": "prettier --write"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Problem

Amplify could not render our app when our amplify.yml file's new lines were appended with slashes.

## Solution

Do not lint the amplify.yml file

Maybe there's a better rule for this?
