### PR TITLE
chore: update travis with renamed telegram handler lambda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,7 +184,7 @@ jobs:
             - DB_URI=$PRODUCTION_TELEGRAM_HANDLER_DB_URI
         - provider: lambda
           edge: true
-          function_name: telegram-test
+          function_name: telegram-handler-staging
           region: $AWS_DEFAULT_REGION
           role: $STAGING_CALLBACK_ROLE
           runtime: nodejs12.x


### PR DESCRIPTION
## Problem
Inconsistent naming of lambda

## Solution
- Renamed lambda in travis
- Set up new lambda in staging vpc
- Redeployed API gateway to point to this lambda