### PR TITLE
fix: Unhandled promise rejection in multipart upload

### DIFF
--- a/frontend/src/services/protect-csv.service.ts
+++ b/frontend/src/services/protect-csv.service.ts
@@ -106,25 +106,34 @@ export async function protectAndUploadCsv(
         const rows = chunk.data
 
         // transform into rows of data into {recipient,payload,passwordHash,id}
-        const data = await transformRows(template, rows, partNumber)
+        try {
+          const data = await transformRows(template, rows, partNumber)
 
-        // Upload the single string onto s3 based through the presigned url
-        const etag = await uploadPartWithPresignedUrl({
-          presignedUrl: presignedUrls[partNumber - 1],
-          data,
-        })
-        etags.push(etag)
+          // Upload the single string onto s3 based through the presigned url
+          const etag = await uploadPartWithPresignedUrl({
+            presignedUrl: presignedUrls[partNumber - 1],
+            data,
+          })
+          etags.push(etag)
+        } catch (e) {
+          reject(e)
+        }
+
         parser.resume()
       },
       complete: async function () {
-        await completeMultiPartUpload({
-          campaignId,
-          filename: file.name,
-          transactionId,
-          partCount: partNumber,
-          etags,
-        })
-        resolve()
+        try {
+          await completeMultiPartUpload({
+            campaignId,
+            filename: file.name,
+            transactionId,
+            partCount: partNumber,
+            etags,
+          })
+          resolve()
+        } catch (e) {
+          reject(e)
+        }
       },
       error: reject,
     })

--- a/frontend/src/services/upload.service.ts
+++ b/frontend/src/services/upload.service.ts
@@ -216,16 +216,20 @@ export async function uploadPartWithPresignedUrl({
   presignedUrl: string
   data: string[]
 }): Promise<string> {
-  const contentType = 'text/csv'
-  const response = await axios.put(
-    presignedUrl,
-    new Blob(data, { type: contentType }),
-    {
-      withCredentials: false,
-      timeout: 0,
-    }
-  )
-  return response.headers.etag
+  try {
+    const contentType = 'text/csv'
+    const response = await axios.put(
+      presignedUrl,
+      new Blob(data, { type: contentType }),
+      {
+        withCredentials: false,
+        timeout: 0,
+      }
+    )
+    return response.headers.etag
+  } catch (e) {
+    errorHandler(e, 'Error uploading part with presigned url')
+  }
 }
 
 export async function completeMultiPartUpload({


### PR DESCRIPTION
## Problem

Unhandled promise rejections in `protectAndUploadCsv` causes browser to crash.

## Solution

I don't completely understand what is going on; it seems like within a Promise if any of the code throws an error and it is not handled by the Promise, it will be dealt as any other uncaught errors by the JS engine.

## Before & After Screenshots

**BEFORE**:
![uncaught_error](https://user-images.githubusercontent.com/33112945/87621457-6f324580-c753-11ea-92a9-e929965cb40a.gif)


**AFTER**:
![recording (6)](https://user-images.githubusercontent.com/33112945/87621633-cd5f2880-c753-11ea-81b3-9dbad81f5589.gif)

