### PR TITLE
[Registered] chore: Template A checks

### DIFF
--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -3,7 +3,7 @@ import { ProtectedService } from '@core/services'
 import logger from '@core/logger'
 
 /**
- * Ensure that the template has the necessary keywords if it is a protected campaign.
+ * Ensure that the template only has the necessary keywords if it is a protected campaign.
  * @param req
  * @param res
  * @param next

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -3,12 +3,13 @@ import { ProtectedService } from '@core/services'
 import logger from '@core/logger'
 
 /**
- * Ensure that the template only has the necessary keywords if it is a protected campaign.
+ * Ensure that the template body only has the necessary keywords if it is a protected campaign.
+ * Subject should not have any keywords.
  * @param req
  * @param res
  * @param next
  */
-const verifyTemplateBody = async (
+const verifyTemplate = async (
   req: Request,
   res: Response,
   next: NextFunction
@@ -19,9 +20,10 @@ const verifyTemplateBody = async (
       return next()
     }
 
-    const { body } = req.body
+    const { subject, body } = req.body
 
-    ProtectedService.checkTemplateVariables(body)
+    ProtectedService.checkTemplateSubject(subject)
+    ProtectedService.checkTemplateBody(body)
 
     return next()
   } catch (err) {
@@ -59,6 +61,6 @@ const verifyPasswordHash = async (
 }
 
 export const ProtectedMiddleware = {
-  verifyTemplateBody,
+  verifyTemplate,
   verifyPasswordHash,
 }

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -70,17 +70,21 @@ const storeProtectedMessages = async (
 const checkTemplateVariables = (body: string): void => {
   const { variables } = templateClient.parseTemplate(body)
 
+  const unique = [...new Set(variables)]
+
   const essential = ['protectedlink']
 
-  const missing = essential.filter((keyword) => !variables.includes(keyword))
+  const missing = essential.filter((keyword) => !unique.includes(keyword))
 
+  // Makes sure that all the compulsory keywords are inside the template
   if (missing.length !== 0) {
     throw new Error(
       `Compulsory keywords are missing from the template: ${missing}`
     )
   }
 
-  if (variables.length !== essential.length) {
+  // Should only contain the the compulsory keywords
+  if (unique.length !== essential.length) {
     throw new Error(
       `Only 'protectedlink' is allowed as a keyword in the template.`
     )

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -68,7 +68,7 @@ const storeProtectedMessages = async (
  * Verifies that the template for protected campaigns has the compulsory keywords
  * The template should not contain any other keywords other than the compulsory ones.
  */
-const checkTemplateVariables = (body: string): void => {
+const checkTemplateBody = (body: string): void => {
   const { variables } = templateClient.parseTemplate(body)
 
   const unique = [...new Set(variables)]
@@ -93,6 +93,18 @@ const checkTemplateVariables = (body: string): void => {
 }
 
 /**
+ * Ensures that subject does not have any keywords.
+ */
+const checkTemplateSubject = (subject: string): void => {
+  const { variables } = templateClient.parseTemplate(subject)
+  if (variables.length !== 0) {
+    throw new Error(
+      `Subject should not contain any keywords. Currently contains ${variables}`
+    )
+  }
+}
+
+/**
  * Get corresponding payload for given message id and password hash
  * @param id
  * @param passwordHash
@@ -110,7 +122,8 @@ const getProtectedMessage = async (
 
 export const ProtectedService = {
   isProtectedCampaign,
-  checkTemplateVariables,
+  checkTemplateBody,
+  checkTemplateSubject,
   storeProtectedMessages,
   getProtectedMessage,
 }

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -66,6 +66,7 @@ const storeProtectedMessages = async (
 }
 /**
  * Verifies that the template for protected campaigns has the compulsory keywords
+ * The template should not contain any other keywords other than the compulsory ones.
  */
 const checkTemplateVariables = (body: string): void => {
   const { variables } = templateClient.parseTemplate(body)

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -190,7 +190,7 @@ router.put(
   '/template',
   celebrate(storeTemplateValidator),
   CampaignMiddleware.canEditCampaign,
-  ProtectedMiddleware.verifyTemplateBody,
+  ProtectedMiddleware.verifyTemplate,
   EmailTemplateMiddleware.storeTemplate
 )
 

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -41,7 +41,6 @@ const EmailTemplate = ({
       if (!campaignId) {
         throw new Error('Invalid campaign id')
       }
-      // TODO: Parse template and check for protectedlink params
       const { updatedTemplate, numRecipients } = await saveTemplate(
         +campaignId,
         subject,


### PR DESCRIPTION
## Problem

Multiple `protectedlink` would throw an error:
![recording (4)](https://user-images.githubusercontent.com/33112945/87365305-7f59f180-c5a8-11ea-81eb-227b6273359e.gif)


Template A's subject was allowed to have keywords:
![recording (5)](https://user-images.githubusercontent.com/33112945/87365414-bc25e880-c5a8-11ea-9218-f29f243b127b.gif)



## Solution

**Improvements**:

- Added checks for subject to ensure it has no keywords. (We could allow them to add `protectedlink`)
- Allow multiple mentions of `protectedlink` in `checkTemplateBody`


## After Screenshots

**AFTER**:
Multiple `protectedlink`:
![recording (2)](https://user-images.githubusercontent.com/33112945/87365128-05c20380-c5a8-11ea-88c5-38cd41e47302.gif)

Keywords in subject:
![recording (3)](https://user-images.githubusercontent.com/33112945/87365242-4b7ecc00-c5a8-11ea-93fa-ba3173ac4885.gif)
