### PR TITLE
chore: add telegram as node_env option for sentry

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -33,7 +33,7 @@ convict.addFormats({
 const config = convict({
   env: {
     doc: 'The application environment.',
-    format: ['production', 'staging', 'development'],
+    format: ['production', 'staging', 'development', 'telegram'],
     default: 'production',
     env: 'NODE_ENV',
   },


### PR DESCRIPTION
Adds `telegram` NODE_ENV option for convict for backend, so we can switch it on for sentry