### PR TITLE
feat: Include error code in exported CSV

### DIFF
--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -172,7 +172,7 @@ const getFailedRecipients = async (
         [Op.or]: [MessageStatus.Error, MessageStatus.InvalidRecipient],
       },
     },
-    attributes: ['recipient', 'status', 'updated_at'],
+    attributes: ['recipient', 'status', 'error_code', 'updated_at'],
     useMaster: false,
   })
 

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -78,11 +78,13 @@ export class CampaignStats {
 export class CampaignInvalidRecipient {
   recipient: string
   status: string
+  errorCode: string
   updatedAt: string
 
   constructor(input: any) {
     this.recipient = input['recipient']
     this.status = input['status']
+    this.errorCode = input['error_code']
     this.updatedAt = input['updated_at']
   }
 }

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -10,7 +10,7 @@ import {
 } from 'classes'
 import moment from 'moment'
 
-const EXPORT_LINK_DISPLAY_WAIT_TIME = 5 * 60 * 1000
+const EXPORT_LINK_DISPLAY_WAIT_TIME = 1 * 60 * 1000 // 1 min
 
 function getJobTimestamps(
   jobs: Array<{ sent_at: Date; status_updated_at: Date }>


### PR DESCRIPTION
## Problem

Closes #506 

## Solution
- Include error code in the backend `/export` endpoints
- Include `errorCode` in `CampaignInvalidRecipient`

## Tests
1. Create campaign with invalid recipients
2. Send campaign
3. Export CSV when available and look for `errorCode` column 