### PR TITLE
fix: Set backend url back to staging

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -2,7 +2,7 @@ version: 0.1
 env:
   variables:
     BACKEND_URL_PRODUCTION: "https://api.postman.gov.sg/v1"
-    BACKEND_URL_STAGING: "https://api-telegram.postman.gov.sg/v1"
+    BACKEND_URL_STAGING: "https://api-staging.postman.gov.sg/v1"
     SENTRY_ORG: "open-government-products-re"
     SENTRY_PROJECT: "postmangovsg-frontend"
     REACT_APP_SENTRY_DSN: "https://b7b979b458ee470a86efff9ef1653b50@o399364.ingest.sentry.io/5261024"


### PR DESCRIPTION
## Problem

Frontend env var for backend url was not set back to `api-staging.postmang.gov.sg`.

## Solution
Set env var to in `amplify.yml` back.