### PR TITLE
feat: Directly link user to add credential modal from create modal for Telegram

### DIFF
--- a/backend/src/core/routes/settings.routes.ts
+++ b/backend/src/core/routes/settings.routes.ts
@@ -129,10 +129,7 @@ router.delete(
  *              schema:
  *                type: array
  *                items:
- *                  type: object
- *                  properties:
- *                    label:
- *                     type: string
+ *                  type: string
  *
  */
 router.get(

--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -7,6 +7,7 @@ interface PrimaryButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   alignRight?: boolean
   onClick?: (...args: any[]) => void | Promise<void>
+  loadingPlaceholder?: string | React.ReactElement
 }
 
 const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
@@ -15,6 +16,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
   disabled,
   onClick,
   children,
+  loadingPlaceholder,
   ...otherProps
 }) => {
   const [asyncLoading, setAsyncLoading] = useState(false)
@@ -55,7 +57,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
       onClick={asyncOnClick}
       {...otherProps}
     >
-      {children}
+      {loadingPlaceholder && asyncLoading ? loadingPlaceholder : children}
     </button>
   )
 }

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -95,3 +95,8 @@
 .newCredentialsButton {
   margin-top: 2rem;
 }
+
+.inputLabelHelpLink {
+  margin-left: 0.5rem;
+  font-weight: normal;
+}

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -99,4 +99,8 @@
 .inputLabelHelpLink {
   margin-left: 0.5rem;
   font-weight: normal;
+  font-size: 0.75rem;
+  font-style: italic;
+  color: $dark-blue;
+  text-decoration: underline;
 }

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentialsInput.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentialsInput.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState } from 'react'
+import { OutboundLink } from 'react-ga'
+import { GUIDE_TELEGRAM_CREDENTIALS_URL } from 'config'
 
 import { TextInput } from 'components/common'
