### PR TITLE
feat: support separate environment for email callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,17 @@ jobs:
           bucket_name: "postmangovsg-elasticbeanstalk-appversion"
           on:
             branch: $PRODUCTION_BRANCH
+        - provider: elasticbeanstalk
+          edge: true
+          skip_cleanup: true
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          region: $AWS_DEFAULT_REGION
+          app: "postmangovsg"
+          env: "postmangovsg-production-02"
+          bucket_name: "postmangovsg-elasticbeanstalk-appversion"
+          on:
+            branch: $PRODUCTION_02_BRANCH
     - name: worker
       before_install:
         - cd worker
@@ -64,6 +75,12 @@ jobs:
           script: ./deploy.sh postmangovsg-workers prod-sending prod-logging
           on:
             branch: $PRODUCTION_BRANCH
+            condition: "$DEPLOY_WORKER = true"
+        - provider: script
+          skip_cleanup: true
+          script: ./deploy.sh postmangovsg-workers prod-sending-02 prod-logging-02
+          on:
+            branch: $PRODUCTION_02_BRANCH
             condition: "$DEPLOY_WORKER = true"
     - name: frontend
       before_install:
@@ -167,6 +184,26 @@ jobs:
             - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
             - SENDGRID_PUBLIC_KEY=$PRODUCTION_EMAIL_SENDGRID_PUBLIC_KEY
             - CALLBACK_SECRET=$PRODUCTION_EMAIL_CALLBACK_SECRET
+        - provider: lambda
+          edge: true
+          function_name: log-email-callback-production-02
+          region: $AWS_DEFAULT_REGION
+          role: $PRODUCTION_CALLBACK_ROLE
+          runtime: nodejs12.x
+          module_name: build/index
+          handler_name: handler
+          timeout: 30
+          publish: true
+          zip: "../log-email-sns/code.zip"
+          on:
+            branch: $PRODUCTION_02_BRANCH
+          environment_variables:
+            - DB_URI=$PRODUCTION_02_EMAIL_DB_URI
+            - MIN_HALT_NUMBER=$PRODUCTION_EMAIL_MIN_HALT_NUMBER
+            - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
+            - SENDGRID_PUBLIC_KEY=$PRODUCTION_EMAIL_SENDGRID_PUBLIC_KEY
+            - CALLBACK_SECRET=$PRODUCTION_EMAIL_CALLBACK_SECRET
+            - NODE_ENV=production-02
         - provider: lambda
           edge: true
           function_name: telegram-handler-production

--- a/amplify.yml
+++ b/amplify.yml
@@ -2,6 +2,7 @@ version: 0.1
 env:
   variables:
     BACKEND_URL_PRODUCTION: "https://api.postman.gov.sg/v1"
+    BACKEND_URL_PRODUCTION_MOM: "https://api-mom.postman.gov.sg/v1"
     BACKEND_URL_STAGING: "https://api-staging.postman.gov.sg/v1"
     SENTRY_ORG: "open-government-products-re"
     SENTRY_PROJECT: "postmangovsg-frontend"
@@ -29,6 +30,9 @@ frontend:
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
           export REACT_APP_SENTRY_ENVIRONMENT="production";
