### PR TITLE
Fix/update stats

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -59,6 +59,7 @@ export interface CampaignStatsCount {
   unsent: number
   sent: number
   invalid: number
+  updatedAt?: Date
 }
 
 export interface CampaignInvalidRecipient {

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -246,4 +246,5 @@ export const StatsService = {
   getNumRecipients,
   setNumRecipients,
   getFailedRecipients,
+  updateStats,
 }

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -250,6 +250,7 @@ const getFailedRecipients = async (
   campaignId: number,
   logsTable: any
 ): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+  await updateStats(+campaignId)
   const data = await logsTable.findAll({
     raw: true,
     where: {

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -8,6 +8,19 @@ import {
 import { MessageStatus, ChannelType } from '@core/constants'
 import logger from '@core/logger'
 
+import bluebird from 'bluebird'
+
+const getUnfinalisedCampaigns = async (): Promise<Array<number>> => {
+  const result = await Statistic.sequelize?.query(`
+      SELECT id FROM campaigns WHERE id NOT IN (
+        SELECT DISTINCT(campaign_id) FROM email_messages
+        WHERE
+          updated_at::TIMESTAMP > (clock_timestamp() - '36 hours'::INTERVAL)
+          AND status IS NOT NULL
+      ) AND halted <> TRUE;`)
+  return result?.[0].map((r: any) => r.id as number) || []
+}
+
 /**
  * Calls update_stats SQL function for respective channels.
  * fails silently
@@ -18,6 +31,9 @@ const updateStats = async (campaignId: number): Promise<void> => {
     where: { id: campaignId },
   })
   if (!campaign) return
+
+  logger.info(`updateStats invoked for campaign ${campaignId}`)
+
   switch (campaign.type) {
     case ChannelType.Email: {
       await Statistic.sequelize?.query(
@@ -53,6 +69,19 @@ const updateStats = async (campaignId: number): Promise<void> => {
       logger.error(`Invalid channel type found for campaign ${campaignId}`)
     }
   }
+}
+
+const consolidateStats = async (): Promise<void> => {
+  const campaigns = await getUnfinalisedCampaigns()
+  await bluebird.map(
+    campaigns,
+    (campaign) => {
+      return updateStats(campaign)
+    },
+    {
+      concurrency: 5,
+    }
+  )
 }
 
 /**
@@ -237,6 +266,7 @@ const getFailedRecipients = async (
 }
 
 export const StatsService = {
+  consolidateStats,
   getCurrentStats,
   getTotalSentCount,
   getNumRecipients,

--- a/backend/src/email/middlewares/email-stats.middleware.ts
+++ b/backend/src/email/middlewares/email-stats.middleware.ts
@@ -12,9 +12,29 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
-  const { refresh } = req.query
   try {
-    const stats = await EmailStatsService.getStats(+campaignId, refresh)
+    const stats = await EmailStatsService.getStats(+campaignId)
+    return res.json(stats)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Forcibly refresh stats for campaign, then retrieves them
+ * @param req
+ * @param res
+ * @param next
+ */
+const updateAndGetStats = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  const { campaignId } = req.params
+  try {
+    await EmailStatsService.refreshStats(+campaignId)
+    const stats = await EmailStatsService.getStats(+campaignId)
     return res.json(stats)
   } catch (err) {
     next(err)
@@ -44,4 +64,5 @@ const getFailedRecipients = async (
 export const EmailStatsMiddleware = {
   getStats,
   getFailedRecipients,
+  updateAndGetStats,
 }

--- a/backend/src/email/middlewares/email-stats.middleware.ts
+++ b/backend/src/email/middlewares/email-stats.middleware.ts
@@ -12,8 +12,9 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
+  const { refresh } = req.query
   try {
-    const stats = await EmailStatsService.getStats(+campaignId)
+    const stats = await EmailStatsService.getStats(+campaignId, refresh)
     return res.json(stats)
   } catch (err) {
     next(err)

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -74,12 +74,6 @@ const completeMultipartValidator = {
   }),
 }
 
-const statsValidator = {
-  [Segments.QUERY]: Joi.object({
-    refresh: Joi.boolean().default(false),
-  }),
-}
-
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -570,10 +564,6 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
- *        - name: refresh
- *          in: query
- *          schema:
- *            type: boolean
  *
  *      responses:
  *        200:
@@ -586,7 +576,35 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/stats', celebrate(statsValidator), EmailStatsMiddleware.getStats)
+router.get('/stats', EmailStatsMiddleware.getStats)
+
+/**
+ * @swagger
+ * path:
+ *  /campaign/{campaignId}/email/refresh-stats:
+ *    post:
+ *      tags:
+ *        - Email
+ *      summary: Get email campaign stats
+ *      parameters:
+ *        - name: campaignId
+ *          in: path
+ *          required: true
+ *          schema:
+ *            type: string
+ *
+ *      responses:
+ *        200:
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/CampaignStats'
+ *        "401":
+ *           description: Unauthorized
+ *        "500":
+ *           description: Internal Server Error
+ */
+router.post('/refresh-stats', EmailStatsMiddleware.updateAndGetStats)
 
 /**
  * @swagger

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -74,6 +74,12 @@ const completeMultipartValidator = {
   }),
 }
 
+const statsValidator = {
+  [Segments.QUERY]: Joi.object({
+    refresh: Joi.boolean().default(false),
+  }),
+}
+
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -564,6 +570,10 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
+ *        - name: refresh
+ *          in: query
+ *          schema:
+ *            type: boolean
  *
  *      responses:
  *        200:
@@ -576,7 +586,7 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/stats', EmailStatsMiddleware.getStats)
+router.get('/stats', celebrate(statsValidator), EmailStatsMiddleware.getStats)
 
 /**
  * @swagger

--- a/backend/src/email/services/email-stats.service.ts
+++ b/backend/src/email/services/email-stats.service.ts
@@ -1,3 +1,6 @@
+import { QueryTypes } from 'sequelize'
+
+import logger from '@core/logger'
 import { StatsService } from '@core/services'
 import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
 
@@ -16,7 +19,15 @@ const getStats = (campaignId: number): Promise<CampaignStats> => {
  * @param campaignId
  */
 const refreshStats = async (campaignId: number): Promise<void> => {
-  return StatsService.updateStats(campaignId)
+  logger.info(`updateStats invoked for campaign ${campaignId}`)
+
+  await EmailMessage.sequelize?.query(
+    'SELECT update_stats_email(:campaign_id)',
+    {
+      replacements: { campaign_id: campaignId },
+      type: QueryTypes.SELECT,
+    }
+  )
 }
 
 /**
@@ -26,6 +37,7 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 const getFailedRecipients = async (
   campaignId: number
 ): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+  await refreshStats(+campaignId)
   return StatsService.getFailedRecipients(campaignId, EmailMessage)
 }
 

--- a/backend/src/email/services/email-stats.service.ts
+++ b/backend/src/email/services/email-stats.service.ts
@@ -7,8 +7,11 @@ import { EmailOp, EmailMessage } from '@email/models'
  * Gets stats for email project
  * @param campaignId
  */
-const getStats = async (campaignId: number): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, EmailOp)
+const getStats = (
+  campaignId: number,
+  refresh: boolean
+): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, EmailOp, refresh)
 }
 
 /**

--- a/backend/src/email/services/email-stats.service.ts
+++ b/backend/src/email/services/email-stats.service.ts
@@ -7,11 +7,16 @@ import { EmailOp, EmailMessage } from '@email/models'
  * Gets stats for email project
  * @param campaignId
  */
-const getStats = (
-  campaignId: number,
-  refresh: boolean
-): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, EmailOp, refresh)
+const getStats = (campaignId: number): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, EmailOp)
+}
+
+/**
+ * Forcibly updates stats from email_messages table
+ * @param campaignId
+ */
+const refreshStats = async (campaignId: number): Promise<void> => {
+  return StatsService.updateStats(campaignId)
 }
 
 /**
@@ -27,4 +32,5 @@ const getFailedRecipients = async (
 export const EmailStatsService = {
   getStats,
   getFailedRecipients,
+  refreshStats,
 }

--- a/backend/src/sms/middlewares/sms-stats.middleware.ts
+++ b/backend/src/sms/middlewares/sms-stats.middleware.ts
@@ -12,8 +12,9 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
+  const { refresh } = req.query
   try {
-    const stats = await SmsStatsService.getStats(+campaignId)
+    const stats = await SmsStatsService.getStats(+campaignId, refresh)
     return res.json(stats)
   } catch (err) {
     next(err)

--- a/backend/src/sms/middlewares/sms-stats.middleware.ts
+++ b/backend/src/sms/middlewares/sms-stats.middleware.ts
@@ -12,9 +12,29 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
-  const { refresh } = req.query
   try {
-    const stats = await SmsStatsService.getStats(+campaignId, refresh)
+    const stats = await SmsStatsService.getStats(+campaignId)
+    return res.json(stats)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Forcibly refresh stats for campaign, then retrieves them
+ * @param req
+ * @param res
+ * @param next
+ */
+const updateAndGetStats = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  const { campaignId } = req.params
+  try {
+    await SmsStatsService.refreshStats(+campaignId)
+    const stats = await SmsStatsService.getStats(+campaignId)
     return res.json(stats)
   } catch (err) {
     next(err)
@@ -44,4 +64,5 @@ const getFailedRecipients = async (
 export const SmsStatsMiddleware = {
   getStats,
   getFailedRecipients,
+  updateAndGetStats,
 }

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -56,6 +56,12 @@ const sendCampaignValidator = {
   }),
 }
 
