### PR TITLE
feat: remove new lines from tables, fix css

### DIFF
--- a/frontend/src/components/common/protected-preview/ProtectedPreview.module.scss
+++ b/frontend/src/components/common/protected-preview/ProtectedPreview.module.scss
@@ -53,5 +53,23 @@
     a {
       font-size: 1rem;
     }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      tr {
+        display: table-row;
+        border-bottom: 1px solid $transparent-blue;
+
+        td,
+        th {
+          display: table-cell;
+        }
+
+        &:last-child {
+          border-bottom: none;
+        }
+      }
+    }
   }
 }

--- a/frontend/src/services/validate-csv.service.ts
+++ b/frontend/src/services/validate-csv.service.ts
@@ -74,8 +74,17 @@ export async function validateCsv(
   })
 }
 
+function removeNewLinesFromTables(template: string) {
+  // Get all text within <table> tags
+  return template.replace(/<table\s*>(.*?)<\/table\s*>/gs, (match) =>
+    // Remove all new lines
+    match.replace(/(\r\n|\r|\n)/g, '')
+  )
+}
+
 export function hydrateTemplate(template: string, row: Record<string, any>) {
-  const newLinesReplaced = template.replace(/(?:\r\n|\r|\n)/g, '<br>')
+  const cleanedTemplate = removeNewLinesFromTables(template)
+  const newLinesReplaced = cleanedTemplate.replace(/(?:\r\n|\r|\n)/g, '<br>')
   return templateClient.template(newLinesReplaced, row)
 }
 

--- a/frontend/src/services/validate-csv.service.ts
+++ b/frontend/src/services/validate-csv.service.ts
@@ -75,8 +75,8 @@ export async function validateCsv(
 }
 
 function removeNewLinesFromTables(template: string) {
-  // Get all text within <table> tags
-  return template.replace(/<table\s*>(.*?)<\/table\s*>/gs, (match) =>
+  // Get all text within <table (attr?)> tags
+  return template.replace(/<table(\s+.*?|\s*)>(.*?)<\/table\s*>/gs, (match) =>
     // Remove all new lines
     match.replace(/(\r\n|\r|\n)/g, '')
   )


### PR DESCRIPTION
## Problem

New lines were being replaced with `<br>`'s and hoisted to the top of the table.

## Solution

Remove newlines in between table tags and fix css

![Screenshot 2020-07-23 at 6 56 31 PM](https://user-images.githubusercontent.com/10072985/88279210-3e837a80-cd16-11ea-94c3-0ee870da71e1.png)
