### PR TITLE
Speed up worker

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2830,10 +2830,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -2845,6 +2844,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -2859,8 +2869,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "packet-reader": {
       "version": "1.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -31,6 +31,7 @@
     "module-alias": "^2.2.2",
     "nodemailer": "^6.4.6",
     "nodemailer-direct-transport": "^3.3.2",
+    "p-limit": "^3.0.2",
     "pg": "^8.2.1",
     "postman-templating": "file:../modules/postman-templating",
     "reflect-metadata": "^0.1.13",

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -137,7 +137,8 @@ const enqueueAndSend = async (): Promise<void> => {
         hasNext = false
       } else {
         const start = Date.now()
-        await Promise.all(messages.map((m) => sendMessage(m)))
+        // Fire and forget. This risks opening too many unresolved connections if the rate is high (Error: read ECONNRESET)
+        messages.forEach((m) => sendMessage(m))
         // Make sure at least 1 second has elapsed
         const wait = Math.max(0, 1000 - (Date.now() - start))
         await waitForMs(wait)


### PR DESCRIPTION
## Problem
Addresses #501
The following query computes time taken for email messages to be sent. 
```sql
-- Compute ratio of time taken to expected time. The closer it is to 1, the better.
select *,  time_taken/expected_time as ratio from (
        -- Expected time taken (based on number of messages / send rate)
	select a.campaign_id, num_messages, extract(epoch from time_taken) as time_taken, (num_messages::float/job_queue.send_rate) as expected_time, job_queue.updated_at from (
		-- Actual Time taken for num_messages to be sent
		select campaign_id, count(*) as num_messages, max(delivered_at)-min(sent_at) as time_taken  from email_messages, campaigns where email_messages.campaign_id = campaigns.id  and sent_at is not null group by campaign_id
	) a, 
job_queue where job_queue.campaign_id = a.campaign_id and num_messages>10
) b order by updated_at desc;
```
It shows that most of the email campaigns take longer to send than necessary. 
## Solution
## Implementation 2

With Ian's advice, use plimit to limit the number of messages being sent concurrently. This resolves the risks that are listed in the following description of implementation 1.
Campaign 338 was sent using the current implementation which awaits on the network calls to send messages. 339 and 340 were sent using this plimit implementation. 
<img width="789" alt="Screenshot 2020-08-25 at 6 45 49 AM" src="https://user-images.githubusercontent.com/33819199/91103667-a541de00-e69e-11ea-9415-a93cf20c930c.png">


## Previous implementation 1
Do not await on sending messages. Instead, just fire off the message at the specified rate. 
Risks:
- Too many unresolved connections (since we do not await, we're not sure if a connection is closed). I tested keeping some connections open, reaching around 1500 connections before ECONNRESET is thrown. 
- log_next_job will finalize a campaign when 1) all the messages that have sent_at set, also have delivered_at set, or, 2) all the messages have sent_at set, and twenty seconds have passed (to account for orphan campaigns where the sending worker died). With this fire-and-forget modification, in scenario (2), some messages may not have delivered_at set before getting logged. This situation is mitigated by the callback status being set on the messages table instead of the ground truth table. 

On staging - campaigns 245 and 246 were sent using this implementation. The ratio is much closer to 1. 
<img width="790" alt="Screenshot 2020-07-25 at 1 29 06 AM" src="https://user-images.githubusercontent.com/33819199/88423597-96a5a400-ce1e-11ea-811f-b8c0f3735f74.png">

