### PR TITLE
feat: Append unsubscribe url to email message body

### DIFF
--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -225,6 +225,11 @@ const config = convict({
       },
     },
   },
+  frontendUrl: {
+    doc: 'Used to generate unsubscribe url',
+    default: 'https://postman.gov.sg', // prod only
+    env: 'FRONTEND_URL',
+  },
 })
 
 // If mailFrom was not set in an env var, set it using the app_name
@@ -235,6 +240,7 @@ config.set('mailFrom', config.get('mailFrom') || defaultMailFrom)
 // Override with local config
 if (config.get('env') === 'development') {
   config.load({
+    frontendUrl: 'http://localhost:3000',
     IS_PROD: false,
     database: {
       dialectOptions: {
@@ -245,6 +251,12 @@ if (config.get('env') === 'development') {
         },
       },
     },
+  })
+}
+
+if (config.get('env') === 'staging') {
+  config.load({
+    frontendUrl: 'https://staging.postman.gov.sg/p',
   })
 }
 

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -67,7 +67,7 @@ class Email {
       .then((result) => map(result, 'get_messages_to_send_email'))
   }
 
-  calculateHmac(campaignId: number, recipient: string) {
+  calculateHash(campaignId: number, recipient: string): string {
     const version = config.get('unsubscribeHmac.version')
     return crypto
       .createHmac(
@@ -80,7 +80,7 @@ class Email {
 
   generateUnsubLink(campaignId: number, recipient: string): URL {
     const version = config.get('unsubscribeHmac.version')
-    const hmac = this.calculateHmac(campaignId, recipient)
+    const hmac = this.calculateHash(campaignId, recipient)
     const link = new URL(`/unsubscribe/${version}`, config.get('frontendUrl'))
     link.searchParams.append('c', campaignId.toString())
     link.searchParams.append('r', recipient)

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -56,6 +56,7 @@ class Email {
       body: string
       subject: string
       replyTo: string | null
+      campaignId: number
     }[]
   > {
     return this.connection

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -96,7 +96,7 @@ class Email {
       For more information, please visit our <a href="https://guide.postman.gov.sg/faqs/faq-recipients" style="color:#edae49" target="_blank">site</a>. 
     </p>
     <p style="font-size:12px;color:#818284;line-height:2em">
-      If you wish to unsubscribe from similar emails from your sender, please click <a href="${unsubUrl}" style="color:#edae49" target="_blank">here</a
+      If you wish to unsubscribe from similar emails from your sender, please click <a href="${unsubUrl}" style="color:#edae49" target="_blank">here</a>
       to unsubscribe and we will inform the respective agency.
     </p>
     `

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -89,9 +89,17 @@ class Email {
   }
 
   appendUnsubToMessage(msg: string, unsubUrl: string): string {
-    return `${msg} <br> <hr> <p style="font-size:12px;color:#818284;line-height:2em">
-    Click <a href="${unsubUrl}" style="color:#edae49" target="_blank">here</a> to unsubscribe.
-</p>`
+    return `${msg} <br><hr> 
+    <p style="font-size:12px;color:#818284;line-height:2em">\
+      <a href="https://postman.gov.sg" style="color:#edae49" target="_blank">Postman.gov.sg</a>
+      is a mass messaging platform used by the Singapore Government to communicate with stakeholders.
+      For more information, please visit our <a href="https://guide.postman.gov.sg/faqs/faq-recipients" style="color:#edae49" target="_blank">site</a>. 
+    </p>
+    <p style="font-size:12px;color:#818284;line-height:2em">
+      If you wish to unsubscribe from similar emails from your sender, please click <a href="${unsubUrl}" style="color:#edae49" target="_blank">here</a
+      to unsubscribe and we will inform the respective agency.
+    </p>
+    `
   }
 
   async sendMessage({

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -1,7 +1,7 @@
 import { Sequelize } from 'sequelize-typescript'
 import { QueryTypes, Transaction } from 'sequelize'
 import map from 'lodash/map'
-
+import crypto from 'crypto'
 import logger from '@core/logger'
 import config from '@core/config'
 import MailClient from '@email/services/mail-client.class'
@@ -67,13 +67,41 @@ class Email {
       .then((result) => map(result, 'get_messages_to_send_email'))
   }
 
-  sendMessage({
+  calculateHmac(campaignId: number, recipient: string) {
+    const version = config.get('unsubscribeHmac.version')
+    return crypto
+      .createHmac(
+        config.get(`unsubscribeHmac.${version}.algo`),
+        config.get(`unsubscribeHmac.${version}.key`)
+      )
+      .update(`${campaignId}.${recipient}`)
+      .digest('hex')
+  }
+
+  generateUnsubLink(campaignId: number, recipient: string): URL {
+    const version = config.get('unsubscribeHmac.version')
+    const hmac = this.calculateHmac(campaignId, recipient)
+    const link = new URL(`/unsubscribe/${version}`, config.get('frontendUrl'))
+    link.searchParams.append('c', campaignId.toString())
+    link.searchParams.append('r', recipient)
+    link.searchParams.append('h', hmac)
+    return link
+  }
+
+  appendUnsubToMessage(msg: string, unsubUrl: string): string {
+    return `${msg} <br> <hr> <p style="font-size:12px;color:#818284;line-height:2em">
+    Click <a href="${unsubUrl}" style="color:#edae49" target="_blank">here</a> to unsubscribe.
+</p>`
+  }
+
+  async sendMessage({
     id,
     recipient,
     params,
     body,
     subject,
     replyTo,
+    campaignId,
   }: {
     id: number
     recipient: string
@@ -81,7 +109,12 @@ class Email {
     body: string
     subject?: string
     replyTo?: string | null
+    campaignId?: number
   }): Promise<void> {
+    const unsubUrl = await this.generateUnsubLink(
+      campaignId!,
+      recipient
+    ).toString()
     return Promise.resolve()
       .then(() => {
         return {
@@ -98,10 +131,14 @@ class Email {
           subject: string
           hydratedBody: string
         }) => {
+          const bodyWithUnsub = this.appendUnsubToMessage(
+            hydratedBody,
+            unsubUrl
+          )
           return this.mailService.sendMail({
             recipients: [recipient],
             subject,
-            body: hydratedBody,
+            body: bodyWithUnsub,
             referenceId: String(id),
             ...(replyTo ? { replyTo } : {}),
           })

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -70,7 +70,7 @@ const enqueueMessages = (jobId: number, campaignId: number): Promise<void> => {
   return service().enqueueMessages(jobId, campaignId)
 }
 
-const calculateHmac = (campaignId: number, recipient: string) => {
+const calculateHash = (campaignId: number, recipient: string) => {
   const version = config.get('unsubscribeHmac.version')
   return crypto
     .createHmac(
@@ -83,11 +83,11 @@ const calculateHmac = (campaignId: number, recipient: string) => {
 
 const generateUnsubLink = (campaignId: number, recipient: string): URL => {
   const version = config.get('unsubscribeHmac.version')
-  const hmac = calculateHmac(campaignId, recipient)
+  const hash = calculateHash(campaignId, recipient)
   const link = new URL(`/unsubscribe/${version}`, config.get('frontendUrl'))
   link.searchParams.append('c', campaignId.toString())
   link.searchParams.append('r', recipient)
-  link.searchParams.append('h', hmac)
+  link.searchParams.append('h', hash)
   return link
 }
 

--- a/worker/src/core/loaders/message-worker/interface.ts
+++ b/worker/src/core/loaders/message-worker/interface.ts
@@ -1,0 +1,9 @@
+export interface Message {
+  id: number
+  recipient: string
+  params: { [key: string]: string }
+  body: string
+  subject?: string
+  replyTo?: string | null
+  campaignId?: number
+}

--- a/worker/src/email/resources/sql/get-messages-to-send-email.sql
+++ b/worker/src/email/resources/sql/get-messages-to-send-email.sql
@@ -17,7 +17,7 @@ BEGIN
       id in (SELECT * from selected_ids)
       RETURNING id, recipient, params, campaign_id
     )
-    SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body, 'subject', t.subject, 'replyTo', t.reply_to)
+    SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'campaignId', m.campaign_id, 'body', t.body, 'subject', t.subject, 'replyTo', t.reply_to)
     FROM messages m, email_templates t
     WHERE m.campaign_id = t.campaign_id;
 		


### PR DESCRIPTION
## Problem

Closes #579

## Solution

Initially I thought that appending unsubscribe url through the workers wasn't a very good idea because:
- User won't be able to see it in the test message (We don't use the workers to send the test message)
- Single responsibility; workers should focus on sending messages and not editing messages

However, after considering other ways to achieve this like adding it to every email template & storing the url as a param, I find that the other ways are significantly more complicated.

We could append a test url to the body for the test message if we wanted to.

**Features**:

- Calculate hash, create unsubscribe url and append it to the hydrated message body.

**Improvements**:

- Added an interface named `Message` to make `message-worker/index.ts` neater

<img width="1680" alt="Screenshot 2020-07-22 at 3 19 30 PM" src="https://user-images.githubusercontent.com/33112945/88146842-f9d0e400-cc2e-11ea-8922-0dd5f7e50a1d.png">