+const statsValidator = {
+  [Segments.QUERY]: Joi.object({
+    refresh: Joi.boolean().default(false),
+  }),
+}
+
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -599,6 +605,10 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
+ *        - name: refresh
+ *          in: query
+ *          schema:
+ *            type: boolean
  *
  *      responses:
  *        200:
@@ -613,7 +623,7 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/stats', SmsStatsMiddleware.getStats)
+router.get('/stats', celebrate(statsValidator), SmsStatsMiddleware.getStats)
 
 /**
  * @swagger

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -56,12 +56,6 @@ const sendCampaignValidator = {
   }),
 }
 
-const statsValidator = {
-  [Segments.QUERY]: Joi.object({
-    refresh: Joi.boolean().default(false),
-  }),
-}
-
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -605,10 +599,6 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
- *        - name: refresh
- *          in: query
- *          schema:
- *            type: boolean
  *
  *      responses:
  *        200:
@@ -623,7 +613,37 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/stats', celebrate(statsValidator), SmsStatsMiddleware.getStats)
+router.get('/stats', SmsStatsMiddleware.getStats)
+
+/**
+ * @swagger
+ * path:
+ *  /campaign/{campaignId}/sms/refresh-stats:
+ *    post:
+ *      tags:
+ *        - SMS
+ *      summary: Forcibly refresh sms campaign stats, then retrieves them
+ *      parameters:
+ *        - name: campaignId
+ *          in: path
+ *          required: true
+ *          schema:
+ *            type: string
+ *
+ *      responses:
+ *        200:
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/CampaignStats'
+ *        "401":
+ *           description: Unauthorized
+ *        "403":
+ *           description: Forbidden, campaign not owned by user
+ *        "500":
+ *           description: Internal Server Error
+ */
+router.post('/refresh-stats', SmsStatsMiddleware.updateAndGetStats)
 
 /**
  * @swagger

--- a/backend/src/sms/services/sms-stats.service.ts
+++ b/backend/src/sms/services/sms-stats.service.ts
@@ -7,8 +7,11 @@ import { SmsOp, SmsMessage } from '@sms/models'
  * Gets stats for sms project
  * @param campaignId
  */
