### PR TITLE
chore: Convert params into lowercase when looking for missing keys

### DIFF
--- a/frontend/src/services/validate-csv.service.ts
+++ b/frontend/src/services/validate-csv.service.ts
@@ -84,7 +84,8 @@ function validateRow(
   requiredParams: Array<string>,
   recipientValidator: Function
 ): boolean {
-  const missingParams = difference(requiredParams, keys(row))
+  const params = keys(row).map((key) => key.toLowerCase())
+  const missingParams = difference(requiredParams, params)
   if (missingParams.length) {
     throw new Error(`Missing params: ${missingParams.join(',')}`)
   }


### PR DESCRIPTION
## Problem

Closes #565

## Solution

Turns all the params into lowercase before looking for the missing params. 

Although this solution solves the problem, a better solution would be for `postman-templating` module to retain the original value of the params instead of converting them into lowercase. However, this probably requires alot more work and I'm not sure if it's worth it.

![recording (9)](https://user-images.githubusercontent.com/33112945/87648749-7b81c700-c782-11ea-882d-4d83becac1b0.gif)
