### PR TITLE
feat: Telegram help command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,8 @@ jobs:
             - DB_URI=$PRODUCTION_TELEGRAM_HANDLER_DB_URI
             - SENTRY_DSN=$SERVERLESS_SENTRY_DSN
             - SENTRY_LAMBDA_FUNCTION_NAME=telegram-handler-production
+            - TELEGRAM_BOT_CONTACT_US_URL=$TELEGRAM_BOT_CONTACT_US_URL
+            - TELEGRAM_BOT_GUIDE_URL=$TELEGRAM_BOT_GUIDE_URL
         - provider: lambda
           edge: true
           function_name: telegram-handler-staging
@@ -202,6 +204,8 @@ jobs:
             - SENTRY_DSN=$SERVERLESS_SENTRY_DSN
             - SENTRY_LAMBDA_FUNCTION_NAME=telegram-handler-staging
             - NODE_ENV=staging
+            - TELEGRAM_BOT_CONTACT_US_URL=$TELEGRAM_BOT_CONTACT_US_URL
+            - TELEGRAM_BOT_GUIDE_URL=$TELEGRAM_BOT_GUIDE_URL
     - name: root
       install:
         - npm install --ignore-scripts

--- a/backend/src/telegram/services/telegram.service.ts
+++ b/backend/src/telegram/services/telegram.service.ts
@@ -145,6 +145,7 @@ const validateAndConfigureBot = async (
 
   const commands = [
     { command: 'updatenumber', description: 'Update linked phone number' },
+    { command: 'help', description: 'Get help' },
   ]
   await telegramService.setCommands(commands)
 }

--- a/serverless/telegram-handler/.env-example
+++ b/serverless/telegram-handler/.env-example
@@ -1,7 +1,7 @@
 # Required
 DB_URI=postgres://localhost:5432/postmangovsg_dev
 TELEGRAM_BOT_CONTACT_US_URL=https://go.gov.sg/postman-contact-us-recipient
-TELEGRAM_BOT_GUIDE_URL=https://guide.postman.gov.sg/faqs/faq-recipients
+TELEGRAM_BOT_GUIDE_URL=https://go.gov.sg/postman-recipient-guide
 # SENTRY_DSN=https://123.ingest.sentry.io/456
 
 # Optional, required in dev

--- a/serverless/telegram-handler/.env-example
+++ b/serverless/telegram-handler/.env-example
@@ -1,5 +1,7 @@
 # Required
 DB_URI=postgres://localhost:5432/postmangovsg_dev
+TELEGRAM_BOT_CONTACT_US_URL=https://go.gov.sg/postman-contact-us-recipient
+TELEGRAM_BOT_GUIDE_URL=https://guide.postman.gov.sg/faqs/faq-recipients
 # SENTRY_DSN=https://123.ingest.sentry.io/456
 
 # Optional, required in dev

--- a/serverless/telegram-handler/src/bot/handlers/help.ts
+++ b/serverless/telegram-handler/src/bot/handlers/help.ts
@@ -2,8 +2,24 @@ import { TelegrafContext } from 'telegraf/typings/context'
 import { Message } from 'telegraf/typings/telegram-types'
 
 import { Logger } from '../../utils/logger'
+import config from '../../config'
 
 const logger = new Logger('help')
+
+const HELP_MESSAGE = `
+*Commands*
+/updatenumber - update your phone number
+/help - show this help message
+
+If you are experiencing issues with the Telegram bot, please contact us by submitting a [support form](${config.get(
+  'help.contactUsUrl'
+)}) to the Postman team.
+
+--
+This bot is powered by Postman – a mass messaging platform used by the Government to communicate with stakeholders. For more information, please visit our [site](${config.get(
+  'help.guideUrl'
+)}).
+`
 
 /**
  * Handles updates for the /help command.
@@ -13,6 +29,8 @@ export const helpCommandHandler = async (
 ): Promise<Message> => {
   logger.log(ctx.from?.id.toString())
 
-  const REPLY = 'stub' // TODO: add copy
-  return ctx.reply(REPLY)
+  return ctx.reply(HELP_MESSAGE, {
+    parse_mode: 'Markdown',
+    disable_web_page_preview: true,
+  })
 }

--- a/serverless/telegram-handler/src/bot/handlers/help.ts
+++ b/serverless/telegram-handler/src/bot/handlers/help.ts
@@ -1,0 +1,18 @@
+import { TelegrafContext } from 'telegraf/typings/context'
+import { Message } from 'telegraf/typings/telegram-types'
+
+import { Logger } from '../../utils/logger'
+
+const logger = new Logger('help')
+
+/**
+ * Handles updates for the /help command.
+ */
+export const helpCommandHandler = async (
+  ctx: TelegrafContext
+): Promise<Message> => {
+  logger.log(ctx.from?.id.toString())
+
+  const REPLY = 'stub' // TODO: add copy
+  return ctx.reply(REPLY)
+}

--- a/serverless/telegram-handler/src/bot/index.ts
+++ b/serverless/telegram-handler/src/bot/index.ts
@@ -5,6 +5,7 @@ import { Sequelize } from 'sequelize-typescript'
 import { startCommandHandler } from './handlers/start'
 import { contactMessageHandler } from './handlers/contact'
 import { updatenumberCommandHandler } from './handlers/updatenumber'
+import { helpCommandHandler } from './handlers/help'
 import { PostmanTelegramError } from './PostmanTelegramError'
 import { verifyBotToken } from '../credentials'
 
@@ -26,6 +27,7 @@ export const handleUpdate = async (
   // Attach handlers
   bot.command('start', startCommandHandler)
   bot.command('updatenumber', updatenumberCommandHandler)
+  bot.command('help', helpCommandHandler)
   bot.on('contact', contactMessageHandler(botId, sequelize))
 
   // Handle update

--- a/serverless/telegram-handler/src/config.ts
+++ b/serverless/telegram-handler/src/config.ts
@@ -100,6 +100,20 @@ const config = convict({
     default: 'telegram-handler',
     env: 'SENTRY_LAMBDA_FUNCTION_NAME',
   },
+  help: {
+    contactUsUrl: {
+      doc: 'URL to contact form',
+      default: '',
+      env: 'TELEGRAM_BOT_CONTACT_US_URL',
+      format: 'required',
+    },
+    guideUrl: {
+      doc: 'URL to recipient guide',
+      default: '',
+      env: 'TELEGRAM_BOT_GUIDE_URL',
+      format: 'required',
+    },
+  },
 })
 
 // Only development is a non-production environment


### PR DESCRIPTION
## Problem

From the issue: 
> If users are confused while talking to the Telegram bot, there's no easy way for them to get help.

Closes #593.

## Solution

![Screen Shot 2020-07-22 at 5 17 56 PM](https://user-images.githubusercontent.com/6095637/88158990-4ae8d400-cc3f-11ea-8693-64ec45c63df3.png)

Add a new `/help` command that:
- Shows a short summary of the commands available (similar to BotFather)
- Provides a way for recipients to contact us via a support form

## Tests

Already tested on staging, to test locally: 

1. Make sure the new env vars are set, then run the handler locally
2. Send a `/help`, you should receive the message shown above
3. Storing your bot token via the frontend should also add a `/help` option to the suggestion list when you type `/`

## Deploy Notes

**New environment variables**:

- `TELEGRAM_BOT_CONTACT_US_URL`: Support form URL
- `TELEGRAM_BOT_GUIDE_URL`: Recipient guide URL

Also remember to update all current bots with the new command. 