-const getStats = async (campaignId: number): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, SmsOp)
+const getStats = async (
+  campaignId: number,
+  refresh: boolean
+): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, SmsOp, refresh)
 }
 
 /**

--- a/backend/src/sms/services/sms-stats.service.ts
+++ b/backend/src/sms/services/sms-stats.service.ts
@@ -7,11 +7,16 @@ import { SmsOp, SmsMessage } from '@sms/models'
  * Gets stats for sms project
  * @param campaignId
  */
-const getStats = async (
-  campaignId: number,
-  refresh: boolean
-): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, SmsOp, refresh)
+const getStats = async (campaignId: number): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, SmsOp)
+}
+
+/**
+ * Forcibly updates stats from sms_messages table
+ * @param campaignId
+ */
+const refreshStats = async (campaignId: number): Promise<void> => {
+  return StatsService.updateStats(campaignId)
 }
 
 /**
@@ -27,4 +32,5 @@ const getFailedRecipients = async (
 export const SmsStatsService = {
   getStats,
   getFailedRecipients,
+  refreshStats,
 }

--- a/backend/src/sms/services/sms-stats.service.ts
+++ b/backend/src/sms/services/sms-stats.service.ts
@@ -1,3 +1,6 @@
+import { QueryTypes } from 'sequelize'
+
+import logger from '@core/logger'
 import { StatsService } from '@core/services'
 import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
 
@@ -16,7 +19,12 @@ const getStats = async (campaignId: number): Promise<CampaignStats> => {
  * @param campaignId
  */
 const refreshStats = async (campaignId: number): Promise<void> => {
-  return StatsService.updateStats(campaignId)
+  logger.info(`updateStats invoked for campaign ${campaignId}`)
+
+  await SmsMessage.sequelize?.query('SELECT update_stats_sms(:campaign_id)', {
+    replacements: { campaign_id: campaignId },
+    type: QueryTypes.SELECT,
+  })
 }
 
 /**
@@ -26,6 +34,7 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 const getFailedRecipients = async (
   campaignId: number
 ): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+  await refreshStats(+campaignId)
   return StatsService.getFailedRecipients(campaignId, SmsMessage)
 }
 

--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -12,9 +12,29 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
-  const { refresh } = req.query
   try {
-    const stats = await TelegramStatsService.getStats(+campaignId, refresh)
+    const stats = await TelegramStatsService.getStats(+campaignId)
+    return res.json(stats)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Forcibly refresh stats for campaign, then retrieves them
+ * @param req
+ * @param res
+ * @param next
+ */
+const updateAndGetStats = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  const { campaignId } = req.params
+  try {
+    await TelegramStatsService.refreshStats(+campaignId)
+    const stats = await TelegramStatsService.getStats(+campaignId)
     return res.json(stats)
   } catch (err) {
     next(err)
@@ -46,4 +66,5 @@ const getFailedRecipients = async (
 export const TelegramStatsMiddleware = {
   getStats,
   getFailedRecipients,
+  updateAndGetStats,
 }

--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -12,8 +12,9 @@ const getStats = async (
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
+  const { refresh } = req.query
   try {
-    const stats = await TelegramStatsService.getStats(+campaignId)
+    const stats = await TelegramStatsService.getStats(+campaignId, refresh)
     return res.json(stats)
   } catch (err) {
     next(err)

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -56,12 +56,6 @@ const sendCampaignValidator = {
   }),
 }
 
-const statsValidator = {
-  [Segments.QUERY]: Joi.object({
-    refresh: Joi.boolean().default(false),
-  }),
-}
-
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -666,10 +660,6 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
- *        - name: refresh
- *          in: query
- *          schema:
- *            type: boolean
  *
  *      responses:
  *        200:
@@ -684,11 +674,37 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get(
-  '/stats',
-  celebrate(statsValidator),
-  TelegramStatsMiddleware.getStats
-)
+router.get('/stats', TelegramStatsMiddleware.getStats)
+
+/**
+ * @swagger
+ * path:
+ *  /campaign/{campaignId}/telegram/update-stats:
+ *    post:
+ *      tags:
+ *        - Telegram
+ *      summary: Get telegram campaign stats
+ *      parameters:
+ *        - name: campaignId
+ *          in: path
+ *          required: true
+ *          schema:
+ *            type: string
+ *
+ *      responses:
+ *        200:
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/CampaignStats'
+ *        "401":
+ *           description: Unauthorized
+ *        "403":
+ *           description: Forbidden, campaign not owned by user
+ *        "500":
+ *           description: Internal Server Error
+ */
+router.post('/refresh-stats', TelegramStatsMiddleware.updateAndGetStats)
 
 /**
  * @swagger

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -56,6 +56,12 @@ const sendCampaignValidator = {
   }),
 }
 
+const statsValidator = {
+  [Segments.QUERY]: Joi.object({
+    refresh: Joi.boolean().default(false),
+  }),
+}
+
 // Routes
 
 // Check if campaign belongs to user for this router
@@ -660,6 +666,10 @@ router.post(
  *          required: true
  *          schema:
  *            type: string
+ *        - name: refresh
+ *          in: query
+ *          schema:
+ *            type: boolean
  *
  *      responses:
  *        200:
@@ -674,7 +684,11 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/stats', TelegramStatsMiddleware.getStats)
+router.get(
+  '/stats',
+  celebrate(statsValidator),
+  TelegramStatsMiddleware.getStats
+)
 
 /**
  * @swagger

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -7,11 +7,16 @@ import { TelegramOp, TelegramMessage } from '@telegram/models'
  * Gets stats for telegram project
  * @param campaignId
  */
-const getStats = async (
-  campaignId: number,
-  refresh: boolean
-): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, TelegramOp, refresh)
+const getStats = async (campaignId: number): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, TelegramOp)
+}
+
+/**
+ * Forcibly updates stats from telegram_messages table
+ * @param campaignId
+ */
+const refreshStats = async (campaignId: number): Promise<void> => {
+  return StatsService.updateStats(campaignId)
 }
 
 /**
@@ -27,4 +32,5 @@ const getFailedRecipients = async (
 export const TelegramStatsService = {
   getStats,
   getFailedRecipients,
+  refreshStats,
 }

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -1,3 +1,5 @@
+import { QueryTypes } from 'sequelize'
+import logger from '@core/logger'
 import { StatsService } from '@core/services'
 import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
 
@@ -16,7 +18,15 @@ const getStats = async (campaignId: number): Promise<CampaignStats> => {
  * @param campaignId
  */
 const refreshStats = async (campaignId: number): Promise<void> => {
-  return StatsService.updateStats(campaignId)
+  logger.info(`updateStats invoked for campaign ${campaignId}`)
+
+  await TelegramMessage.sequelize?.query(
+    'SELECT update_stats_telegram(:campaign_id)',
+    {
+      replacements: { campaign_id: campaignId },
+      type: QueryTypes.SELECT,
+    }
+  )
 }
 
 /**
@@ -26,6 +36,7 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 const getFailedRecipients = async (
   campaignId: number
 ): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+  await refreshStats(+campaignId)
   return StatsService.getFailedRecipients(campaignId, TelegramMessage)
 }
 

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -7,8 +7,11 @@ import { TelegramOp, TelegramMessage } from '@telegram/models'
  * Gets stats for telegram project
  * @param campaignId
  */