+import styles from '../Create.module.scss'
 
 const TelegramCredentialsInput = ({
   onFilled,
@@ -19,7 +22,17 @@ const TelegramCredentialsInput = ({
 
   return (
     <>
-      <h5>Telegram Bot Token</h5>
+      <h5>
+        Telegram Bot Token
+        <OutboundLink
+          className={styles.inputLabelHelpLink}
+          eventLabel={GUIDE_TELEGRAM_CREDENTIALS_URL}
+          to={GUIDE_TELEGRAM_CREDENTIALS_URL}
+          target="_blank"
+        >
+          (What&apos;s this?)
+        </OutboundLink>
+      </h5>
       <TextInput
         placeholder="Enter Telegram Bot Token"
         value={telegramBotToken}

--- a/frontend/src/components/dashboard/settings/Settings.tsx
+++ b/frontend/src/components/dashboard/settings/Settings.tsx
@@ -45,7 +45,6 @@ const Settings = () => {
     modalContext.setModalContent(
       <AddCredentialModal
         credType={null}
-        labels={creds.map((c) => c.label)}
         onSuccess={fetchUserSettings}
       ></AddCredentialModal>
     )

--- a/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.module.scss
+++ b/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.module.scss
@@ -53,3 +53,8 @@
     }
   }
 }
+
+.loading {
+  text-align: center;
+  font-size: 3rem;
+}

--- a/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
+++ b/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
@@ -43,7 +43,7 @@ const AddCredentialModal = ({
   onSuccess: Function
 }) => {
   // Using channel type as proxy for credential type for now
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(credType !== null)
   const [label, setLabel] = useState('')
   const [credLabels, setCredLabels] = useState([] as string[])
   const [selectedCredType, setSelectedCredType] = useState(credType)

--- a/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
+++ b/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { OutboundLink } from 'react-ga'
 import cx from 'classnames'
 
@@ -11,8 +11,12 @@ import SMSValidationInput from 'components/dashboard/create/sms/SMSValidationInp
 import TelegramValidationInput from 'components/dashboard/create/telegram/TelegramValidationInput'
 import EmailValidationInput from 'components/dashboard/create/email/EmailValidationInput'
 import { ModalContext } from 'contexts/modal.context'
-import { storeCredentials as storeSmsCredentials } from 'services/sms.service'
 import {
+  getStoredCredentials as getSmsStoredCredentials,
+  storeCredentials as storeSmsCredentials,
+} from 'services/sms.service'
+import {
+  getStoredCredentials as getTelegramStoredCredentials,
   verifyUserCredentials as verifyUserTelegramCredentials,
   storeCredentials as storeTelegramCredentials,
 } from 'services/telegram.service'
@@ -32,23 +36,21 @@ enum AddCredentialStep {
 }
 
 const AddCredentialModal = ({
-  labels,
   credType,
   onSuccess,
 }: {
-  labels: string[]
   credType: ChannelType | null
   onSuccess: Function
 }) => {
   // Using channel type as proxy for credential type for now
-  // Hardcode to add new twilio cred
+  const [isLoading, setIsLoading] = useState(true)
   const [label, setLabel] = useState('')
+  const [credLabels, setCredLabels] = useState([] as string[])
   const [selectedCredType, setSelectedCredType] = useState(credType)
   const [credStep, setCredStep] = useState(
     credType ? AddCredentialStep.Input : AddCredentialStep.SelectType
   )
   const [credentials, setCredentials] = useState(null as any)
-  const [isValidating, setIsValidating] = useState(false)
   const [error, setError] = useState(
     null as null | {
       message: string
@@ -58,8 +60,34 @@ const AddCredentialModal = ({
   )
   const modalContext = useContext(ModalContext)
 
+  async function loadCredLabels(channelType: ChannelType) {
+    setIsLoading(true)
+
+    let storedCredLabels: string[]
+    switch (channelType) {
+      case ChannelType.SMS:
+        storedCredLabels = await getSmsStoredCredentials()
+        break
+      case ChannelType.Telegram:
+        storedCredLabels = await getTelegramStoredCredentials()
+        break
+      default:
+        storedCredLabels = []
+        break
+    }
+
+    setCredLabels(storedCredLabels)
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    if (credType) {
+      loadCredLabels(credType)
+    }
+  }, [credType])
+
   function isValidLabel() {
-    return label && !labels.includes(label)
+    return label && !credLabels.includes(label)
   }
 
   // Render credential input based on selected type of credential
@@ -103,10 +131,8 @@ const AddCredentialModal = ({
           </>
         )
 
-        nextFunc = async () => {
-          setIsValidating(true)
-          await validateTelegramBotToken()
-          setIsValidating(false)
+        nextFunc = () => {
+          return validateTelegramBotToken()
         }
         break
     }
@@ -116,16 +142,14 @@ const AddCredentialModal = ({
         <div className="separator"></div>
         <div className="progress-button">
           <PrimaryButton
-            disabled={!isValidLabel() || !credentials || isValidating}
             onClick={nextFunc}
-          >
-            {isValidating ? (
+            loadingPlaceholder={
               <>
                 Validating<i className="bx bx-loader-alt bx-spin"></i>
               </>
-            ) : (
-              'Next →'
-            )}
+            }
+          >
+            Next →
           </PrimaryButton>
         </div>
       </>
@@ -312,7 +336,17 @@ const AddCredentialModal = ({
     }
   }
 
-  return <div className={styles.container}>{renderAddCredStep()}</div>
+  return (
+    <div className={styles.container}>
+      {isLoading ? (
+        <div className={styles.loading}>
+          <i className={'bx bx-loader-alt bx-spin'}></i>
+        </div>
+      ) : (
+        renderAddCredStep()
+      )}
+    </div>
+  )
 }
 
 export default AddCredentialModal

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
@@ -29,7 +29,6 @@ const Credentials = ({
     modalContext.setModalContent(
       <AddCredentialModal
         credType={credType}
-        labels={creds.map((c) => c.label)}
         onSuccess={refresh}
       ></AddCredentialModal>
     )

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -73,6 +73,7 @@ h5 {
 a {
   font-size: 0.8rem;
   text-decoration: none;
+  cursor: pointer;
 }
 
 li,


### PR DESCRIPTION
## Problem
Link in the create modal should directly link user to the add Telegram credential modal.

Closes #491 

## Solution
**Features**:
- Link user to `AddCredentialModal` directly from `CreateModal`

**Improvements**:
- Load stored credentials within `AddCredentialModal` 
- Added `loadingPlaceholder` to `PrimaryButton` to allow display of custom content when loading (e.g. spinner)
- Add link to guide for Telegram bot token field in modal 

## Tests
1. Open campaign creation modal 
2. Fill in a name for the campaign
3. Select Telegram as channel type
4. Click on the link "store and validate your credentials"
5. Fill in form with label and Telegram bot token and validate credential
6. Upon successful validation, user should be redirected back to the create campaign modal. The name for the campaign should be preserved from step 2. 