### PR TITLE
feat: Force custom Telegram keyboards to be shown

### DIFF
--- a/serverless/telegram-handler/src/bot/handlers/start.ts
+++ b/serverless/telegram-handler/src/bot/handlers/start.ts
@@ -2,6 +2,7 @@ import { TelegrafContext } from 'telegraf/typings/context'
 import { Message } from 'telegraf/typings/telegram-types'
 
 import { Logger } from '../../utils/logger'
+import { generatePadding } from '../../utils/generatePadding'
 
 const logger = new Logger('start')
 
@@ -17,7 +18,15 @@ export const startCommandHandler = async (
     'Hello! To complete the subscription, please send me your phone number by pressing the button below.'
   return ctx.reply(REPLY, {
     reply_markup: {
-      keyboard: [[{ text: 'Send your phone number', request_contact: true }]],
+      keyboard: [
+        [
+          {
+            // Refer to generatePadding for more details
+            text: `Send your phone number ${generatePadding()}`,
+            request_contact: true,
+          },
+        ],
+      ],
     },
   })
 }

--- a/serverless/telegram-handler/src/bot/handlers/updatenumber.ts
+++ b/serverless/telegram-handler/src/bot/handlers/updatenumber.ts
@@ -2,6 +2,7 @@ import { TelegrafContext } from 'telegraf/typings/context'
 import { Message } from 'telegraf/typings/telegram-types'
 
 import { Logger } from '../../utils/logger'
+import { generatePadding } from '../../utils/generatePadding'
 
 const logger = new Logger('updatenumber')
 
@@ -18,7 +19,13 @@ export const updatenumberCommandHandler = async (
   return ctx.reply(REPLY, {
     reply_markup: {
       keyboard: [
-        [{ text: 'Send your updated phone number', request_contact: true }],
+        [
+          {
+            // Refer to generatePadding for more details
+            text: `Send your updated phone number ${generatePadding()}`,
+            request_contact: true,
+          },
+        ],
       ],
     },
   })

--- a/serverless/telegram-handler/src/utils/generatePadding.ts
+++ b/serverless/telegram-handler/src/utils/generatePadding.ts
@@ -1,0 +1,13 @@
+/**
+ * Generates a random-length whitespace string for padding purposes.
+ *
+ * If a user has previously hidden/dismissed the custom keyboard, some Telegram clients (e.g. iOS)
+ * continue hiding the custom keyboard sent with subsequent messages if there are no changes
+ * detected in the button labels. A random-length whitespace string is padded to the button labels
+ * to force clients to always show the custom keyboard. This has no visible effect to users because
+ * Telegram trims whitespace before it reaches the user.
+ */
+export const generatePadding = (): string => {
+  const padLength = Math.round(Math.random() * 100)
+  return ' '.repeat(padLength)
+}

--- a/serverless/telegram-handler/src/utils/generatePadding.ts
+++ b/serverless/telegram-handler/src/utils/generatePadding.ts
@@ -9,5 +9,5 @@
  */
 export const generatePadding = (): string => {
   const padLength = Math.round(Math.random() * 100)
-  return ' '.repeat(padLength)
+  return '​'.repeat(padLength)
 }

--- a/serverless/telegram-handler/src/utils/generatePadding.ts
+++ b/serverless/telegram-handler/src/utils/generatePadding.ts
@@ -5,9 +5,12 @@
  * continue hiding the custom keyboard sent with subsequent messages if there are no changes
  * detected in the button labels. A random-length whitespace string is padded to the button labels
  * to force clients to always show the custom keyboard. This has no visible effect to users because
- * Telegram trims whitespace before it reaches the user.
+ * we use a zero-width space character to form the string.
  */
 export const generatePadding = (): string => {
+  // This is a zero-width space character, unicode U+200B
+  const SPACE_CHARACTER = '​'
+
   const padLength = Math.round(Math.random() * 100)
-  return '​'.repeat(padLength)
+  return SPACE_CHARACTER.repeat(padLength)
 }


### PR DESCRIPTION
## Summary

From the comment in `generatePadding`: 

```
 * If a user has previously hidden/dismissed the custom keyboard, some Telegram clients (e.g. iOS)
 * continue hiding the custom keyboard sent with subsequent messages if there are no changes
 * detected in the button labels. A random-length whitespace string is padded to the button labels
 * to force clients to always show the custom keyboard. This has no visible effect to users because
 * Telegram trims whitespace before it reaches the user.
```

## Tests

1. Run the handler locally
2. Send `/start` then hide the custom keyboard
3. Continue sending `/start` – Each time a response is received, the custom keyboard should be brought up again. 