### PR TITLE
Protected error msg fix

### DIFF
--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -82,9 +82,9 @@ const verifyPasswordHash = async (
       passwordHash
     )
     if (!protectedMessage) {
-      // Return unauthorized if nothing retrieved from db
+      // Return 403 if nothing retrieved from db
       return res
-        .status(401)
+        .status(403)
         .json({ message: 'Wrong password or message id. Please try again.' })
     }
     return res.json({ payload: protectedMessage.payload })

--- a/backend/src/core/routes/protected.routes.ts
+++ b/backend/src/core/routes/protected.routes.ts
@@ -42,7 +42,7 @@ const protectVerifyValidator = {
  *                properties:
  *                 payload:
  *                  type: string
- *         "401":
+ *         "403":
  *           description: Wrong password or message id
  *         "500":
  *           description: Internal Server Error

--- a/frontend/src/services/decrypt-mail.service.ts
+++ b/frontend/src/services/decrypt-mail.service.ts
@@ -31,16 +31,12 @@ async function getEncryptedPayload(
     })
     return response.data.payload
   } catch (e) {
-    errorHandler(e, 'Unable to fetch protected message.')
+    errorHandler(e, 'Please try again later.')
   }
 }
 
 function errorHandler(e: AxiosError, defaultMsg: string): never {
   console.error(e)
-  if (e.response?.status === 429) {
-    // Rate limited
-    throw new Error('Attempts exceeded. Please try again later.')
-  }
   if (e.response && e.response.data && e.response.data.message) {
     throw new Error(e.response.data.message)
   }


### PR DESCRIPTION
## Problem

401 logs users out of postman. Error message from 429 not showing due to CORS.

## Solution

Returning 403 instead of 401. 

Unable to read status code 429 from cloudflare as cors header not sent with response. Generic error message 'Please try again later.' shown on all any network errors (includes rate limit or disconnected).