### PR TITLE
Refactor failed recipients check in Campaigns component

### DIFF
--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -63,6 +63,12 @@ const listCampaigns = ({
         literal('CASE WHEN "cred_name" IS NULL THEN False ELSE True END'),
         'has_credential',
       ],
+      [
+        literal(
+          'CASE WHEN Statistic IS NULL THEN False ELSE (Statistic.errored + Statistic.invalid) > 0 END'
+        ),
+        'has_failed_recipients',
+      ],
       'halted',
       'protect',
     ],
@@ -75,6 +81,11 @@ const listCampaigns = ({
           ['created_at', 'sent_at'],
           ['updated_at', 'status_updated_at'],
         ],
+      },
+      {
+        model: Statistic,
+        attributes: [],
+        required: true,
       },
     ],
   }

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -63,12 +63,6 @@ const listCampaigns = ({
         literal('CASE WHEN "cred_name" IS NULL THEN False ELSE True END'),
         'has_credential',
       ],
-      [
-        literal(
-          'CASE WHEN Statistic IS NULL THEN False ELSE (Statistic.errored + Statistic.invalid) > 0 END'
-        ),
-        'has_failed_recipients',
-      ],
       'halted',
       'protect',
     ],
@@ -84,8 +78,14 @@ const listCampaigns = ({
       },
       {
         model: Statistic,
-        attributes: [],
-        required: true,
+        attributes: [
+          [
+            literal(
+              'CASE WHEN (errored + invalid) > 0 THEN True ELSE False END'
+            ),
+            'has_failed_recipients',
+          ],
+        ],
       },
     ],
   }

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -27,6 +27,7 @@ export class Campaign {
   isCsvProcessing: boolean
   statusUpdatedAt: Date
   protect: boolean
+  hasFailedRecipients: boolean
 
   constructor(input: any) {
     this.id = input['id']
@@ -40,6 +41,7 @@ export class Campaign {
     this.sentAt = input['sentAt']
     this.statusUpdatedAt = input['statusUpdatedAt']
     this.protect = input['protect']
+    this.hasFailedRecipients = input['has_failed_recipients']
   }
 
   getStatus(jobs: Array<{ status: string }>): Status {

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -48,7 +48,7 @@ const ExportRecipients = ({
         'text/csv'
       )
     } catch (error) {
-      console.log(error)
+      console.error(error)
     } finally {
       setDisabled(false)
     }

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -46,7 +46,6 @@ const ProgressDetails = ({
     async function checkHasExportButton() {
       const failedCount = error + invalid
       const displayExportButton = await hasFailedRecipients(
-        campaignId,
         status,
         updatedAt,
         failedCount

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import Moment from 'react-moment'
 import cx from 'classnames'
 
-import { hasFailedRecipients } from 'services/campaign.service'
+import { hasExportButton } from 'services/campaign.service'
 import { CampaignStats, Status } from 'classes/Campaign'
 import {
   ProgressBar,
@@ -45,7 +45,7 @@ const ProgressDetails = ({
   useEffect(() => {
     async function checkHasExportButton() {
       const failedCount = error + invalid
-      const displayExportButton = await hasFailedRecipients(
+      const displayExportButton = hasExportButton(
         status,
         updatedAt,
         failedCount

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -14,7 +14,7 @@ import {
   PrimaryButton,
   ExportRecipients,
 } from 'components/common'
-import { getCampaigns } from 'services/campaign.service'
+import { getCampaigns, hasExportButton } from 'services/campaign.service'
 import { Campaign, channelIcons } from 'classes'
 import CreateCampaign from 'components/dashboard/create/create-modal'
 
@@ -103,16 +103,20 @@ const Campaigns = () => {
     },
     {
       name: 'Export',
-      render: (campaign: Campaign) =>
-        campaign.hasFailedRecipients && (
-          <ExportRecipients
-            className={styles.exportRecipients}
-            campaignId={campaign.id}
-            campaignName={campaign.name}
-            status={campaign.status}
-            sentAt={campaign.sentAt}
-          />
-        ),
+      render: (campaign: Campaign) => {
+        const { status, statusUpdatedAt, hasFailedRecipients } = campaign
+        return (
+          hasExportButton(status, statusUpdatedAt, +hasFailedRecipients) && (
+            <ExportRecipients
+              className={styles.exportRecipients}
+              campaignId={campaign.id}
+              campaignName={campaign.name}
+              status={campaign.status}
+              sentAt={campaign.sentAt}
+            />
+          )
+        )
+      },
       width: 'xs',
     },
   ]

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -14,7 +14,7 @@ import {
   PrimaryButton,
   ExportRecipients,
 } from 'components/common'
-import { getCampaigns, hasFailedRecipients } from 'services/campaign.service'
+import { getCampaigns } from 'services/campaign.service'
 import { Campaign, channelIcons } from 'classes'
 import CreateCampaign from 'components/dashboard/create/create-modal'
 
@@ -30,9 +30,6 @@ const Campaigns = () => {
   const [campaignsDisplayed, setCampaignsDisplayed] = useState(
     new Array<Campaign>()
   )
-  const [hasExport, setHasExport] = useState<{
-    [key: number]: boolean
-  }>({})
   const [selectedPage, setSelectedPage] = useState(0)
   const [campaignCount, setCampaignCount] = useState(0)
   const history = useHistory()
@@ -56,12 +53,6 @@ const Campaigns = () => {
     })
     setCampaignCount(totalCount)
     setCampaignsDisplayed(campaigns)
-    const hasExport: { [key: number]: boolean } = {}
-    for (const campaign of campaigns) {
-      const { id, status, statusUpdatedAt } = campaign
-      hasExport[id] = await hasFailedRecipients(id, status, statusUpdatedAt)
-    }
-    setHasExport(hasExport)
     setLoading(false)
   }
 
@@ -113,7 +104,7 @@ const Campaigns = () => {
     {
       name: 'Export',
       render: (campaign: Campaign) =>
-        hasExport[campaign.id] && (
+        campaign.hasFailedRecipients && (
           <ExportRecipients
             className={styles.exportRecipients}
             campaignId={campaign.id}

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -22,11 +22,11 @@ function getJobTimestamps(
   return { sentAt: jobsSentAt[0], statusUpdatedAt: jobsUpdatedAt[0] }
 }
 
-export async function hasFailedRecipients(
+export function hasExportButton(
   status: Status,
   updatedAt: Date,
   failedCount: number
-) {
+): boolean {
   if (status !== Status.Sent) {
     return false
   }

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -23,10 +23,9 @@ function getJobTimestamps(
 }
 
 export async function hasFailedRecipients(
-  campaignId: number,
   status: Status,
   updatedAt: Date,
-  count?: number
+  failedCount: number
 ) {
   if (status !== Status.Sent) {
     return false
@@ -38,11 +37,6 @@ export async function hasFailedRecipients(
     return false
   }
 
-  let failedCount = count
-  if (failedCount === undefined) {
-    const { error, invalid } = await getCampaignStats(campaignId)
-    failedCount = error + invalid
-  }
   return failedCount > 0
 }
 


### PR DESCRIPTION
## Problem

Loading of campaign list was slow - after calling the campaign list endpoint to get the list of campaigns, the stats endpoint was called to determine the existence of failed recipients for each campaign. This was blocking the display of the campaign list on the frontend hence resulting in slower loading times for campaign list.

Closes #535

## Solution

Return `has_failed_recipients` as a boolean with the get campaign list endpoint and remove the calls to the stats endpoint from Campaigns component.
