### PR TITLE
chore: Messaging tweaks to improve UX

### DIFF
--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -39,11 +39,26 @@ const Create = () => {
   function renderCreateChannel() {
     switch (campaign.type) {
       case ChannelType.SMS:
-        return <SMSCreate campaign={campaign as SMSCampaign} />
+        return (
+          <SMSCreate
+            campaign={campaign as SMSCampaign}
+            onCampaignChange={setCampaign}
+          />
+        )
       case ChannelType.Email:
-        return <EmailCreate campaign={campaign as EmailCampaign} />
+        return (
+          <EmailCreate
+            campaign={campaign as EmailCampaign}
+            onCampaignChange={setCampaign}
+          />
+        )
       case ChannelType.Telegram:
-        return <TelegramCreate campaign={campaign as TelegramCampaign} />
+        return (
+          <TelegramCreate
+            campaign={campaign as TelegramCampaign}
+            onCampaignChange={setCampaign}
+          />
+        )
       default:
         return <p>Invalid Channel Type</p>
     }

--- a/frontend/src/components/dashboard/create/email/EmailCreate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCreate.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { cloneDeep } from 'lodash'
 
-import { EmailCampaign, EmailProgress } from 'classes/EmailCampaign'
+import { Campaign, EmailCampaign, EmailProgress } from 'classes'
 import { ProgressPane } from 'components/common'
 import EmailTemplate from './EmailTemplate'
 import EmailRecipients from './EmailRecipients'
@@ -21,11 +21,17 @@ const EMAIL_PROGRESS_STEPS = [
 
 const CreateEmail = ({
   campaign: initialCampaign,
+  onCampaignChange,
 }: {
   campaign: EmailCampaign
+  onCampaignChange: (c: Campaign) => void
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
+
+  useEffect(() => {
+    onCampaignChange(campaign)
+  }, [campaign, onCampaignChange])
 
   // Modifies campaign object in state and navigates to next step
   const onNext = useCallback((changes: any, next = true) => {

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -76,7 +76,8 @@ const EmailTemplate = ({
         double curly braces. The keywords in your message template should match
         the headers in your recipients CSV file.
         <br />
-        <b>Note:</b> Recipient is a required column in the CSV file.
+        <b>Note:</b> Recipient (email address) is a required column in the CSV
+        file.
       </p>
       <p>
         Example

--- a/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { cloneDeep } from 'lodash'
 
-import { SMSCampaign, SMSProgress, Status } from 'classes'
+import { Campaign, SMSCampaign, SMSProgress, Status } from 'classes'
 import { ProgressPane } from 'components/common'
 import SMSTemplate from './SMSTemplate'
 import SMSRecipients from './SMSRecipients'
@@ -20,11 +20,17 @@ const SMS_PROGRESS_STEPS = [
 
 const CreateSMS = ({
   campaign: initialCampaign,
+  onCampaignChange,
 }: {
   campaign: SMSCampaign
+  onCampaignChange: (c: Campaign) => void
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
+
+  useEffect(() => {
+    onCampaignChange(campaign)
+  }, [campaign, onCampaignChange])
 
   // Modifies campaign object in state and navigates to next step
   const onNext = useCallback((changes: any, next = true) => {

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -49,7 +49,8 @@ const SMSTemplate = ({
         double curly braces. The keywords in your message template should match
         the headers in your recipients CSV file.
         <br />
-        <b>Note:</b> Recipient is a required column in the CSV file.
+        <b>Note:</b> Recipient (mobile number) is a required column in the CSV
+        file.
       </p>
       <p>
         Example

--- a/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { cloneDeep } from 'lodash'
 
-import { TelegramCampaign, TelegramProgress, Status } from 'classes'
+import { Campaign, TelegramCampaign, TelegramProgress, Status } from 'classes'
 import { ProgressPane } from 'components/common'
 import TelegramTemplate from './TelegramTemplate'
 import TelegramRecipients from './TelegramRecipients'
@@ -20,11 +20,17 @@ const TELEGRAM_PROGRESS_STEPS = [
 
 const CreateTelegram = ({
   campaign: initialCampaign,
+  onCampaignChange,
 }: {
   campaign: TelegramCampaign
+  onCampaignChange: (c: Campaign) => void
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
+
+  useEffect(() => {
+    onCampaignChange(campaign)
+  }, [campaign, onCampaignChange])
 
   // Modifies campaign object in state and navigates to next step
   const onNext = useCallback((changes: any, next = true) => {

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react'
+import { OutboundLink } from 'react-ga'
 import { useParams } from 'react-router-dom'
 import cx from 'classnames'
 
+import { GUIDE_TELEGRAM_CREDENTIALS_URL } from 'config'
 import {
   validateStoredCredentials,
   validateNewCredentials,
@@ -158,9 +160,16 @@ const TelegramCredentials = ({
 
             <h2>Add new credentials</h2>
             <p className={styles.validateCredentialsInfo}>
-              Before you validate the credentials, the phone number you are
-              testing with <b>must be already subscribed to the bot</b>. Learn
-              more.
+              Please provide your Telegram bot token for validation. If you are
+              unsure about how to retrieve your bot token, please follow the
+              instructions provided&nbsp;
+              <OutboundLink
+                eventLabel={GUIDE_TELEGRAM_CREDENTIALS_URL}
+                to={GUIDE_TELEGRAM_CREDENTIALS_URL}
+                target="_blank"
+              >
+                here.
+              </OutboundLink>
             </p>
 
             <div className={styles.validateCredentialsInfo}>

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -80,8 +80,10 @@ const TelegramDetail = ({
         <>
           <h2>Your campaign has been sent!</h2>
           <p>
-            Some messages may have failed to send. You can retry these by
-            clicking on Retry.{' '}
+            A retry button will appear if some messages had an error while
+            sending. You can click on retry to try sending the message(s) again.
+            An export button will appear for you to download a list of failed
+            deliveries with the recipient’s mobile number.
           </p>
         </>
       )}

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -49,7 +49,8 @@ const TelegramTemplate = ({
         double curly braces. The keywords in your message template should match
         the headers in your recipients CSV file.
         <br />
-        <b>Note:</b> Recipient is a required column in the CSV file.
+        <b>Note:</b> Recipient (mobile number) is a required column in the CSV
+        file.
       </p>
       <p>
         Example


### PR DESCRIPTION
Collection of minor tweaks in messaging to improve UX from Sarah's feedback/testing.

## Solution

**Improvements**:

- [x] Improve messaging for insertion of bot token during campaign creation (closes #478)
- [x] Provide more information on what type of data is expected in the `recipient` column (closes #492)
- [x] Add message in Telegram statistics page to highlight the 5 minutes wait for exports to be available
- [x] Button should show "Back to campaigns" on the statistics page immediately after sending is triggered
    - Updates in `campaign` status was not propagated to the top level `Create` component. As such, a page refresh is required to fetch the updated `campaign` from the backend. This cause the button to show the wrong message at the final send step. 

## Screenshots
1. Messaging for bot token insertion
![image](https://user-images.githubusercontent.com/3666479/86768221-c82d1a00-c07f-11ea-9c5a-244f3feaae2d.png)

2. Information on recipient column
![image](https://user-images.githubusercontent.com/3666479/86768013-708eae80-c07f-11ea-8a35-17f6ccc6673d.png)

3. Export instructions for Telegram statistics page
![image](https://user-images.githubusercontent.com/3666479/86768045-7c7a7080-c07f-11ea-9c8f-ef325c2f0f53.png)

4. "Back to campaigns" button
![image](https://user-images.githubusercontent.com/3666479/86768309-f3176e00-c07f-11ea-9795-81cc20d2aa95.png)
