### PR TITLE
refactor: Remove GET unsubscriber status endpoint

### DIFF
--- a/backend/src/core/middlewares/unsubscriber.middleware.ts
+++ b/backend/src/core/middlewares/unsubscriber.middleware.ts
@@ -64,9 +64,9 @@ const findOrCreateUnsubscriber = async (
   const statusCode = created ? 201 : 200
   const { createdAt } = unsubscriber
   return res.status(statusCode).json({
-    campaignId,
+    campaign_id: campaignId,
     recipient,
-    createdAt,
+    created_at: createdAt,
   })
 }
 

--- a/backend/src/core/middlewares/unsubscriber.middleware.ts
+++ b/backend/src/core/middlewares/unsubscriber.middleware.ts
@@ -59,10 +59,7 @@ const findOrCreateUnsubscriber = async (
   })
 
   const statusCode = created ? 201 : 200
-  return res.status(statusCode).json({
-    campaign_id: campaignId,
-    recipient,
-  })
+  return res.sendStatus(statusCode)
 }
 
 export const UnsubscriberMiddleware = {

--- a/backend/src/core/middlewares/unsubscriber.middleware.ts
+++ b/backend/src/core/middlewares/unsubscriber.middleware.ts
@@ -1,5 +1,4 @@
 import { Request, Response, NextFunction } from 'express'
-import { UniqueConstraintError } from 'sequelize'
 
 import { CampaignService, UnsubscriberService } from '@core/services'
 
@@ -15,18 +14,23 @@ const isUnsubscribeRequestValid = async (
   next: NextFunction
 ): Promise<Response | void> => {
   try {
-    const params = req.query.c ? req.query : req.body
-    const { c: campaignId, r: recipient, v: version, h: hash } = params
+    const { campaignId, recipient } = req.params
+    const { v: version, h: hash } = req.body
 
-    UnsubscriberService.validateHash({ campaignId, recipient, version, hash })
+    UnsubscriberService.validateHash({
+      campaignId: +campaignId,
+      recipient,
+      version,
+      hash,
+    })
 
-    const campaign = await CampaignService.getCampaignDetails(campaignId, [])
+    const campaign = await CampaignService.getCampaignDetails(+campaignId, [])
     if (!campaign) {
       throw new Error('Invalid campaign')
     }
 
-    res.locals.unsubscribe = {
-      campaign,
+    res.locals.unsubscriber = {
+      campaignId: +campaignId,
       recipient,
     }
 
@@ -39,66 +43,34 @@ const isUnsubscribeRequestValid = async (
 }
 
 /**
- * Retrieves the unsubscribe status and the associated campaign
- * @param _req
- * @param res
- */
-const getUnsubscriberStatus = async (
-  _req: Request,
-  res: Response
-): Promise<Response> => {
-  const { campaign, recipient } = res.locals.unsubscribe
-  const unsubscribe = await UnsubscriberService.getUnsubscriber(
-    campaign.id,
-    recipient
-  )
-
-  return res.json({
-    unsubscribed: unsubscribe !== null,
-    campaign: {
-      name: campaign.name,
-      channelType: campaign.type,
-    },
-  })
-}
-
-/**
  * Creates a new unsubscribe record
  * @param _req
  * @param res
  * @param next
  */
-const createUnsubscriber = async (
+const findOrCreateUnsubscriber = async (
   _req: Request,
-  res: Response,
-  next: NextFunction
+  res: Response
 ): Promise<Response | void> => {
-  try {
-    const { campaign, recipient } = res.locals.unsubscribe
-    await UnsubscriberService.createUnsubscriber({
-      campaignId: campaign.id,
-      recipient,
-    })
-    return res.status(201).json({
-      unsubscribed: true,
-      campaign: {
-        name: campaign.name,
-        channelType: campaign.type,
-      },
-    })
-  } catch (err) {
-    if (err instanceof UniqueConstraintError) {
-      return res.status(400).json({
-        message: 'Campaign is already unsubscribed',
-      })
-    }
+  const { campaignId, recipient } = res.locals.unsubscriber
+  const [
+    unsubscriber,
+    created,
+  ] = await UnsubscriberService.findOrCreateUnsubscriber({
+    campaignId,
+    recipient,
+  })
 
-    next(err)
-  }
+  const statusCode = created ? 201 : 200
+  const { createdAt } = unsubscriber
+  return res.status(statusCode).json({
+    campaignId,
+    recipient,
+    createdAt,
+  })
 }
 
 export const UnsubscriberMiddleware = {
   isUnsubscribeRequestValid,
-  getUnsubscriberStatus,
-  createUnsubscriber,
+  findOrCreateUnsubscriber,
 }

--- a/backend/src/core/middlewares/unsubscriber.middleware.ts
+++ b/backend/src/core/middlewares/unsubscriber.middleware.ts
@@ -53,20 +53,15 @@ const findOrCreateUnsubscriber = async (
   res: Response
 ): Promise<Response | void> => {
   const { campaignId, recipient } = res.locals.unsubscriber
-  const [
-    unsubscriber,
-    created,
-  ] = await UnsubscriberService.findOrCreateUnsubscriber({
+  const { 1: created } = await UnsubscriberService.findOrCreateUnsubscriber({
     campaignId,
     recipient,
   })
 
   const statusCode = created ? 201 : 200
-  const { createdAt } = unsubscriber
   return res.status(statusCode).json({
     campaign_id: campaignId,
     recipient,
-    created_at: createdAt,
   })
 }
 

--- a/backend/src/core/routes/unsubscriber.routes.ts
+++ b/backend/src/core/routes/unsubscriber.routes.ts
@@ -21,7 +21,7 @@ const findOrCreateUnsubscribeValidator = {
  * path:
  *  /unsubscribe/{campaignId}/{recipient}:
  *    put:
- *      summary: Add a new unsubscriber
+ *      summary: Add an unsubscriber
  *      tags:
  *        - Unsubscribe
  *      parameters:
@@ -61,9 +61,6 @@ const findOrCreateUnsubscribeValidator = {
  *                    type: integer
  *                  recipient:
  *                    type: string
- *                  created_at:
- *                    type: string
- *                    format: date-time
  *        "201":
  *          content:
  *            application/json:
@@ -74,9 +71,6 @@ const findOrCreateUnsubscribeValidator = {
  *                    type: integer
  *                  recipient:
  *                    type: string
- *                  created_at:
- *                    type: string
- *                    format: date-time
  *        "400":
  *           description: Bad Request (invalid request, already unsubscribed)
  *        "500":

--- a/backend/src/core/routes/unsubscriber.routes.ts
+++ b/backend/src/core/routes/unsubscriber.routes.ts
@@ -52,25 +52,9 @@ const findOrCreateUnsubscribeValidator = {
  *
  *      responses:
  *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  campaign_id:
- *                    type: integer
- *                  recipient:
- *                    type: string
+ *           description: OK (subscriber already exists, no update required)
  *        "201":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  campaign_id:
- *                    type: integer
- *                  recipient:
- *                    type: string
+ *           description: Created (new subscriber added)
  *        "400":
  *           description: Bad Request (invalid request, already unsubscribed)
  *        "500":

--- a/backend/src/core/routes/unsubscriber.routes.ts
+++ b/backend/src/core/routes/unsubscriber.routes.ts
@@ -5,90 +5,34 @@ import { UnsubscriberMiddleware } from '@core/middlewares'
 
 const router = Router()
 
-const unsubscribeSchema = Joi.object({
-  h: Joi.string().required(),
-  c: Joi.number().integer().required(),
-  r: Joi.string().required(),
-  v: Joi.string().required(),
-})
-const getUnsubscribeStatusValidator = {
-  [Segments.QUERY]: unsubscribeSchema,
-}
-
-const createUnsubscribeValidator = {
-  [Segments.BODY]: unsubscribeSchema,
+const findOrCreateUnsubscribeValidator = {
+  [Segments.PARAMS]: Joi.object({
+    campaignId: Joi.number().integer().required(),
+    recipient: Joi.string().required(),
+  }),
+  [Segments.BODY]: Joi.object({
+    h: Joi.string().required(),
+    v: Joi.string().required(),
+  }),
 }
 
 /**
  * @swagger
  * path:
- *  /unsubscribe:
- *    get:
- *      tags:
- *        - Unsubscribe
- *      summary: Get unsubscriber's status
- *      parameters:
- *        - in: query
- *          name: c
- *          description: campaign ID
- *          required: true
- *          schema:
- *            type: integer
- *        - in: query
- *          name: r
- *          description: recipient
- *          required: true
- *          schema:
- *            type: string
- *        - in: query
- *          name: v
- *          description: HMAC version
- *          required: true
- *          schema:
- *            type: string
- *        - in: query
- *          name: h
- *          description: unsubscribe hash
- *          required: true
- *          schema:
- *            type: string
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  unsubscribed:
- *                    type: boolean
- *                  campaign:
- *                    type: object
- *                    properties:
- *                      name:
- *                        type: string
- *                      type:
- *                        $ref: '#/components/schemas/ChannelType'
- *
- *        "400":
- *           description: Bad Request (invalid request, invalid campaign)
- *        "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/',
-  celebrate(getUnsubscribeStatusValidator),
-  UnsubscriberMiddleware.isUnsubscribeRequestValid,
-  UnsubscriberMiddleware.getUnsubscriberStatus
-)
-
-/**
- * @swagger
- * path:
- *  /unsubscribe:
- *    post:
+ *  /unsubscribe/{campaignId}/{recipient}:
+ *    put:
  *      summary: Add a new unsubscriber
  *      tags:
  *        - Unsubscribe
+ *      parameters:
+ *        - name: campaignId
+ *          in: path
+ *          type: string
+ *          required: true
+ *        - name: recipient
+ *          in: path
+ *          type: string
+ *          required: true
  *      requestBody:
  *        required: true
  *        content:
@@ -96,12 +40,6 @@ router.get(
  *            schema:
  *              type: object
  *              properties:
- *                c:
- *                  type: integer
- *                  description: campaign ID
- *                r:
- *                  type: string
- *                  description: recipient
  *                v:
  *                  type: string
  *                  description: HMAC version
@@ -109,37 +47,40 @@ router.get(
  *                  type: string
  *                  description: unsubscribe hash
  *              required:
- *                - c
- *                - r
  *                - v
  *                - h
  *
  *      responses:
+ *        "200":
+ *          content:
+ *            application/json:
+ *              schema:
+ *                type: object
+ *                properties:
+ *                  campaignId:
+ *                    type: integer
+ *                  recipient:
+ *                    type: string
  *        "201":
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
- *                  unsubscribed:
- *                    type: boolean
- *                  campaign:
- *                    type: object
- *                    properties:
- *                      name:
- *                        type: string
- *                      type:
- *                        $ref: '#/components/schemas/ChannelType'
+ *                  campaignId:
+ *                    type: integer
+ *                  recipient:
+ *                    type: string
  *        "400":
  *           description: Bad Request (invalid request, already unsubscribed)
  *        "500":
  *           description: Internal Server Error
  */
-router.post(
-  '/',
-  celebrate(createUnsubscribeValidator),
+router.put(
+  '/:campaignId/:recipient',
+  celebrate(findOrCreateUnsubscribeValidator),
   UnsubscriberMiddleware.isUnsubscribeRequestValid,
-  UnsubscriberMiddleware.createUnsubscriber
+  UnsubscriberMiddleware.findOrCreateUnsubscriber
 )
 
 export default router

--- a/backend/src/core/routes/unsubscriber.routes.ts
+++ b/backend/src/core/routes/unsubscriber.routes.ts
@@ -27,7 +27,7 @@ const findOrCreateUnsubscribeValidator = {
  *      parameters:
  *        - name: campaignId
  *          in: path
- *          type: string
+ *          type: integer
  *          required: true
  *        - name: recipient
  *          in: path
@@ -57,20 +57,26 @@ const findOrCreateUnsubscribeValidator = {
  *              schema:
  *                type: object
  *                properties:
- *                  campaignId:
+ *                  campaign_id:
  *                    type: integer
  *                  recipient:
  *                    type: string
+ *                  created_at:
+ *                    type: string
+ *                    format: date-time
  *        "201":
  *          content:
  *            application/json:
  *              schema:
  *                type: object
  *                properties:
- *                  campaignId:
+ *                  campaign_id:
  *                    type: integer
  *                  recipient:
  *                    type: string
+ *                  created_at:
+ *                    type: string
+ *                    format: date-time
  *        "400":
  *           description: Bad Request (invalid request, already unsubscribed)
  *        "500":

--- a/backend/src/core/services/unsubscriber.service.ts
+++ b/backend/src/core/services/unsubscriber.service.ts
@@ -36,36 +36,26 @@ const validateHash = ({
 }
 
 /**
- * Retrieves unsubscriber
- * @param campaignId
- * @param recipient
- */
-const getUnsubscriber = (
-  campaignId: number,
-  recipient: string
-): Promise<Unsubscriber> => {
-  return Unsubscriber.findOne({
-    where: { campaignId, recipient },
-  })
-}
-
-/**
  * Create a new unsubscriber
  * @param campaignId
  * @param recipient
  */
-const createUnsubscriber = ({
+const findOrCreateUnsubscriber = ({
   campaignId,
   recipient,
 }: {
   campaignId: number
   recipient: string
-}): Promise<Unsubscriber> => {
-  return Unsubscriber.create({ campaignId, recipient })
+}): Promise<[Unsubscriber, boolean]> => {
+  return Unsubscriber.findOrCreate({
+    where: {
+      campaignId,
+      recipient,
+    },
+  })
 }
 
 export const UnsubscriberService = {
   validateHash,
-  getUnsubscriber,
-  createUnsubscriber,
+  findOrCreateUnsubscriber,
 }


### PR DESCRIPTION
## Problem

GET endpoint wasn't required. Should be removed to minimise API surface. 

## Solution

**Improvements**:
- Removed `GET /unsubscribe` endpoint
- Changed `POST /unsubscribe` to `PUT /unsubscribe/:campaignId/:recipient`
   - Used `PUT` instead as `POST` endpoints are typically not idempotent
   - Moved `campaignId` and `recipient` to URL params to be in line with [RFC2616](https://tools.ietf.org/html/rfc2616#section-9.6) where the _"PUT method requests that the enclosed entity be stored under the supplied Request-URI"_
   - Also conforming with [RFC2616](https://tools.ietf.org/html/rfc2616#section-9.6), if a new unsubscriber is added, the  endpoint should return `201 Created`. Otherwise a `200 OK` is returned if the unsubscriber already exists. 
   - `h` and `v` are still passed in the request body JSON

## Tests
**Successfully add new subscriber**
- Create a campaign and note down the campaignId
- Call `PUT /unsubscribe/:campaignId/:recipient` with the following payload
```json
{
   "h":"hash",
   "v":"v1"
}
```
- Endpoint returns unsubscriber object in the request body with a status of `201 Created`

**Test idempotence**
- Call `PUT /unsubscribe/:campaignId/:recipient` with the following payload. The `campaignId` and and `recipient` should already been previously added before. 
```json
{
   "h":"hash",
   "v":"v1"
}
```
- Endpoint returns unsubscriber object in the request body with a status of `200 OK`

**Test invalid unsubscribe request**
- Create a campaign and note down the campaignId
- Call `PUT /unsubscribe/:campaignId/:recipient` with an invalid hash 
- Endpoint returns an error message with a `400 Bad Request` status
- Repeat this with invalid values for `campaignId` and `v`