-const getStats = async (campaignId: number): Promise<CampaignStats> => {
-  return StatsService.getCurrentStats(campaignId, TelegramOp)
+const getStats = async (
+  campaignId: number,
+  refresh: boolean
+): Promise<CampaignStats> => {
+  return StatsService.getCurrentStats(campaignId, TelegramOp, refresh)
 }
 
 /**

--- a/frontend/build.sh
+++ b/frontend/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e 
+
+CI=false && npm run build

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -80,6 +80,11 @@
   }
 }
 
+.statsLastUpdated {
+  @include flex-horizontal;
+  justify-content: space-between;
+}
+
 .actionButton {
   @include flex-horizontal;
   justify-content: flex-end;

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -24,6 +24,7 @@ const ProgressDetails = ({
   stats,
   handlePause,
   handleRetry,
+  handleRefreshStats,
 }: {
   campaignId: number
   campaignName: string
@@ -32,6 +33,7 @@ const ProgressDetails = ({
   stats: CampaignStats
   handlePause: () => Promise<void>
   handleRetry: () => Promise<void>
+  handleRefreshStats: () => Promise<void>
 }) => {
   const { status, error, unsent, sent, invalid, updatedAt, halted } = stats
   const [isSent, setIsSent] = useState(status === Status.Sent)
@@ -124,7 +126,6 @@ const ProgressDetails = ({
           </tr>
         </tbody>
       </table>
-
       <div className={styles.progressTitle}>
         {renderProgressTitle()}
         {renderButton()}
@@ -158,7 +159,6 @@ const ProgressDetails = ({
           </ActionButton>
         </div>
       )}
-
       <table className={styles.stats}>
         <thead>
           <tr>
@@ -210,6 +210,16 @@ const ProgressDetails = ({
           </tr>
         </tbody>
       </table>
+
+      <div className={styles.statsLastUpdated}>
+        <span>
+          Stats last retrieved on{' '}
+          <Moment format="LLL">{stats.updatedAt}</Moment>
+        </span>
+        <PrimaryButton onClick={handleRefreshStats}>
+          Refresh stats
+        </PrimaryButton>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -105,6 +105,22 @@ const ProgressDetails = ({
     return <h2>{progressMessage}</h2>
   }
 
+  function renderUpdateStats() {
+    if (isSent) {
+      return (
+        <div className={styles.statsLastUpdated}>
+          <span>
+            Stats last retrieved on{' '}
+            <Moment format="LLL">{stats.updatedAt}</Moment>
+          </span>
+          <PrimaryButton onClick={handleRefreshStats}>
+            Refresh stats
+          </PrimaryButton>
+        </div>
+      )
+    }
+  }
+
   return (
     <div className={styles.progress}>
       <table>
@@ -210,16 +226,7 @@ const ProgressDetails = ({
           </tr>
         </tbody>
       </table>
-
-      <div className={styles.statsLastUpdated}>
-        <span>
-          Stats last retrieved on{' '}
-          <Moment format="LLL">{stats.updatedAt}</Moment>
-        </span>
-        <PrimaryButton onClick={handleRefreshStats}>
-          Refresh stats
-        </PrimaryButton>
-      </div>
+      {renderUpdateStats()}
     </div>
   )
 }

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import Moment from 'react-moment'
 
 import { Status, CampaignStats, ChannelType } from 'classes/Campaign'
 import {
@@ -104,6 +105,8 @@ const EmailDetail = ({
           handleRetry={handleRetry}
         />
       )}
+
+      Stats last retrieved on {stats.updatedAt}
     </>
   )
 }

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import Moment from 'react-moment'
 
 import { Status, CampaignStats, ChannelType } from 'classes/Campaign'
 import {
@@ -23,10 +22,18 @@ const EmailDetail = ({
 }) => {
   const [stats, setStats] = useState(new CampaignStats({}))
 
-  async function refreshCampaignStats(id: number) {
-    const campaignStats = await getCampaignStats(id)
+  async function refreshCampaignStats(id: number, forceRefresh = false) {
+    const campaignStats = await getCampaignStats(id, forceRefresh)
     setStats(campaignStats)
     return campaignStats
+  }
+
+  async function handleRefreshStats() {
+    try {
+      await refreshCampaignStats(id, true)
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   async function handlePause() {
@@ -91,9 +98,7 @@ const EmailDetail = ({
           </p>
         </>
       )}
-
       <div className="separator"></div>
-
       {stats.status && (
         <ProgressDetails
           campaignId={id}
@@ -103,10 +108,9 @@ const EmailDetail = ({
           stats={stats}
           handlePause={handlePause}
           handleRetry={handleRetry}
+          handleRefreshStats={handleRefreshStats}
         />
       )}
-
-      Stats last retrieved on {stats.updatedAt}
     </>
   )
 }

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -22,10 +22,18 @@ const SMSDetail = ({
 }) => {
   const [stats, setStats] = useState(new CampaignStats({}))
 
-  async function refreshCampaignStats(id: number) {
-    const campaignStats = await getCampaignStats(id)
+  async function refreshCampaignStats(id: number, forceRefresh = false) {
+    const campaignStats = await getCampaignStats(id, forceRefresh)
     setStats(campaignStats)
     return campaignStats
+  }
+
+  async function handleRefreshStats() {
+    try {
+      await refreshCampaignStats(id, true)
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   async function handlePause() {
@@ -101,6 +109,7 @@ const SMSDetail = ({
           stats={stats}
           handlePause={handlePause}
           handleRetry={handleRetry}
+          handleRefreshStats={handleRefreshStats}
         />
       )}
     </>

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -22,10 +22,18 @@ const TelegramDetail = ({
 }) => {
   const [stats, setStats] = useState(new CampaignStats({}))
 
-  async function refreshCampaignStats(id: number) {
-    const campaignStats = await getCampaignStats(id)
+  async function refreshCampaignStats(id: number, forceRefresh = false) {
+    const campaignStats = await getCampaignStats(id, forceRefresh)
     setStats(campaignStats)
     return campaignStats
+  }
+
+  async function handleRefreshStats() {
+    try {
+      await refreshCampaignStats(id, true)
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   async function handlePause() {
@@ -99,6 +107,7 @@ const TelegramDetail = ({
           stats={stats}
           handlePause={handlePause}
           handleRetry={handleRetry}
+          handleRefreshStats={handleRefreshStats}
         />
       )}
     </>

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -95,16 +95,27 @@ export async function getCampaignStats(
   campaignId: number,
   forceRefresh = false
 ): Promise<CampaignStats> {
-  return axios
-    .get(`/campaign/${campaignId}/stats?refresh=${forceRefresh}`)
-    .then((response) => {
-      const { status, updatedAt, ...counts } = response.data
-      return new CampaignStats({
-        ...counts,
-        status: parseStatus(status),
-        updatedAt,
+  if (forceRefresh) {
+    return axios
+      .post(`/campaign/${campaignId}/refresh-stats`)
+      .then((response) => {
+        const { status, updatedAt, ...counts } = response.data
+        return new CampaignStats({
+          ...counts,
+          status: parseStatus(status),
+          updatedAt,
+        })
       })
+  }
+
+  return axios.get(`/campaign/${campaignId}/stats`).then((response) => {
+    const { status, updatedAt, ...counts } = response.data
+    return new CampaignStats({
+      ...counts,
+      status: parseStatus(status),
+      updatedAt,
     })
+  })
 }
 
 export async function getCampaignDetails(

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -92,16 +92,19 @@ function parseStatus(status: string): Status {
 }
 
 export async function getCampaignStats(
-  campaignId: number
+  campaignId: number,
+  forceRefresh = false
 ): Promise<CampaignStats> {
-  return axios.get(`/campaign/${campaignId}/stats`).then((response) => {
-    const { status, updatedAt, ...counts } = response.data
-    return new CampaignStats({
-      ...counts,
-      status: parseStatus(status),
-      updatedAt,
+  return axios
+    .get(`/campaign/${campaignId}/stats?refresh=${forceRefresh}`)
+    .then((response) => {
+      const { status, updatedAt, ...counts } = response.data
+      return new CampaignStats({
+        ...counts,
+        status: parseStatus(status),
+        updatedAt,
+      })
     })
-  })
 }
 
 export async function getCampaignDetails(


### PR DESCRIPTION
## Problem

Closes #514 

## Solution

* Added a `refresh-stats` endpoint, that updates that `statistics` table with the entries from the `<channel>_messages` table. Also added a manual refresh button the frontend stats dashboard that allows this endpoint to be called. 
I went with a separate endpoint instead of a query param in the end cloudflare didn't allow for a rate limiting rule with just a query param. I've also opted to carry out rate limiting at the Cloudflare level over express and nginx as it wasn't API server instance specific (ie. I don't have to handle stuff like "did this IP hit my other API instance already"), and I just simply don't feel like messing with nginx if I can avoid it. 

* Stats also get updated from the messages table when `/export` is run.

## Before & After Screenshots

**AFTER**:
How the refresh stats button appears on the stats dashboard:
<img width="744" alt="Screenshot 2020-07-20 at 1 19 04 PM" src="https://user-images.githubusercontent.com/4611861/87902203-98244480-ca8b-11ea-895b-3747d52e97e5.png">

## Deployment Notes
* Turn on rate limiting rules for prod, on `/refresh-stats` and `/export`