### PR TITLE
chore: add xss options into postman-templating module

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2844,11 +2844,6 @@
         "which": "^1.2.9"
       }
     },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
-    },
     "cssom": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
@@ -15957,22 +15952,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
-    },
-    "xss": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
-      "integrity": "sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==",
-      "requires": {
-        "commander": "^2.9.0",
-        "cssfilter": "0.0.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        }
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,8 +65,7 @@
     "twilio": "^3.42.1",
     "uuid": "^7.0.3",
     "winston": "^3.2.1",
-    "winston-cloudwatch": "^2.3.2",
-    "xss": "^1.0.6"
+    "winston-cloudwatch": "^2.3.2"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.30",

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -5,7 +5,6 @@
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
-import xss from 'xss'
 import { isSupportedCountry } from 'libphonenumber-js'
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 /**
@@ -345,53 +344,6 @@ const config = convict({
     doc: 'Semi-colon separated list of domains that can sign in to the app.',
     default: '.gov.sg',
     env: 'DOMAIN_WHITELIST',
-  },
-  xssOptions: {
-    doc: 'List of html tags allowed',
-    default: {
-      email: {
-        whiteList: {
-          b: [],
-          i: [],
-          u: [],
-          br: [],
-          p: [],
-          a: ['href', 'title', 'target'],
-          img: ['src', 'alt', 'title', 'width', 'height'],
-        },
-        stripIgnoreTag: true,
-      },
-      sms: {
-        whiteList: { br: [] },
-        stripIgnoreTag: true,
-      },
-      telegram: {
-        whiteList: {
-          b: [],
-          i: [],
-          u: [],
-          s: [],
-          strike: [],
-          del: [],
-          p: [],
-          code: ['class'],
-          pre: [],
-          a: ['href'],
-        },
-        safeAttrValue: (
-          tag: string,
-          name: string,
-          value: string
-        ): string | void => {
-          // Handle Telegram mention as xss-js does not recognize it as a valid url.
-          if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
-            return value
-          }
-          return xss.safeAttrValue(tag, name, value, xss.cssFilter)
-        },
-        stripIgnoreTag: true,
-      },
-    },
   },
   csvProcessingTimeout: {
     doc:

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -22,8 +22,16 @@ const verifyTemplate = async (
 
     const { subject, body } = req.body
 
-    ProtectedService.checkTemplateSubject(subject)
-    ProtectedService.checkTemplateBody(body)
+    ProtectedService.checkTemplateVariables(
+      subject,
+      [],
+      ['protectedlink', 'recipient']
+    )
+    ProtectedService.checkTemplateVariables(
+      body,
+      ['protectedlink'],
+      ['recipient']
+    )
 
     return next()
   } catch (err) {

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -70,13 +70,13 @@ const storeProtectedMessages = async (
 }
 /**
  * Verifies that the template for protected campaigns has the required and optional keywords.
- * The template should not contain any other keywords other than these.
  */
-const checkTemplateBody = (body: string): void => {
-  const { variables } = templateClient.parseTemplate(body)
-
-  const required = ['protectedlink']
-  const optional = ['recipient']
+const checkTemplateVariables = (
+  template: string,
+  required: string[],
+  optional: string[]
+): void => {
+  const { variables } = templateClient.parseTemplate(template)
 
   const missing = difference(required, variables)
 
@@ -93,18 +93,6 @@ const checkTemplateBody = (body: string): void => {
   if (forbidden.length > 0) {
     throw new Error(
       `Only these keywords are allowed: ${whitelist}.\nRemove the other keywords from the template: ${forbidden}`
-    )
-  }
-}
-
-/**
- * Ensures that subject does not have any keywords.
- */
-const checkTemplateSubject = (subject: string): void => {
-  const { variables } = templateClient.parseTemplate(subject)
-  if (variables.length !== 0) {
-    throw new Error(
-      `Subject should not contain any keywords. Currently contains ${variables}`
     )
   }
 }
@@ -127,8 +115,7 @@ const getProtectedMessage = async (
 
 export const ProtectedService = {
   isProtectedCampaign,
-  checkTemplateBody,
-  checkTemplateSubject,
+  checkTemplateVariables,
   storeProtectedMessages,
   getProtectedMessage,
 }

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -1,6 +1,6 @@
 import url from 'url'
 import { Transaction } from 'sequelize'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
 
 import config from '@core/config'
 import logger from '@core/logger'
@@ -8,7 +8,7 @@ import { ProtectedMessage, Campaign } from '@core/models'
 
 const PROTECT_METHOD_VERSION = 1
 
-const templateClient = new TemplateClient()
+const templateClient = new TemplateClient(XSS_EMAIL_OPTION)
 /**
  * Whether a campaign is protected or not
  */

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -1,5 +1,5 @@
 import url from 'url'
-import { uniq, difference } from 'lodash'
+import { difference } from 'lodash'
 import { Transaction } from 'sequelize'
 import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
 
@@ -75,12 +75,10 @@ const storeProtectedMessages = async (
 const checkTemplateBody = (body: string): void => {
   const { variables } = templateClient.parseTemplate(body)
 
-  const unique = uniq(variables.map((v) => v.toLowerCase()))
-
   const required = ['protectedlink']
   const optional = ['recipient']
 
-  const missing = difference(required, unique)
+  const missing = difference(required, variables)
 
   // Makes sure that all the required keywords are inside the template
   if (missing.length !== 0) {
@@ -90,7 +88,7 @@ const checkTemplateBody = (body: string): void => {
   }
 
   const whitelist = [...required, ...optional]
-  const forbidden = difference(unique, whitelist)
+  const forbidden = difference(variables, whitelist)
   // Should only contain the whitelisted keywords
   if (forbidden.length > 0) {
     throw new Error(

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -2,17 +2,16 @@ import { difference, keys, chunk } from 'lodash'
 import validator from 'validator'
 import { Transaction } from 'sequelize'
 
-import config from '@core/config'
 import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssEmailOption } from 'postman-templating'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@email/interfaces'
 
-const client = new TemplateClient(config.get('xssOptions.email'))
+const client = new TemplateClient(XssEmailOption)
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -6,12 +6,12 @@ import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient, XssEmailOption } from 'postman-templating'
+import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@email/interfaces'
 
-const client = new TemplateClient(XssEmailOption)
+const client = new TemplateClient(XSS_EMAIL_OPTION)
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -1,17 +1,16 @@
 import { difference, keys, chunk } from 'lodash'
 import { Transaction } from 'sequelize'
 
-import config from '@core/config'
 import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssSmsOption } from 'postman-templating'
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
 
-const client = new TemplateClient(config.get('xssOptions.sms'))
+const client = new TemplateClient(XssSmsOption)
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -5,12 +5,12 @@ import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient, XssSmsOption } from 'postman-templating'
+import { TemplateClient, XSS_SMS_OPTION } from 'postman-templating'
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
 
-const client = new TemplateClient(XssSmsOption)
+const client = new TemplateClient(XSS_SMS_OPTION)
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -8,12 +8,12 @@ import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign } from '@core/models'
 import { PhoneNumberService } from '@core/services'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssTelegramOption } from 'postman-templating'
 
 import { TelegramMessage, TelegramTemplate } from '@telegram/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
 
-const client = new TemplateClient(config.get('xssOptions.telegram'), '\n')
+const client = new TemplateClient(XssTelegramOption, '\n')
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -8,12 +8,12 @@ import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign } from '@core/models'
 import { PhoneNumberService } from '@core/services'
-import { TemplateClient, XssTelegramOption } from 'postman-templating'
+import { TemplateClient, XSS_TELEGRAM_OPTION } from 'postman-templating'
 
 import { TelegramMessage, TelegramTemplate } from '@telegram/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
 
-const client = new TemplateClient(XssTelegramOption, '\n')
+const client = new TemplateClient(XSS_TELEGRAM_OPTION, '\n')
 
 /**
  * Create or replace a template. The mustached attributes are extracted in a sequelize hook,

--- a/frontend/src/services/validate-csv.service.ts
+++ b/frontend/src/services/validate-csv.service.ts
@@ -1,6 +1,6 @@
 import Papa from 'papaparse'
 import { keys, difference, uniq } from 'lodash'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
 
 export interface ProtectedCsvInfo {
   csvFilename: string
@@ -10,20 +10,7 @@ export interface ProtectedCsvInfo {
 
 export const PROTECTED_CSV_HEADERS = ['recipient', 'password']
 
-const protectedMailXssOptions = {
-  whiteList: {
-    b: [],
-    i: [],
-    u: [],
-    br: [],
-    p: [],
-    a: ['href', 'title', 'target'],
-    img: ['src', 'alt', 'title', 'width', 'height'],
-  },
-  stripIgnoreTag: true,
-}
-
-const templateClient = new TemplateClient(protectedMailXssOptions)
+const templateClient = new TemplateClient(XSS_EMAIL_OPTION)
 
 export function extractParams(template: string): string[] {
   return templateClient.parseTemplate(template).variables

--- a/modules/postman-templating/src/index.ts
+++ b/modules/postman-templating/src/index.ts
@@ -1,2 +1,3 @@
 export * from './template-client'
 export * from './errors'
+export * from './xss-options'

--- a/modules/postman-templating/src/template-client.ts
+++ b/modules/postman-templating/src/template-client.ts
@@ -40,7 +40,7 @@ export class TemplateClient {
     variables: Array<string>
     tokens: Array<string>
   } {
-    const variables: Array<string> = []
+    const variables: Set<string> = new Set()
     const tokens: Array<string> = []
 
     /**
@@ -102,7 +102,7 @@ export class TemplateClient {
           }
 
           // add key regardless, note that this is also returned in lowercase
-          variables.push(key)
+          variables.add(key)
 
           // if no params continue with the loop
           if (!params) return
@@ -128,7 +128,7 @@ export class TemplateClient {
         }
       })
       return {
-        variables,
+        variables: Array.from(variables), // variables are unique
         tokens,
       }
     } catch (err) {

--- a/modules/postman-templating/src/xss-options.ts
+++ b/modules/postman-templating/src/xss-options.ts
@@ -1,0 +1,60 @@
+import xss from 'xss'
+export const XssEmailOption = {
+  whiteList: {
+    b: [],
+    i: [],
+    u: [],
+    br: [],
+    p: [],
+    a: ['href', 'title', 'target'],
+    img: ['src', 'alt', 'title', 'width', 'height'],
+  },
+  safeAttrValue: (tag: string, name: string, value: string): string => {
+    const keywordRegex = /{{\s*?\w+\s*?}}/g
+    // Do not sanitize keyword when it's a href link, eg: <a href="{{protectedlink}}">link</a>
+    if (tag === 'a' && name === 'href' && value.match(keywordRegex)) {
+      return value
+    }
+
+    // Do not sanitize keyword when it's a img src, eg: <img src="{{protectedImg}}">
+    if (tag === 'img' && name === 'src' && value.match(keywordRegex)) {
+      return value
+    }
+    // The default safeAttrValue does guard against some edge cases
+    // https://github.com/leizongmin/js-xss/blob/446f5daa3b65e9e8f0e9c71276cf61dad73d1ec3/dist/xss.js
+    return xss.safeAttrValue(tag, name, value, xss.cssFilter)
+  },
+  stripIgnoreTag: true,
+}
+
+export const XssSmsOption = {
+  whiteList: { br: [] },
+  stripIgnoreTag: true,
+}
+
+export const XssTelegramOption = {
+  whiteList: {
+    b: [],
+    i: [],
+    u: [],
+    s: [],
+    strike: [],
+    del: [],
+    p: [],
+    code: ['class'],
+    pre: [],
+    a: ['href'],
+  },
+  safeAttrValue: (
+    tag: string,
+    name: string,
+    value: string
+  ): string => {
+    // Handle Telegram mention as xss-js does not recognize it as a valid url.
+    if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
+      return value
+    }
+    return xss.safeAttrValue(tag, name, value, xss.cssFilter)
+  },
+  stripIgnoreTag: true,
+}

--- a/modules/postman-templating/src/xss-options.ts
+++ b/modules/postman-templating/src/xss-options.ts
@@ -1,5 +1,5 @@
 import xss from 'xss'
-export const XssEmailOption = {
+export const XSS_EMAIL_OPTION = {
   whiteList: {
     b: [],
     i: [],
@@ -27,12 +27,12 @@ export const XssEmailOption = {
   stripIgnoreTag: true,
 }
 
-export const XssSmsOption = {
+export const XSS_SMS_OPTION = {
   whiteList: { br: [] },
   stripIgnoreTag: true,
 }
 
-export const XssTelegramOption = {
+export const XSS_TELEGRAM_OPTION = {
   whiteList: {
     b: [],
     i: [],

--- a/modules/postman-templating/src/xss-options.ts
+++ b/modules/postman-templating/src/xss-options.ts
@@ -1,4 +1,7 @@
 import xss from 'xss'
+
+const KEYWORD_REGEX = /^{{\s*?\w+\s*?}}$/
+
 export const XSS_EMAIL_OPTION = {
   whiteList: {
     b: [],
@@ -10,14 +13,15 @@ export const XSS_EMAIL_OPTION = {
     img: ['src', 'alt', 'title', 'width', 'height'],
   },
   safeAttrValue: (tag: string, name: string, value: string): string => {
-    const keywordRegex = /{{\s*?\w+\s*?}}/g
+    // Note: value has already been auto-trimmed of whitespaces
+
     // Do not sanitize keyword when it's a href link, eg: <a href="{{protectedlink}}">link</a>
-    if (tag === 'a' && name === 'href' && value.match(keywordRegex)) {
+    if (tag === 'a' && name === 'href' && value.match(KEYWORD_REGEX)) {
       return value
     }
 
     // Do not sanitize keyword when it's a img src, eg: <img src="{{protectedImg}}">
-    if (tag === 'img' && name === 'src' && value.match(keywordRegex)) {
+    if (tag === 'img' && name === 'src' && value.match(KEYWORD_REGEX)) {
       return value
     }
     // The default safeAttrValue does guard against some edge cases
@@ -45,11 +49,7 @@ export const XSS_TELEGRAM_OPTION = {
     pre: [],
     a: ['href'],
   },
-  safeAttrValue: (
-    tag: string,
-    name: string,
-    value: string
-  ): string => {
+  safeAttrValue: (tag: string, name: string, value: string): string => {
     // Handle Telegram mention as xss-js does not recognize it as a valid url.
     if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
       return value

--- a/modules/postman-templating/test/template-client.test.ts
+++ b/modules/postman-templating/test/template-client.test.ts
@@ -1,7 +1,11 @@
 import { TemplateClient } from '../src/template-client'
 import { TemplateError } from '../src/errors'
 
-import { XSS_EMAIL_OPTION, XSS_SMS_OPTION, XSS_TELEGRAM_OPTION } from '../src/xss-options'
+import {
+  XSS_EMAIL_OPTION,
+  XSS_SMS_OPTION,
+  XSS_TELEGRAM_OPTION,
+} from '../src/xss-options'
 
 describe('template', () => {
   let templateClient: TemplateClient
@@ -110,10 +114,12 @@ describe('template', () => {
       })
     })
     describe('telegram', () => {
-
-      const client: TemplateClient = new TemplateClient(XSS_TELEGRAM_OPTION, '\n')
+      const client: TemplateClient = new TemplateClient(
+        XSS_TELEGRAM_OPTION,
+        '\n'
+      )
       test('Telegram should support b i u s strike del p code pre a', () => {
-        const body = 
+        const body =
           '<b>bold</b>' +
           '<i>italic</i>' +
           '<u>underline</u>' +
@@ -160,7 +166,13 @@ describe('replaceNewLinesAndSanitize', () => {
       const body = '<a href="{{protectedlink}}">link</a>'
       expect(client.replaceNewLinesAndSanitize(body)).toEqual(body)
     })
-    
+
+    test('Should strip if href contains keyword with prohibited values', () => {
+      const body = '<a href="fakemailto:{{recipient}}">link</a>'
+      const expected = '<a href>link</a>'
+      expect(client.replaceNewLinesAndSanitize(body)).toEqual(expected)
+    })
+
     test('Should not sanitize keyword in a img src', () => {
       const body = '<img src="{{protectedimage}}">'
       expect(client.replaceNewLinesAndSanitize(body)).toEqual(body)

--- a/modules/postman-templating/test/template-client.test.ts
+++ b/modules/postman-templating/test/template-client.test.ts
@@ -1,7 +1,7 @@
 import { TemplateClient } from '../src/template-client'
 import { TemplateError } from '../src/errors'
 
-import { XssEmailOption, XssSmsOption, XssTelegramOption } from '../src/xss-options'
+import { XSS_EMAIL_OPTION, XSS_SMS_OPTION, XSS_TELEGRAM_OPTION } from '../src/xss-options'
 
 describe('template', () => {
   let templateClient: TemplateClient
@@ -60,7 +60,7 @@ describe('template', () => {
 
   describe('xss', () => {
     describe('email', () => {
-      const client: TemplateClient = new TemplateClient(XssEmailOption)
+      const client: TemplateClient = new TemplateClient(XSS_EMAIL_OPTION)
 
       test('email template should allow b, i, u, br, a, img tags', () => {
         const body =
@@ -90,7 +90,7 @@ describe('template', () => {
       })
     })
     describe('sms', () => {
-      const client: TemplateClient = new TemplateClient(XssSmsOption)
+      const client: TemplateClient = new TemplateClient(XSS_SMS_OPTION)
 
       test('sms template should not allow any html tags except br', () => {
         const body =
@@ -111,7 +111,7 @@ describe('template', () => {
     })
     describe('telegram', () => {
 
-      const client: TemplateClient = new TemplateClient(XssTelegramOption, '\n')
+      const client: TemplateClient = new TemplateClient(XSS_TELEGRAM_OPTION, '\n')
       test('Telegram should support b i u s strike del p code pre a', () => {
         const body = 
           '<b>bold</b>' +
@@ -154,7 +154,7 @@ describe('template', () => {
 
 describe('replaceNewLinesAndSanitize', () => {
   describe('email', () => {
-    const client: TemplateClient = new TemplateClient(XssEmailOption)
+    const client: TemplateClient = new TemplateClient(XSS_EMAIL_OPTION)
 
     test('Should not sanitize keyword in a href', () => {
       const body = '<a href="{{protectedlink}}">link</a>'
@@ -168,7 +168,7 @@ describe('replaceNewLinesAndSanitize', () => {
   })
 
   describe('telegram', () => {
-    const client: TemplateClient = new TemplateClient(XssTelegramOption)
+    const client: TemplateClient = new TemplateClient(XSS_TELEGRAM_OPTION)
 
     test('Should not sanitize tg:// telegram links', () => {
       const body = '<a href="tg://join?invite=">link</a>'

--- a/modules/postman-templating/test/template-client.test.ts
+++ b/modules/postman-templating/test/template-client.test.ts
@@ -62,6 +62,20 @@ describe('template', () => {
     })
   })
 
+  describe('parseTemplate variables', () => {
+    test('variables should be unique, lowercased and returned in order of appearance', () => {
+      const body = '{{ blah }} {{chip}}{{ BLAH}} {{chip}} {{F1sh}}'
+      const expected = ['blah', 'chip', 'f1sh']
+      expect(templateClient.parseTemplate(body).variables).toEqual(expected)
+    })
+
+    test('variables should return an empty array if no keywords', () => {
+      const body = 'fishpaste is good'
+      const expected: string[] = []
+      expect(templateClient.parseTemplate(body).variables).toEqual(expected)
+    })
+  })
+
   describe('xss', () => {
     describe('email', () => {
       const client: TemplateClient = new TemplateClient(XSS_EMAIL_OPTION)

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -801,11 +801,6 @@
         "text-hex": "1.0.x"
       }
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -878,11 +873,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "dayjs": {
       "version": "1.8.24",
@@ -9135,15 +9125,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xss": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
-      "integrity": "sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==",
-      "requires": {
-        "commander": "^2.9.0",
-        "cssfilter": "0.0.10"
-      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/worker/package.json
+++ b/worker/package.json
@@ -40,8 +40,7 @@
     "threads": "^1.4.0",
     "tiny-worker": "^2.3.0",
     "twilio": "^3.42.1",
-    "winston": "^3.2.1",
-    "xss": "^1.0.6"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.30",

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -5,7 +5,6 @@
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
-import xss from 'xss'
 
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 
@@ -187,53 +186,6 @@ const config = convict({
     default: '',
     env: 'BACKEND_URL',
     sensitive: true,
-  },
-  xssOptions: {
-    doc: 'List of html tags allowed',
-    default: {
-      email: {
-        whiteList: {
-          b: [],
-          i: [],
-          u: [],
-          br: [],
-          p: [],
-          a: ['href', 'title', 'target'],
-          img: ['src', 'alt', 'title', 'width', 'height'],
-        },
-        stripIgnoreTag: true,
-      },
-      sms: {
-        whiteList: { br: [] },
-        stripIgnoreTag: true,
-      },
-      telegram: {
-        whiteList: {
-          b: [],
-          i: [],
-          u: [],
-          s: [],
-          strike: [],
-          del: [],
-          p: [],
-          code: ['class'],
-          pre: [],
-          a: ['href'],
-        },
-        safeAttrValue: (
-          tag: string,
-          name: string,
-          value: string
-        ): string | void => {
-          // Handle Telegram mention as xss-js does not recognize it as a valid url.
-          if (tag === 'a' && name === 'href' && value.startsWith('tg://')) {
-            return value
-          }
-          return xss.safeAttrValue(tag, name, value, xss.cssFilter)
-        },
-        stripIgnoreTag: true,
-      },
-    },
   },
   messageWorker: {
     numSender: {

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -5,9 +5,9 @@ import map from 'lodash/map'
 import logger from '@core/logger'
 import config from '@core/config'
 import MailClient from '@email/services/mail-client.class'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssEmailOption } from 'postman-templating'
 
-const templateClient = new TemplateClient(config.get('xssOptions.email'))
+const templateClient = new TemplateClient(XssEmailOption)
 class Email {
   private workerId: string
   private connection: Sequelize

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -5,9 +5,9 @@ import map from 'lodash/map'
 import logger from '@core/logger'
 import config from '@core/config'
 import MailClient from '@email/services/mail-client.class'
-import { TemplateClient, XssEmailOption } from 'postman-templating'
+import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
 
-const templateClient = new TemplateClient(XssEmailOption)
+const templateClient = new TemplateClient(XSS_EMAIL_OPTION)
 class Email {
   private workerId: string
   private connection: Sequelize

--- a/worker/src/core/loaders/message-worker/sms.class.ts
+++ b/worker/src/core/loaders/message-worker/sms.class.ts
@@ -2,12 +2,11 @@ import { Sequelize } from 'sequelize-typescript'
 import { QueryTypes, Transaction } from 'sequelize'
 import map from 'lodash/map'
 import logger from '@core/logger'
-import config from '@core/config'
 import { CredentialService } from '@core/services/credential.service'
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssSmsOption } from 'postman-templating'
 import TwilioClient from '@sms/services/twilio-client.class'
 
-const templateClient = new TemplateClient(config.get('xssOptions.sms'))
+const templateClient = new TemplateClient(XssSmsOption)
 class SMS {
   private workerId: string
   private connection: Sequelize

--- a/worker/src/core/loaders/message-worker/sms.class.ts
+++ b/worker/src/core/loaders/message-worker/sms.class.ts
@@ -3,10 +3,10 @@ import { QueryTypes, Transaction } from 'sequelize'
 import map from 'lodash/map'
 import logger from '@core/logger'
 import { CredentialService } from '@core/services/credential.service'
-import { TemplateClient, XssSmsOption } from 'postman-templating'
+import { TemplateClient, XSS_SMS_OPTION } from 'postman-templating'
 import TwilioClient from '@sms/services/twilio-client.class'
 
-const templateClient = new TemplateClient(XssSmsOption)
+const templateClient = new TemplateClient(XSS_SMS_OPTION)
 class SMS {
   private workerId: string
   private connection: Sequelize

--- a/worker/src/core/loaders/message-worker/telegram.class.ts
+++ b/worker/src/core/loaders/message-worker/telegram.class.ts
@@ -2,12 +2,12 @@ import { Sequelize } from 'sequelize-typescript'
 import { QueryTypes, Transaction } from 'sequelize'
 import { map } from 'lodash'
 
-import { TemplateClient, XssTelegramOption } from 'postman-templating'
+import { TemplateClient, XSS_TELEGRAM_OPTION } from 'postman-templating'
 import logger from '@core/logger'
 import TelegramClient from '@telegram/services/telegram-client.class'
 import { CredentialService } from '@core/services/credential.service'
 
-const templateClient = new TemplateClient(XssTelegramOption)
+const templateClient = new TemplateClient(XSS_TELEGRAM_OPTION)
 
 class Telegram {
   private workerId: string

--- a/worker/src/core/loaders/message-worker/telegram.class.ts
+++ b/worker/src/core/loaders/message-worker/telegram.class.ts
@@ -2,13 +2,12 @@ import { Sequelize } from 'sequelize-typescript'
 import { QueryTypes, Transaction } from 'sequelize'
 import { map } from 'lodash'
 
-import { TemplateClient } from 'postman-templating'
+import { TemplateClient, XssTelegramOption } from 'postman-templating'
 import logger from '@core/logger'
 import TelegramClient from '@telegram/services/telegram-client.class'
 import { CredentialService } from '@core/services/credential.service'
-import config from '@core/config'
 
-const templateClient = new TemplateClient(config.get('xssOptions.telegram'))
+const templateClient = new TemplateClient(XssTelegramOption)
 
 class Telegram {
   private workerId: string


### PR DESCRIPTION
## Problem

Closes #532, #516 

## Solution

To use the xss options :
`import { TemplateClient, XssEmailOption } from 'postman-templating'`
`const client = new TemplateClient(XssEmailOption)`

Initially we installed `xss` on backend and worker to use the default `safeAttrValue` from `xss`, now that we moved the options into postman-templating we can uninstall `xss`.