### PR TITLE
feature: Normalise SMS phone numbers with libphonenumber-js

### DIFF
--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -152,11 +152,11 @@ const uploadCompleteHandler = async (
       smsTemplate.params as string[]
     )
 
-    await SmsTemplateService.testHydration(records, smsTemplate.body as string)
+    SmsTemplateService.testHydration(records, smsTemplate.body as string)
 
-    if (SmsTemplateService.hasInvalidSmsRecipient(records)) {
-      throw new InvalidRecipientError()
-    }
+    // Append default country code as telegram handler stores number with the country
+    // code by default.
+    const formattedRecords = SmsTemplateService.validateAndFormatNumber(records)
 
     // Store temp filename
     await UploadService.storeS3TempFilename(+campaignId, filename)
@@ -166,7 +166,12 @@ const uploadCompleteHandler = async (
       res.sendStatus(202)
 
       // Slow bulk insert
-      await updateCampaignAndMessages(+campaignId, s3Key, filename, records)
+      await updateCampaignAndMessages(
+        +campaignId,
+        s3Key,
+        filename,
+        formattedRecords
+      )
     } catch (err) {
       // Do not return any response since it has already been sent
       logger.error(

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -235,16 +235,19 @@ const validateAndFormatNumber = (
   records: MessageBulkInsertInterface[]
 ): MessageBulkInsertInterface[] => {
   return records.map((record) => {
-    const { recipient } = record
     try {
-      record.recipient = PhoneNumberService.normalisePhoneNumber(
+      const { recipient } = record
+      const normalised = PhoneNumberService.normalisePhoneNumber(
         recipient,
         config.get('defaultCountry')
       )
+      return {
+        ...record,
+        recipient: normalised,
+      }
     } catch (e) {
       throw new InvalidRecipientError()
     }
-    return record
   })
 }
 

--- a/backend/src/sms/services/sms.service.ts
+++ b/backend/src/sms/services/sms.service.ts
@@ -10,6 +10,7 @@ import { CampaignService } from '@core/services'
 import { SmsMessage, SmsTemplate } from '@sms/models'
 import { SmsTemplateService } from '@sms/services'
 import { TwilioCredentials } from '@sms/interfaces'
+import { PhoneNumberService } from '@core/services'
 
 import TwilioClient from './twilio-client.class'
 
@@ -64,6 +65,10 @@ const sendCampaignMessage = async (
   if (!msg) throw new Error('No message to send')
 
   const twilioService = new TwilioClient(credential)
+  recipient = PhoneNumberService.normalisePhoneNumber(
+    recipient,
+    config.get('defaultCountry')
+  )
   return twilioService.send(recipient, msg?.body)
 }
 
@@ -77,6 +82,10 @@ const sendValidationMessage = async (
   credential: TwilioCredentials
 ): Promise<string | void> => {
   const twilioService = new TwilioClient(credential)
+  recipient = PhoneNumberService.normalisePhoneNumber(
+    recipient,
+    config.get('defaultCountry')
+  )
   return twilioService.send(
     recipient,
     'Your Twilio credential has been validated.'

--- a/backend/src/sms/services/twilio-client.class.ts
+++ b/backend/src/sms/services/twilio-client.class.ts
@@ -1,5 +1,4 @@
 import twilio from 'twilio'
-import config from '@core/config'
 import { TwilioCredentials } from '@sms/interfaces'
 
 export default class TwilioClient {
@@ -15,7 +14,7 @@ export default class TwilioClient {
   public send(recipient: string, message: string): Promise<string | void> {
     return this.client.messages
       .create({
-        to: this.addDefaultCountryCode(recipient),
+        to: recipient,
         body: this.replaceNewLines(message),
         from: this.messagingServiceSid,
       })
@@ -31,17 +30,6 @@ export default class TwilioClient {
           return Promise.reject(new Error(`${status};Unknown error`))
         }
       })
-  }
-
-  /**
-   * Add a default country code if the recipient does not contain one
-   * @param recipient
-   */
-  private addDefaultCountryCode(recipient: string): string {
-    if (!recipient.startsWith('+') && config.get('defaultCountryCode')) {
-      return `+${config.get('defaultCountryCode')}${recipient}`
-    }
-    return recipient
   }
 
   /**

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -211,16 +211,19 @@ const validateAndFormatNumber = (
   records: MessageBulkInsertInterface[]
 ): MessageBulkInsertInterface[] => {
   return records.map((record) => {
-    const { recipient } = record
     try {
-      record.recipient = PhoneNumberService.normalisePhoneNumber(
+      const { recipient } = record
+      const normalised = PhoneNumberService.normalisePhoneNumber(
         recipient,
         config.get('defaultCountry')
       )
+      return {
+        ...record,
+        recipient: normalised,
+      }
     } catch (e) {
       throw new InvalidRecipientError()
     }
-    return record
   })
 }
 

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -1,11 +1,10 @@
 import { chunk, difference, keys } from 'lodash'
 import { Transaction } from 'sequelize'
 
-import { InvalidRecipientError } from '@core/errors'
 import config from '@core/config'
 import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
-import { HydrationError } from '@core/errors'
+import { InvalidRecipientError, HydrationError } from '@core/errors'
 import { Campaign } from '@core/models'
 import { PhoneNumberService } from '@core/services'
 import { TemplateClient, XSS_TELEGRAM_OPTION } from 'postman-templating'

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -138,11 +138,6 @@ const config = convict({
     default: '',
     env: 'SES_FROM',
   },
-  defaultCountryCode: {
-    doc: 'Country code to prepend to phone numbers',
-    default: '65',
-    env: 'DEFAULT_COUNTRY_CODE',
-  },
   smsOptions: {
     accountSid: {
       doc: 'Id of the Twilio account',

--- a/worker/src/sms/services/twilio-client.class.ts
+++ b/worker/src/sms/services/twilio-client.class.ts
@@ -32,7 +32,7 @@ export default class TwilioClient {
     return this.generateStatusCallbackUrl(messageId, campaignId)
       .then((callbackUrl) => {
         return this.client.messages.create({
-          to: this.addDefaultCountryCode(recipient),
+          to: recipient,
           body: this.replaceNewLines(message),
           from: this.messagingServiceSid,
           ...(callbackUrl ? { statusCallback: callbackUrl } : {}),
@@ -73,13 +73,6 @@ export default class TwilioClient {
     callbackUrl.pathname = `${callbackUrl.pathname}/campaign/${campaignId}/message/${messageId}`
     logger.info(`Status callback url for ${messageId}: ${callbackUrl}`)
     return callbackUrl.toString()
-  }
-
-  private addDefaultCountryCode(recipient: string): string {
-    if (!recipient.startsWith('+') && config.get('defaultCountryCode')) {
-      return `+${config.get('defaultCountryCode')}${recipient}`
-    }
-    return recipient
   }
 
   private replaceNewLines(body: string): string {


### PR DESCRIPTION
## Problem

Closes #546 

## Solution
- Uses `PhoneNumberService` to normalise phone numbers before insertion into messages table (similar to Telegram)
- Remove appending of country code in `TwilioClient` for both `backend` and `worker`

## Tests
1. Run unit tests added in previous PR to confirm the validation and normalisation logic
2. Create an SMS campaign with the following recipients:
```
recipient
91234567
14128018888
+8613910998888
6580123456
```
3. Check in `sms_messages` table that all the messages should be normalised  
4. Upload a recipient list with the following numbers. Each of them should raise an error.
```
recipient
612345678   (Invalid length)
8123456     (Invalid length)
11234567    (Number not starting with 6, 8 or 9) 
```

## Deploy Notes
- Deploy workers after merge
- Removed `DEFAULT_COUNTRY_CODE` environment variable in `worker` config