### PR TITLE
chore: Add travis deploy for prod Telegram handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,7 +188,7 @@ jobs:
           edge: true
           function_name: telegram-handler-production
           region: $AWS_DEFAULT_REGION
-          role: $PRODUCTION_TELEGRAM_HANDLER_CALLBACK_ROLE
+          role: $PRODUCTION_TELEGRAM_HANDLER_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -203,7 +203,7 @@ jobs:
           edge: true
           function_name: telegram-test
           region: $AWS_DEFAULT_REGION
-          role: $STAGING_TELEGRAM_HANDLER_CALLBACK_ROLE
+          role: $STAGING_TELEGRAM_HANDLER_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ jobs:
           publish: true
           zip: "../telegram-handler/code.zip"
           on:
-            branch: telegram-travis
+            branch: $PRODUCTION_BRANCH
           environment_variables:
             - DB_URI=$PRODUCTION_TELEGRAM_HANDLER_DB_URI
         - provider: lambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ jobs:
           publish: true
           zip: "../telegram-handler/code.zip"
           on:
-            branch: $PRODUCTION_BRANCH
+            branch: telegram-travis
           environment_variables:
             - DB_URI=$PRODUCTION_TELEGRAM_HANDLER_DB_URI
         - provider: lambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
           on:
             branch: $TELEGRAM_BRANCH
         - provider: elasticbeanstalk
+          edge: true
           skip_cleanup: true
           access_key_id: $AWS_ACCESS_KEY_ID
           secret_access_key: $AWS_SECRET_ACCESS_KEY
@@ -185,9 +186,9 @@ jobs:
             - CALLBACK_SECRET=$PRODUCTION_EMAIL_CALLBACK_SECRET
         - provider: lambda
           edge: true
-          function_name: telegram-test
+          function_name: telegram-handler-production
           region: $AWS_DEFAULT_REGION
-          role: $STAGING_CALLBACK_ROLE
+          role: $PRODUCTION_TELEGRAM_HANDLER_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -195,7 +196,22 @@ jobs:
           publish: true
           zip: "../telegram-handler/code.zip"
           on:
-            branch: $TELEGRAM_BRANCH
+            branch: $PRODUCTION_BRANCH
+          environment_variables:
+            - DB_URI=$PRODUCTION_TELEGRAM_HANDLER_DB_URI
+        - provider: lambda
+          edge: true
+          function_name: telegram-test
+          region: $AWS_DEFAULT_REGION
+          role: $STAGING_TELEGRAM_HANDLER_CALLBACK_ROLE
+          runtime: nodejs12.x
+          module_name: build/index
+          handler_name: handler
+          timeout: 30
+          publish: true
+          zip: "../telegram-handler/code.zip"
+          on:
+            branch: $STAGING_BRANCH
           environment_variables:
             - DB_URI=$STAGING_TELEGRAM_HANDLER_DB_URI
     - name: root


### PR DESCRIPTION
Made the following changes:
- Added additional section to deploy `telegram-handler-production`
- Add roles env var for Telegram handler
- Updated `telegram-test` to deploy on staging branch instead

The following env vars need to be set/update in travis: 
- [x] STAGING_TELEGRAM_HANDLER_ROLE
- [x] STAGING_TELEGRAM_HANDLER_DB_URI _(update to use `postman` db instead of `telegram` db)_
- [x] PRODUCTION_TELEGRAM_HANDLER_ROLE
- [ ] PRODUCTION_TELEGRAM_HANDLER_DB_URI