### PR TITLE
chore: Retry getting s3 object in backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1175,6 +1175,15 @@
         "type-detect": "4.0.8"
       }
     },
+    "@types/async-retry": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.2.tgz",
+      "integrity": "sha512-GUDuJURF0YiJZ+CBjNQA0+vbP/VHlJbB0sFqkzsV7EcOPRfurVonXpXKAt3w8qIjM1TEzpz6hc6POocPvHOS3w==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -1522,6 +1531,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
     },
     "@types/serve-static": {
       "version": "1.13.3",
@@ -1943,6 +1958,14 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "requires": {
         "lodash": "^4.17.14"
+      }
+    },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "requires": {
+        "retry": "0.12.0"
       }
     },
     "asynckit": {
@@ -13933,6 +13956,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-as-promised": {
       "version": "3.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "@types/nodemailer": "^6.4.0",
     "@types/nodemailer-direct-transport": "^1.0.31",
     "@types/redis": "^2.8.17",
+    "async-retry": "^1.3.1",
     "aws-sdk": "^2.654.0",
     "axios": "^0.19.2",
     "bcrypt": "^4.0.1",
@@ -69,6 +70,7 @@
     "xss": "^1.0.6"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.2",
     "@types/bluebird": "^3.5.30",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.3",

--- a/backend/src/core/errors/s3.errors.ts
+++ b/backend/src/core/errors/s3.errors.ts
@@ -15,3 +15,11 @@ export class UnexpectedDoubleQuoteError extends Error {
     Error.captureStackTrace(this)
   }
 }
+
+export class CSVNotFoundError extends Error {
+  constructor() {
+    super(`File could not be loaded. Try re-uploading your file.`)
+    Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
+    Error.captureStackTrace(this)
+  }
+}

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -6,6 +6,7 @@ import { configureEndpoint } from '@core/utils/aws-endpoint'
 
 import { CSVParams } from '@core/types'
 import { ParseCsvService } from '@core/services'
+import { CSVNotFoundError } from '@core/errors'
 
 const FILE_STORAGE_BUCKET_NAME = config.get('aws.uploadBucket')
 
@@ -36,7 +37,7 @@ export default class S3Client {
    * @param s3Key
    */
   async getCsvFile(s3Key: string): Promise<Array<CSVParams>> {
-    return await retry(
+    return retry(
       async (bail) => {
         try {
           const downloadStream = this.download(s3Key)
@@ -47,11 +48,11 @@ export default class S3Client {
             bail(e)
             return []
           }
-          throw e
+          throw new CSVNotFoundError()
         }
       },
       {
-        retries: 5,
+        retries: 3,
         minTimeout: 1000,
         maxTimeout: 3 * 1000,
         factor: 1,

--- a/backend/src/core/services/s3-client.class.ts
+++ b/backend/src/core/services/s3-client.class.ts
@@ -1,4 +1,5 @@
 import S3 from 'aws-sdk/clients/s3'
+import retry from 'async-retry'
 
 import config from '@core/config'
 import { configureEndpoint } from '@core/utils/aws-endpoint'
@@ -30,13 +31,31 @@ export default class S3Client {
   /**
    * Download CSV file from S3 and process it into message.
    * The messages are formed from the template and parameters specified in the csv.
-   *
+   * Retries when s3 can't find the s3Key. This could be due to s3's eventual consistency.
    * @param campaignId
    * @param s3Key
    */
   async getCsvFile(s3Key: string): Promise<Array<CSVParams>> {
-    const downloadStream = this.download(s3Key)
-    const fileContents = await ParseCsvService.parseCsv(downloadStream)
-    return fileContents
+    return await retry(
+      async (bail) => {
+        try {
+          const downloadStream = this.download(s3Key)
+          const fileContents = await ParseCsvService.parseCsv(downloadStream)
+          return fileContents
+        } catch (e) {
+          if (e.code !== 'NoSuchKey') {
+            bail(e)
+            return []
+          }
+          throw e
+        }
+      },
+      {
+        retries: 5,
+        minTimeout: 1000,
+        maxTimeout: 3 * 1000,
+        factor: 1,
+      }
+    )
   }
 }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -6,6 +6,7 @@ import {
   RecipientColumnMissing,
   InvalidRecipientError,
   UnexpectedDoubleQuoteError,
+  CSVNotFoundError,
 } from '@core/errors'
 
 import { TemplateError } from 'postman-templating'
@@ -197,6 +198,7 @@ const uploadCompleteHandler = async (
       MissingTemplateKeysError,
       InvalidRecipientError,
       UnexpectedDoubleQuoteError,
+      CSVNotFoundError,
     ]
 
     if (userErrors.some((errType) => err instanceof errType)) {

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -7,6 +7,7 @@ import {
   RecipientColumnMissing,
   InvalidRecipientError,
   UnexpectedDoubleQuoteError,
+  CSVNotFoundError,
 } from '@core/errors'
 import { TemplateError } from 'postman-templating'
 import { CampaignService, TemplateService, StatsService } from '@core/services'
@@ -181,6 +182,7 @@ const uploadCompleteHandler = async (
       MissingTemplateKeysError,
       InvalidRecipientError,
       UnexpectedDoubleQuoteError,
+      CSVNotFoundError,
     ]
 
     if (userErrors.some((errType) => err instanceof errType)) {

--- a/backend/src/telegram/middlewares/telegram-template.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-template.middleware.ts
@@ -8,6 +8,7 @@ import {
   RecipientColumnMissing,
   InvalidRecipientError,
   UnexpectedDoubleQuoteError,
+  CSVNotFoundError,
 } from '@core/errors'
 import { TemplateError } from 'postman-templating'
 import { CampaignService, TemplateService, StatsService } from '@core/services'
@@ -193,6 +194,7 @@ const uploadCompleteHandler = async (
       MissingTemplateKeysError,
       InvalidRecipientError,
       UnexpectedDoubleQuoteError,
+      CSVNotFoundError,
     ]
 
     if (userErrors.some((errType) => err instanceof errType)) {


### PR DESCRIPTION
## Problem

Closes #379

## Solution

Made use of `async-retry` to retry only when s3 fails to find the specified key. There are other errors that could be thrown from `parseCsv`, so I had to check the error code.

Alternatively, I can do the retry on the frontend by reading the error code given by the backend after calling `upload/complete`. If it is the error message related to this, I will retry using axios.

Not sure which approach is better tbh. 

## Tests

- [ ] When an invalid s3 key is provided, backend will retry before throwing 500.
- [ ] Other parsing errors thrown by parseCsv will not result in any retries.

## Deploy Notes

New dependencies for backend.

**New dependencies**:

- `async-retry` : For async retries operations

**New dev dependencies**:

- `@types/async-retry` 
