### PR TITLE
Verify password endpoint for protected campaigns

### DIFF
--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -42,18 +42,17 @@ const verifyPasswordHash = async (
   next: NextFunction
 ): Promise<Response | void> => {
   try {
-    const { uuid } = req.params
-    const { hashedPassword } = req.body
-    const protectedMessage = await ProtectedService.findProtectedMessage(uuid)
-    if (!protectedMessage) return res.sendStatus(404)
-
-    const payload = await ProtectedService.verifyPasswordHash(
-      protectedMessage,
-      hashedPassword
+    const { id } = req.params
+    const { password_hash: passwordHash } = req.body
+    const protectedMessage = await ProtectedService.getProtectedMessage(
+      id,
+      passwordHash
     )
-
-    if (!payload) return res.sendStatus(401)
-    return res.json({ payload })
+    if (!protectedMessage) {
+      // Return not found if nothing retrieved from db
+      return res.sendStatus(404)
+    }
+    return res.json({ payload: protectedMessage.payload })
   } catch (err) {
     return next(err)
   }

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -30,6 +30,36 @@ const verifyTemplateBody = async (
   }
 }
 
+/**
+ * Retrieves a message for this campaign
+ * @param req
+ * @param res
+ * @param next
+ */
+const verifyPasswordHash = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  try {
+    const { uuid } = req.params
+    const { hashedPassword } = req.body
+    const protectedMessage = await ProtectedService.findProtectedMessage(uuid)
+    if (!protectedMessage) return res.sendStatus(404)
+
+    const payload = await ProtectedService.verifyPasswordHash(
+      protectedMessage,
+      hashedPassword
+    )
+
+    if (!payload) return res.sendStatus(401)
+    return res.json({ payload })
+  } catch (err) {
+    return next(err)
+  }
+}
+
 export const ProtectedMiddleware = {
   verifyTemplateBody,
+  verifyPasswordHash,
 }

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -6,7 +6,7 @@ import { AuthMiddleware } from '@core/middlewares'
 
 // Core routes
 import authenticationRoutes from './auth.routes'
-import protectedCampaignRoutes from './protectedCampaign.routes'
+import protectedMailRoutes from './protected.routes'
 import campaignRoutes from './campaign.routes'
 import settingsRoutes from './settings.routes'
 import statsRoutes from './stats.routes'
@@ -79,7 +79,7 @@ const router = Router()
 router.use('/ping', ping)
 router.use('/auth', authenticationRoutes)
 router.use('/stats', statsRoutes)
