### PR TITLE
chore: update csp headers to allow files from go

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -71,7 +71,7 @@ frontend:
             default-src 'self' https://*.postman.gov.sg;
             object-src 'none';
             script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
-            img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com"
+            img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg"
         - key: "Content-Security-Policy-Report-Only"
           value: report-uri https://b7b979b458ee470a86efff9ef1653b50@o399364.ingest.sentry.io/5261024;
     - pattern: "/static/**/*"


### PR DESCRIPTION
## Problem

Images were broken. 

## Solution

Allow images to be shown if they are hosted on go. 