+          elif [ "${AWS_BRANCH}" = "momgovsg" ]; then
+          export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION_MOM} &&
+          export REACT_APP_SENTRY_ENVIRONMENT="production-02";
           else
           export REACT_APP_BACKEND_URL=${BACKEND_URL_STAGING} &&
           export REACT_APP_SENTRY_ENVIRONMENT="staging";

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -33,7 +33,14 @@ convict.addFormats({
 const config = convict({
   env: {
     doc: 'The application environment.',
-    format: ['production', 'staging', 'development'],
+    format: (val: string) => {
+      if (!/^(production|staging|development)(-\d+)?$/.test(val)) {
+        throw new Error(
+          `${val} is not a valid environment. NODE_ENV must be one of 'production', 'staging', 'development' 
+          or one of these keywords appended with '-digits'. eg. production-01`
+        )
+      }
+    },
     default: 'production',
     env: 'NODE_ENV',
   },

--- a/serverless/log-email-sns/src/config.ts
+++ b/serverless/log-email-sns/src/config.ts
@@ -38,7 +38,14 @@ convict.addFormats({
 const config = convict({
   env: {
     doc: 'The application environment.',
-    format: ['production', 'staging', 'development'],
+    format: (val: string) => {
+      if (!/^(production|staging|development)(-\d+)?$/.test(val)) {
+        throw new Error(
+          `${val} is not a valid environment. NODE_ENV must be one of 'production', 'staging', 'development' 
+          or one of these keywords appended with '-digits'. eg. production-01`
+        )
+      }
+    },
     default: 'production',
     env: 'NODE_ENV',
   },

--- a/serverless/log-email-sns/src/index.ts
+++ b/serverless/log-email-sns/src/index.ts
@@ -37,4 +37,3 @@ exports.handler = async (event: any) => {
   }
   return
 }
-

--- a/serverless/log-email-sns/src/parsers/sendgrid.ts
+++ b/serverless/log-email-sns/src/parsers/sendgrid.ts
@@ -16,6 +16,7 @@ type SendgridEvent = SendgridRecord[]
 type SendgridRecord = {
   // the unique_args that we passed
   message_id: string
+  environment?: string // TODO: make this mandatory when the messages are being sent with this property consistently
   // standard args
   email: string
   event: string
@@ -46,10 +47,18 @@ const parseRecord = async (record: SendgridRecord) => {
     console.log(`No reference message id found for ${record['smtp-id']}`)
     return
   }
+  if (record.environment && record.environment !== config.get('env')) {
+    console.log(
+      `Mismatched environment for ${record.message_id}. Lambda: ${config.get(
+        'env'
+      )}. Message: ${record.environment}. `
+    )
+    return
+  }
   const metadata = {
     id: record.message_id,
     timestamp: new Date(record.timestamp * 1000).toISOString(),
-    messageId: record['smtp-id'],
+    messageId: record['smtp-id'], 
   }
   switch (record.event) {
     case 'delivered':

--- a/serverless/log-email-sns/src/query.ts
+++ b/serverless/log-email-sns/src/query.ts
@@ -84,7 +84,7 @@ export const haltCampaignIfThresholdExceeded = async (campaignId?: number) => {
   }
 
   // Compute threshold for Hard bounces
-  // Your bounce rate includes only hard bounces to domains you haven't verified. 
+  // Your bounce rate includes only hard bounces to domains you haven't verified.
   // Source: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/faqs-enforcement.html#e-faq-bn
   const [result] =
     (await sequelize?.query(

--- a/serverless/log-twilio-callback/src/config.ts
+++ b/serverless/log-twilio-callback/src/config.ts
@@ -28,7 +28,14 @@ convict.addFormats({
 const config = convict({
   env: {
     doc: 'The application environment.',
-    format: ['production', 'staging', 'development'],
+    format: (val: string) => {
+      if (!/^(production|staging|development)(-\d+)?$/.test(val)) {
+        throw new Error(
+          `${val} is not a valid environment. NODE_ENV must be one of 'production', 'staging', 'development' 
+          or one of these keywords appended with '-digits'. eg. production-01`
+        )
+      }
+    },
     default: 'production',
     env: 'NODE_ENV',
   },

--- a/serverless/telegram-handler/src/config.ts
+++ b/serverless/telegram-handler/src/config.ts
@@ -33,7 +33,14 @@ const config = convict({
   },
   env: {
     doc: 'The application environment',
-    format: ['production', 'staging', 'development'],
+    format: (val: string) => {
+      if (!/^(production|staging|development)(-\d+)?$/.test(val)) {
+        throw new Error(
+          `${val} is not a valid environment. NODE_ENV must be one of 'production', 'staging', 'development' 
+          or one of these keywords appended with '-digits'. eg. production-01`
+        )
+      }
+    },
     default: 'production',
     env: 'NODE_ENV',
   },

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -28,7 +28,14 @@ convict.addFormats({
 const config = convict({
   env: {
     doc: 'The application environment.',
-    format: ['production', 'staging', 'development'],
+    format: (val: string) => {
+      if (!/^(production|staging|development)(-\d+)?$/.test(val)) {
+        throw new Error(
+          `${val} is not a valid environment. NODE_ENV must be one of 'production', 'staging', 'development' 
+          or one of these keywords appended with '-digits'. eg. production-01`
+        )
+      }
+    },
     default: 'production',
     env: 'NODE_ENV',
   },

--- a/worker/src/email/services/mail-client.class.ts
+++ b/worker/src/email/services/mail-client.class.ts
@@ -2,7 +2,9 @@ import nodemailer from 'nodemailer'
 import directTransport from 'nodemailer-direct-transport'
 import logger from '@core/logger'
 import { MailToSend, MailCredentials } from '@email/interfaces'
+import config from '@core/config'
 const REFERENCE_ID_HEADER = 'X-SMTPAPI' // Case sensitive
+const ENVIRONMENT = config.get('env')
 export default class MailClient {
   private email: string
   private mailer: nodemailer.Transporter
@@ -50,7 +52,10 @@ export default class MailClient {
         // Signature expected by Sendgrid
         // https://sendgrid.com/docs/for-developers/tracking-events/event/#unique-arguments
         const headerValue = JSON.stringify({
-          unique_args: { message_id: input.referenceId },
+          unique_args: {
+            message_id: input.referenceId,
+            environment: ENVIRONMENT,
+          },
         })
         options.headers = { [REFERENCE_ID_HEADER]: headerValue }
       }


### PR DESCRIPTION
## Problem

Addresses https://github.com/opengovsg/postmangovsg/issues/541
SES can only publish events to one topic. We need a way to differentiate between an event that is meant to update the production db, or to update the db that we spun up separately for MOM. 

## Solution
The gist is that I added an environment variable to the X-SMTPAPI header to differentiate between events from different environments.

A potential solution was to pass two different database connection strings to the current lambda handling email callbacks. The advantage is that the same event only triggers one lambda. 

However, I chose to setup two lambdas instead because it is far easier to extend this to multiple environments (if we wanted production-03, production-04) without changing code. 
The disadvantage is that every SES event now triggers two lambdas. Pricewise, it's negligible (20 cents per mil requests). I'm slightly concerned about the number of concurrent executions (the max number of concurrent executions in the past week is 75 for the email lambda, 400 for the twilio lambda, and 2 for telegram), but we can still handle it for now. 


## Deploy notes
- [x] Add a subscription to this lambda (SES-SNS) for V1 USEast-1
- [x] Add a subscription to this lambda (SES-SNS) for V2 Sydney
- [x] Add a constraint on the new db to prevent creation of sms and telegram campaigns. 
```
CREATE FUNCTION disallow_sms_telegram_campaigns()
  RETURNS trigger AS
$func$
BEGIN
	IF (NEW."type" = 'SMS' or NEW."type"='TELEGRAM') THEN
      RAISE EXCEPTION 'SMS and TELEGRAM campaigns are not allowed in this environment';
   END IF;
   RETURN NEW;
END
$func$  LANGUAGE plpgsql;

CREATE TRIGGER disallow_type_before_insert_campaigns
BEFORE INSERT ON "campaigns"
FOR EACH ROW EXECUTE PROCEDURE disallow_sms_telegram_campaigns();
```
- [ ] When this branch is merged into master, cut momgovsg from master and treat it as a release branch from then on. 

## Tests
Test on mom.postman.gov.sg and api-mom.postman.gov.sg
**Be careful about sending many email messages** as the new lambda's code has not been deployed to production! The production lambda will try to update the status of messages using the message id. Fortunately, the first few email_messages in production are test messages, so we can still test a few messages, and truncate the email_messages table as necessary to keep the id number low. 