-router.use('/protect', protectedCampaignRoutes)
+router.use('/protect', protectedMailRoutes)
 
 router.use(
   '/campaigns',

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -6,6 +6,7 @@ import { AuthMiddleware } from '@core/middlewares'
 
 // Core routes
 import authenticationRoutes from './auth.routes'
+import protectedCampaignRoutes from './protectedCampaign.routes'
 import campaignRoutes from './campaign.routes'
 import settingsRoutes from './settings.routes'
 import statsRoutes from './stats.routes'
@@ -78,6 +79,7 @@ const router = Router()
 router.use('/ping', ping)
 router.use('/auth', authenticationRoutes)
 router.use('/stats', statsRoutes)
+router.use('/protect', protectedCampaignRoutes)
 
 router.use(
   '/campaigns',

--- a/backend/src/core/routes/protected.routes.ts
+++ b/backend/src/core/routes/protected.routes.ts
@@ -6,25 +6,20 @@ const router = Router()
 
 const protectVerifyValidator = {
   [Segments.BODY]: Joi.object({
-    hashedPassword: Joi.string().required(),
+    password_hash: Joi.string().required(),
   }),
 }
 
 /**
  * @swagger
  * path:
- *   /protect/{uuid}:
+ *   /protect/{id}:
  *     post:
- *       description: Verify hashed password and return encrypted payload
+ *       description: Verify password hash and return encrypted payload
  *       tags:
  *         - Email
  *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *         - name: uuid
+ *         - name: id
  *           in: path
  *           required: true
  *           schema:
@@ -34,9 +29,9 @@ const protectVerifyValidator = {
  *           application/json:
  *             schema:
  *               required:
- *                 - hashedPassword
+ *                 - password_hash
  *               properties:
- *                 hashedPassword:
+ *                 password_hash:
  *                   type: string
  *       responses:
  *         200:
@@ -47,15 +42,13 @@ const protectVerifyValidator = {
  *                properties:
  *                 payload:
  *                  type: string
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
+ *         "404":
+ *           description: Not Found
  *         "500":
  *           description: Internal Server Error
  */
 router.post(
-  '/:uuid',
+  '/:id',
   celebrate(protectVerifyValidator),
   ProtectedMiddleware.verifyPasswordHash
 )

--- a/backend/src/core/routes/protectedCampaign.routes.ts
+++ b/backend/src/core/routes/protectedCampaign.routes.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express'
+import { celebrate, Joi, Segments } from 'celebrate'
+import { ProtectedMiddleware } from '@core/middlewares'
+
+const router = Router()
+
+const protectVerifyValidator = {
+  [Segments.BODY]: Joi.object({
+    hashedPassword: Joi.string().required(),
+  }),
+}
+
+/**
+ * @swagger
+ * path:
+ *   /protect/{uuid}:
+ *     post:
+ *       description: Verify hashed password and return encrypted payload
+ *       tags:
+ *         - Email
+ *       parameters:
+ *         - name: campaignId
+ *           in: path
+ *           required: true
+ *           schema:
+ *             type: string
+ *         - name: uuid
+ *           in: path
+ *           required: true
+ *           schema:
+ *             type: string
+ *       requestBody:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               required:
+ *                 - hashedPassword
+ *               properties:
+ *                 hashedPassword:
+ *                   type: string
+ *       responses:
+ *         200:
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                 payload:
+ *                  type: string
+ *         "400" :
+ *           description: Bad Request
+ *         "401":
+ *           description: Unauthorized
+ *         "500":
+ *           description: Internal Server Error
+ */
+router.post(
+  '/:uuid',
+  celebrate(protectVerifyValidator),
+  ProtectedMiddleware.verifyPasswordHash
+)
+
+export default router

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -1,4 +1,5 @@
 import url from 'url'
+import crypto from 'crypto'
 
 import config from '@core/config'
 import logger from '@core/logger'
@@ -85,8 +86,37 @@ const checkTemplateVariables = (body: string): void => {
   }
 }
 
+const findProtectedMessage = async (
+  uuid: string
+): Promise<ProtectedMessage | null> => {
+  const protectedMsg = await ProtectedMessage.findOne({
+    where: { id: uuid },
+  })
+  return protectedMsg
+}
+
+const verifyPasswordHash = async (
+  protectedMsg: ProtectedMessage,
+  inputHash: string
+): Promise<string | null> => {
+  const { passwordHash, payload } = protectedMsg
+
+  // Buffers must be of same length
+  const isPasswordValid = crypto.timingSafeEqual(
+    Buffer.from(passwordHash),
+    Buffer.from(inputHash)
+  )
+
+  if (!isPasswordValid) {
+    return null
+  }
+  return payload
+}
+
 export const ProtectedService = {
   isProtectedCampaign,
   checkTemplateVariables,
   storeProtectedMessages,
+  findProtectedMessage,
+  verifyPasswordHash,
 }

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -1,13 +1,10 @@
 import url from 'url'
-import crypto from 'crypto'
+import { Transaction } from 'sequelize'
+import { TemplateClient } from 'postman-templating'
 
 import config from '@core/config'
 import logger from '@core/logger'
-
 import { ProtectedMessage, Campaign } from '@core/models'
-import { Transaction } from 'sequelize'
-
-import { TemplateClient } from 'postman-templating'
 
 const templateClient = new TemplateClient()
 /**
@@ -86,37 +83,25 @@ const checkTemplateVariables = (body: string): void => {
   }
 }
 
-const findProtectedMessage = async (
-  uuid: string
+/**
+ * Get corresponding payload for given message id and password hash
+ * @param id
+ * @param passwordHash
+ */
+const getProtectedMessage = async (
+  id: string,
+  passwordHash: string
 ): Promise<ProtectedMessage | null> => {
   const protectedMsg = await ProtectedMessage.findOne({
-    where: { id: uuid },
+    where: { id, passwordHash },
+    attributes: ['payload'],
   })
   return protectedMsg
-}
-
-const verifyPasswordHash = async (
-  protectedMsg: ProtectedMessage,
-  inputHash: string
-): Promise<string | null> => {
-  const { passwordHash, payload } = protectedMsg
-
-  // Buffers must be of same length
-  const isPasswordValid = crypto.timingSafeEqual(
-    Buffer.from(passwordHash),
-    Buffer.from(inputHash)
-  )
-
-  if (!isPasswordValid) {
-    return null
-  }
-  return payload
 }
 
 export const ProtectedService = {
   isProtectedCampaign,
   checkTemplateVariables,
   storeProtectedMessages,
-  findProtectedMessage,
-  verifyPasswordHash,
+  getProtectedMessage,
 }


### PR DESCRIPTION
## Problem

The password entered by the user on to decrypt the protected message needs to be verified by the server before sending over the encrypted payload. 

Closes #368 

**Features**:

- `verifyPasswordHash` endpoint verifies the password hash and returns the encrypted payload on success, or returns `401 Unauthorized` on mismatch
- compare the input password hash with the password hash stored in the `protected_messages` table
- use `crypto.timingSafeEqual` function to compare the hashes to prevent timing attacks 
