### PR TITLE
feat: Use full bot token instead of bot ID in Telegram webhook URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,7 +188,7 @@ jobs:
           edge: true
           function_name: telegram-handler-production
           region: $AWS_DEFAULT_REGION
-          role: $PRODUCTION_TELEGRAM_HANDLER_ROLE
+          role: $PRODUCTION_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
@@ -203,7 +203,7 @@ jobs:
           edge: true
           function_name: telegram-test
           region: $AWS_DEFAULT_REGION
-          role: $STAGING_TELEGRAM_HANDLER_ROLE
+          role: $STAGING_CALLBACK_ROLE
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler

--- a/backend/src/telegram/services/telegram.service.ts
+++ b/backend/src/telegram/services/telegram.service.ts
@@ -132,14 +132,15 @@ const validateAndConfigureBot = async (
   telegramBotToken: string
 ): Promise<void> => {
   const telegramService = new TelegramClient(telegramBotToken)
-  let botId
   try {
-    botId = await telegramService.getBotInfo()
+    await telegramService.getBotInfo()
   } catch (err) {
     throw new Error(`Invalid token. ${err.message}`)
   }
 
-  const callbackUrl = `${config.get('telegramOptions.webhookUrl')}/${botId}`
+  const callbackUrl = `${config.get(
+    'telegramOptions.webhookUrl'
+  )}/${telegramBotToken}`
   await telegramService.registerCallbackUrl(callbackUrl)
 
   const commands = [

--- a/serverless/telegram-handler/package-lock.json
+++ b/serverless/telegram-handler/package-lock.json
@@ -299,38 +299,10 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
-    "aws-sdk": {
-      "version": "2.689.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.689.0.tgz",
-      "integrity": "sha512-l9kbgZtIbR9dux4JHoxZ3vDWAfGtp34KpDDf5cwYHC5jDTTJoe6XhBBlEDSruwKh1+5DONpSZWNVhDZ6E02ojg==",
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "uuid": "3.3.2",
-        "xml2js": "0.4.19"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -379,16 +351,6 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "buffer-writer": {
@@ -794,11 +756,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -1053,11 +1010,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1204,21 +1156,11 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1599,11 +1541,6 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
-    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1697,11 +1634,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
       "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ=="
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
       "version": "7.3.2",
@@ -2092,22 +2024,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
-      }
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2172,20 +2088,6 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.2",

--- a/serverless/telegram-handler/package.json
+++ b/serverless/telegram-handler/package.json
@@ -37,7 +37,6 @@
     "@types/bluebird": "^3.5.32",
     "@types/node": "^14.0.9",
     "@types/validator": "^13.0.0",
-    "aws-sdk": "^2.689.0",
     "pg": "^8.2.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^5.21.11",

--- a/serverless/telegram-handler/src/bot/index.ts
+++ b/serverless/telegram-handler/src/bot/index.ts
@@ -6,6 +6,7 @@ import { startCommandHandler } from './handlers/start'
 import { contactMessageHandler } from './handlers/contact'
 import { updatenumberCommandHandler } from './handlers/updatenumber'
 import { PostmanTelegramError } from './PostmanTelegramError'
+import { verifyBotToken } from '../credentials'
 
 /**
  * Instantiates a Telegraf instance to handle the incoming Telegram update.
@@ -18,6 +19,9 @@ export const handleUpdate = async (
 ): Promise<void> => {
   // Instantiate bot
   const bot = new Telegraf(botToken)
+
+  // Verify botToken
+  await verifyBotToken(bot)
 
   // Attach handlers
   bot.command('start', startCommandHandler)

--- a/serverless/telegram-handler/src/config.ts
+++ b/serverless/telegram-handler/src/config.ts
@@ -90,13 +90,6 @@ const config = convict({
       },
     },
   },
-  aws: {
-    awsRegion: {
-      doc: 'Region for the S3 bucket that is used to store file uploads',
-      default: 'ap-northeast-1',
-      env: 'AWS_REGION',
-    },
-  },
 })
 
 // Only development is a non-production environment

--- a/serverless/telegram-handler/src/credentials.ts
+++ b/serverless/telegram-handler/src/credentials.ts
@@ -18,7 +18,7 @@ export const verifyBotIdRegistered = async (
   botId: string,
   sequelize: Sequelize
 ): Promise<void> => {
-  const { exists: botIdExists } = await sequelize.query(
+  const botIdExists = await sequelize.query(
     `SELECT 1 AS exists FROM credentials WHERE name = :botId;`,
     {
       replacements: {

--- a/serverless/telegram-handler/src/credentials.ts
+++ b/serverless/telegram-handler/src/credentials.ts
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk'
 import { Sequelize } from 'sequelize-typescript'
+import crypto from 'crypto'
 
 import config from './config'
 import { Logger } from './utils/logger'
@@ -63,8 +64,15 @@ export const getBotTokenFromId = async (botId: string): Promise<string> => {
  * Compares two bot tokens and throws an error if they do not match.
  */
 export const verifyBotToken = (token1: string, token2: string): void => {
-  if (token1 !== token2) {
+  // `crypto#timingSafeEqual` throws an error if the input buffers are of different length
+  // and returns false if they are of the same length but different contents. Handle both cases.
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(token1), Buffer.from(token2))) {
+      throw new Error()
+    }
+
+    logger.log('Bot token verified')
+  } catch (err) {
     throw new Error('Bot token mismatch')
   }
-  logger.log('Bot token verified')
 }

--- a/serverless/telegram-handler/src/credentials.ts
+++ b/serverless/telegram-handler/src/credentials.ts
@@ -58,3 +58,13 @@ export const getBotTokenFromId = async (botId: string): Promise<string> => {
 
   return botToken
 }
+
+/**
+ * Compares two bot tokens and throws an error if they do not match.
+ */
+export const verifyBotToken = (token1: string, token2: string): void => {
+  if (token1 !== token2) {
+    throw new Error('Bot token mismatch')
+  }
+  logger.log('Bot token verified')
+}

--- a/serverless/telegram-handler/src/index.ts
+++ b/serverless/telegram-handler/src/index.ts
@@ -2,11 +2,7 @@ import { Sequelize } from 'sequelize-typescript'
 
 import { parseEvent } from './parser'
 import sequelizeLoader from './sequelize-loader'
-import {
-  getBotTokenFromId,
-  verifyBotIdRegistered,
-  verifyBotToken,
-} from './credentials'
+import { verifyBotIdRegistered } from './credentials'
 import { handleUpdate } from './bot'
 
 let sequelize: Sequelize | undefined
@@ -18,12 +14,10 @@ const handler = async (event: any): Promise<{ statusCode: number }> => {
     }
 
     // Parse botToken and Telegram update
-    const { botId, botToken: unverifiedBotToken, update } = parseEvent(event)
+    const { botId, botToken, update } = parseEvent(event)
 
-    // Verify botId, fetch and verify bot token
+    // Verify botId
     await verifyBotIdRegistered(botId, sequelize)
-    const botToken = await getBotTokenFromId(botId)
-    verifyBotToken(unverifiedBotToken, botToken)
 
     // Handle update
     await handleUpdate(botId, botToken, update, sequelize)

--- a/serverless/telegram-handler/src/index.ts
+++ b/serverless/telegram-handler/src/index.ts
@@ -2,7 +2,11 @@ import { Sequelize } from 'sequelize-typescript'
 
 import { parseEvent } from './parser'
 import sequelizeLoader from './sequelize-loader'
-import { getBotTokenFromId, verifyBotIdRegistered } from './credentials'
+import {
+  getBotTokenFromId,
+  verifyBotIdRegistered,
+  verifyBotToken,
+} from './credentials'
 import { handleUpdate } from './bot'
 
 let sequelize: Sequelize | undefined
@@ -13,12 +17,13 @@ const handler = async (event: any): Promise<{ statusCode: number }> => {
       sequelize = await sequelizeLoader()
     }
 
-    // Parse botId and Telegram update
-    const { botId, update } = parseEvent(event)
+    // Parse botToken and Telegram update
+    const { botId, botToken: unverifiedBotToken, update } = parseEvent(event)
 
-    // Verify botId and fetch bot token
+    // Verify botId, fetch and verify bot token
     await verifyBotIdRegistered(botId, sequelize)
     const botToken = await getBotTokenFromId(botId)
+    verifyBotToken(unverifiedBotToken, botToken)
 
     // Handle update
     await handleUpdate(botId, botToken, update, sequelize)

--- a/serverless/telegram-handler/src/parser.ts
+++ b/serverless/telegram-handler/src/parser.ts
@@ -1,14 +1,20 @@
 import { Update } from 'telegraf/typings/telegram-types'
 
 /**
- * Extracts botId and Telegram update from the Lambda event
+ * Extracts botId, botToken and Telegram update from the Lambda event
+ *
+ * For reference, botToken = botId:botSecret.
  */
-export const parseEvent = (event: any): { botId: string; update: Update } => {
-  const { botId } = event.pathParameters
+export const parseEvent = (
+  event: any
+): { botId: string; botToken: string; update: Update } => {
+  const { botToken } = event.pathParameters
+  const botId = botToken.split(':')[0]
   const update = JSON.parse(event.body)
+
   if (!(botId && update)) {
-    throw new Error('botId and Telegram update must be specified.')
+    throw new Error('botId, botToken and Telegram update must be specified.')
   }
 
-  return { botId, update }
+  return { botId, botToken, update }
 }

--- a/serverless/telegram-handler/src/server.ts
+++ b/serverless/telegram-handler/src/server.ts
@@ -14,7 +14,7 @@ if (!TOKEN) {
 const app = express()
 app.use(express.json())
 
-app.post('/:botId', async (req, res) => {
+app.post('/:botToken', async (req, res) => {
   const event = {
     body: JSON.stringify(req.body), // simulate Lambda's stringified body
     pathParameters: req.params,


### PR DESCRIPTION
## Problem

We currently use bot ID as the path parameter for bot webhook URLs. Anyone who knows the bot ID (which is not meant to be a secret) can start sending updates to our handler. 

Although an attacker can't make use of this because we have additional checks, ideally our handler should only be handling updates from trusted sources (i.e. from Telegram only and not strangers). 

## Solution

- Extend the path parameter to include the full bot token instead of just the bot ID. The bot token is a secret that is only known to the bot owner. 
- Verify that the incoming bot token is valid and not revoked with a call to Telegram's `getMe` endpoint. 

## Tests

1. Save a new bot credential in the app
    - Your bot's webhook URL should be set to `telegramOptions.webhookUrl` + the full bot token. Verify this via `GET https://api.telegram.org/bot<token>/getWebhookInfo`. 
2. Run the handler locally and go through the bot subscription flow.
    - The handler should be able to handle the new path parameter
    - You should see `credentials: Bot token verified.` in the handler logs - this means that the received token has been validated by Telegram. 

## Deploy Notes

- API Gateway: replace the current `/{botId}` resource with `/{botToken}`
- Execution role: 
    - Travis: Delete `$PRODUCTION_TELEGRAM_HANDLER_ROLE` and `$STAGING_TELEGRAM_HANDLER_ROLE` since the Lambda can now use the generic execution role
    - Lambda: Set the execution role to the generic one, then delete the Telegram-related roles
- Update all current bots to use the new webhook URL scheme