### PR TITLE
[Registered] chore: Validating CSV

### DIFF
--- a/frontend/src/services/validate.service.ts
+++ b/frontend/src/services/validate.service.ts
@@ -20,7 +20,14 @@ export async function validateCsv(
 ): Promise<CsvStatus> {
   try {
     await validateHeaders(file, templateParams)
-    await validateRows(file, templateParams)
+    const numRows = await validateRows(file, templateParams)
+    return Promise.resolve({
+      csvError: '',
+      numRecipients: numRows,
+      // TODO: Change this to an actual preview
+      preview: 'This is a preview of message B',
+      csvFilename: file.name,
+    })
   } catch (err) {
     // if there is an error, return a csv status with the error message
     return Promise.resolve({
@@ -30,12 +37,6 @@ export async function validateCsv(
       csvFilename: file.name,
     })
   }
-  return Promise.resolve({
-    csvError: '',
-    numRecipients: 123,
-    preview: 'This is a preview of message B',
-    csvFilename: file.name,
-  })
 }
 
 /**
@@ -71,13 +72,14 @@ async function validateHeaders(
 
 /**
  * Read the file row by row and ensure that all the required params are there.
- *
+ * Returns the number of rows in the csv file
  */
 async function validateRows(
   file: File,
   templateParams: Array<string>
-): Promise<void> {
-  await new Promise((resolve, reject) => {
+): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    let count = 0
     Papa.parse(file, {
       header: true,
       delimiter: ',',
@@ -97,9 +99,10 @@ async function validateRows(
         } catch (e) {
           reject(e.message)
         }
+        count++
       },
       complete: function () {
-        resolve()
+        resolve(count)
       },
     })
   })

--- a/frontend/src/services/validate.service.ts
+++ b/frontend/src/services/validate.service.ts
@@ -1,0 +1,134 @@
+import Papa from 'papaparse'
+import { keys, difference } from 'lodash'
+
+export interface CsvStatus {
+  csvFilename?: string
+  csvError?: string
+  numRecipients?: number
+  preview?: string
+}
+
+/**
+ * Ensure that the keywords found in the template is all in the csv headers and each row.
+ * Also verifies that the the headers and each row has the following keys:
+ * recipient,password
+ *
+ */
+export async function validateCsv(
+  file: File,
+  templateParams: Array<string>
+): Promise<CsvStatus> {
+  try {
+    await validateHeaders(file, templateParams)
+    await validateRows(file, templateParams)
+  } catch (err) {
+    // if there is an error, return a csv status with the error message
+    return Promise.resolve({
+      csvError: err,
+      numRecipients: 0,
+      preview: 'This is a preview of message B',
+      csvFilename: file.name,
+    })
+  }
+  return Promise.resolve({
+    csvError: '',
+    numRecipients: 123,
+    preview: 'This is a preview of message B',
+    csvFilename: file.name,
+  })
+}
+
+/**
+ * Read only the headers of the csv file
+ *
+ */
+async function validateHeaders(
+  file: File,
+  templateParams: Array<string>
+): Promise<void> {
+  await new Promise((resolve, reject) => {
+    Papa.parse(file, {
+      header: false,
+      delimiter: ',',
+      step: function (_, parser: Papa.Parser) {
+        // Checks header only
+        parser.pause()
+        parser.abort()
+      },
+      complete: function (results) {
+        const headers = results.data as Array<string>
+        try {
+          checkTemplateKeys(headers, templateParams)
+          checkEssentialKeys(headers)
+        } catch (e) {
+          reject(e.message)
+        }
+        resolve()
+      },
+    })
+  })
+}
+
+/**
+ * Read the file row by row and ensure that all the required params are there.
+ *
+ */
+async function validateRows(
+  file: File,
+  templateParams: Array<string>
+): Promise<void> {
+  await new Promise((resolve, reject) => {
+    Papa.parse(file, {
+      header: true,
+      delimiter: ',',
+      skipEmptyLines: true,
+      step: function (step) {
+        // If there is errors, append to the errors array
+        if (step.errors.length != 0) {
+          reject(`Error parsing file.`)
+        }
+        // Check params
+        const params = step.data
+
+        try {
+          const paramKeys = keys(params)
+          checkTemplateKeys(paramKeys, templateParams)
+          checkEssentialKeys(paramKeys)
+        } catch (e) {
+          reject(e.message)
+        }
+      },
+      complete: function () {
+        resolve()
+      },
+    })
+  })
+}
+
+/**
+ * Checks that all the template keys are present in the params
+ *
+ */
+function checkTemplateKeys(
+  params: Array<string>,
+  templateParams: Array<string>
+): void {
+  // Check for keys that is in the template but not params
+  const extraKeysInTemplate = difference(templateParams, params)
+  if (extraKeysInTemplate.length != 0) {
+    throw new Error(`Template keys missing from params: ${extraKeysInTemplate}`)
+  }
+}
+
+/**
+ * Checks that the required keys are present in the params
+ *
+ */
+function checkEssentialKeys(params: Array<string>): void {
+  // Check for essential keys
+  const essentialKeys = ['recipient', 'password']
+  const missingKeys = difference(essentialKeys, params)
+  if (missingKeys.length != 0) {
+    throw new Error(`Essential keys missing from params: ${missingKeys}`)
+  }
+}


### PR DESCRIPTION
## Problem

Encrypting and hashing each row can take up quite alot of time for big files. 

If the csv file turns out to be malformed, the time taken will be wasted. Thus, we decided that we should validate the csv as much as possible before encrypting and hashing.

Closes #475

## Solution

There are two things that needs to be present for the csv:
- The keys that are used in the template: `Hi {{name}}, you scored {{score}} for your O levels.`, the keys `name` and `score` must be present.
- Keys that we need for sending, encryption, and hashing. Currently, they are `recipient` and `password`.

The csv file will parsed twice in `validateCsv`. 

The first time is to validate and ensure all the keys ar in the csv headers. This is a cheap and fast way to find out if the csv file is somewhat valid, since we are just checking the headers.

The second time we will parse the whole file without the headers. We will check that all the required keys are in each row.
