### PR TITLE
chore: support underscore for keywords in template

### DIFF
--- a/modules/postman-templating/src/template-client.ts
+++ b/modules/postman-templating/src/template-client.ts
@@ -93,11 +93,11 @@ export class TemplateClient {
             )
           }
 
-          // only allow alphanumeric template, prevents code execution
-          const keyHasValidChars = key.match(/[^a-zA-Z0-9]/) === null
+          // only allow alphanumeric, underscore template, prevents code execution
+          const keyHasValidChars = key.match(/[^a-zA-Z0-9\_]/) === null
           if (!keyHasValidChars) {
             throw new TemplateError(
-              `Invalid characters in the keyword: {{${key}}}.\nCheck that the keywords only contain letters and numbers.\nKeywords like {{ Person_Name }} are not allowed, but {{ PersonName }} is allowed.`
+              `Invalid characters in the keyword: {{${key}}}.\nCheck that the keywords only contain letters, numbers and underscore.\nKeywords like {{ Person-Name }} are not allowed, but {{ Person_Name }} is allowed.`
             )
           }
 
@@ -139,7 +139,7 @@ export class TemplateClient {
         )
       if (err.message.includes('unclosed string'))
         throw new TemplateError(
-          "Check that the keywords only contain letters and numbers.\nKeywords like {{ Person's Name }} are not allowed, but {{ PersonsName }} is allowed."
+          "Check that the keywords only contain letters, numbers and underscore.\nKeywords like {{ Person's Name }} are not allowed, but {{ Person_Name }} is allowed."
         )
       if (err.name === 'Squirrelly Error') throw new TemplateError(err.message)
       throw err

--- a/modules/postman-templating/src/template-client.ts
+++ b/modules/postman-templating/src/template-client.ts
@@ -94,7 +94,7 @@ export class TemplateClient {
           }
 
           // only allow alphanumeric, underscore template, prevents code execution
-          const keyHasValidChars = key.match(/[^a-zA-Z0-9\_]/) === null
+          const keyHasValidChars = key.match(/\W/) === null
           if (!keyHasValidChars) {
             throw new TemplateError(
               `Invalid characters in the keyword: {{${key}}}.\nCheck that the keywords only contain letters, numbers and underscore.\nKeywords like {{ Person-Name }} are not allowed, but {{ Person_Name }} is allowed.`

--- a/modules/postman-templating/test/template-client.test.ts
+++ b/modules/postman-templating/test/template-client.test.ts
@@ -30,6 +30,13 @@ describe('template', () => {
       const body = 'Hello {{name}}'
       expect(templateClient.template(body, params)).toEqual('Hello ')
     })
+
+    test('supports underscore in keyword', () => {
+      const params = {postal_cd: '123456'}
+      const body = 'Your postal code: {{postal_cd}}'
+      expect(templateClient.template(body, params))
+        .toEqual('Your postal code: 123456')
+    })
   })
 
   describe('parsing errors', () => {


### PR DESCRIPTION
## Problem

Closes #566 

## Solution

Add underscore to the the regex that is validating the template keys.

## After Screenshot

**AFTER**:
![recording (8)](https://user-images.githubusercontent.com/33112945/87639593-0a3d1680-c778-11ea-9e43-c9afdd75f09a.gif)
