### PR TITLE
fix: Phone number normalisation in worker

### DIFF
--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -1,12 +1,10 @@
 import { difference, keys, chunk } from 'lodash'
 import { Transaction } from 'sequelize'
 
-import config from '@core/config'
 import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
-import { InvalidRecipientError, HydrationError } from '@core/errors'
+import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { PhoneNumberService } from '@core/services'
 import { TemplateClient, XSS_SMS_OPTION } from 'postman-templating'
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
@@ -229,29 +227,6 @@ const addToMessageLogs = async (
 }
 
 /**
- * Validate that recipient is a valid phone number and format it.
- */
-const validateAndFormatNumber = (
-  records: MessageBulkInsertInterface[]
-): MessageBulkInsertInterface[] => {
-  return records.map((record) => {
-    try {
-      const { recipient } = record
-      const normalised = PhoneNumberService.normalisePhoneNumber(
-        recipient,
-        config.get('defaultCountry')
-      )
-      return {
-        ...record,
-        recipient: normalised,
-      }
-    } catch (e) {
-      throw new InvalidRecipientError()
-    }
-  })
-}
-
-/**
  * Attempts to hydrate the first record.
  * @param records
  * @param templateBody
@@ -268,7 +243,6 @@ export const SmsTemplateService = {
   storeTemplate,
   getFilledTemplate,
   addToMessageLogs,
-  validateAndFormatNumber,
   testHydration,
   client,
 }

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2018,6 +2018,15 @@
         "type-check": "~0.3.2"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.7.55",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.7.55.tgz",
+      "integrity": "sha512-vYT83akP6uJq5QiMgzzVsWrGWJpQ4KgX2SmW0RBgLFD1UzICjVgp+7ajEep3oRcv2838kMTu1gj7KHPi0Y6Y6w==",
+      "requires": {
+        "minimist": "^1.2.5",
+        "xml2js": "^0.4.17"
+      }
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",

--- a/worker/package.json
+++ b/worker/package.json
@@ -26,6 +26,7 @@
     "bcrypt": "^4.0.1",
     "convict": "^6.0.0",
     "dotenv": "^8.2.0",
+    "libphonenumber-js": "^1.7.55",
     "lodash": "^4.17.19",
     "module-alias": "^2.2.2",
     "nodemailer": "^6.4.6",

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -5,6 +5,7 @@
 import convict from 'convict'
 import fs from 'fs'
 import path from 'path'
+import { isSupportedCountry } from 'libphonenumber-js'
 
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 
@@ -137,6 +138,14 @@ const config = convict({
     doc: 'The email address that appears in the From field of an email',
     default: '',
     env: 'SES_FROM',
+  },
+  defaultCountry: {
+    doc: 'Two-letter ISO country code to use in libphonenumber-js',
+    default: 'SG',
+    env: 'DEFAULT_COUNTRY',
+    format: (countryCode: string): boolean => {
+      return isSupportedCountry(countryCode)
+    },
   },
   smsOptions: {
     accountSid: {

--- a/worker/src/core/loaders/message-worker/sms.class.ts
+++ b/worker/src/core/loaders/message-worker/sms.class.ts
@@ -2,7 +2,9 @@ import { Sequelize } from 'sequelize-typescript'
 import { QueryTypes, Transaction } from 'sequelize'
 import map from 'lodash/map'
 import logger from '@core/logger'
+import config from '@core/config'
 import { CredentialService } from '@core/services/credential.service'
+import { PhoneNumberService } from '@core/services/phone-number.service'
 import { TemplateClient, XSS_SMS_OPTION } from 'postman-templating'
 import TwilioClient from '@sms/services/twilio-client.class'
 
@@ -71,16 +73,21 @@ class SMS {
     body: string
     campaignId?: number
   }): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!/^\+?[0-9]+$/.test(recipient)) {
+    return new Promise<string>((resolve, reject) => {
+      try {
+        const normalisedRecipient = PhoneNumberService.normalisePhoneNumber(
+          recipient,
+          config.get('defaultCountry')
+        )
+        return resolve(normalisedRecipient)
+      } catch (err) {
         return reject(new Error('Recipient is incorrectly formatted'))
       }
-      return resolve()
     })
-      .then(() => {
+      .then((normalisedRecipient: string) => {
         return this.twilioClient?.send(
           id,
-          recipient,
+          normalisedRecipient,
           templateClient.template(body, params),
           campaignId
         )

--- a/worker/src/core/services/phone-number.service.ts
+++ b/worker/src/core/services/phone-number.service.ts
@@ -1,0 +1,26 @@
+import { parsePhoneNumber, CountryCode } from 'libphonenumber-js/max'
+
+/**
+ * Validate and normalise phone number format. Default country code will
+ * be added if no country code is provided.
+ * @param phoneNumber
+ * @return formatted - E.164 formatted phone number
+ */
+const normalisePhoneNumber = (
+  phoneNumber: string,
+  defaultCountry: string
+): string => {
+  let parsed = parsePhoneNumber(phoneNumber, defaultCountry as CountryCode)
+
+  if (!parsed.isValid()) {
+    // If parsing fails with default country code, we retry by prepending a + sign.
+    parsed = parsePhoneNumber(`+${phoneNumber}`)
+    if (!parsed.isValid()) throw new Error('Phone number is invalid')
+  }
+
+  return parsed.number.toString()
+}
+
+export const PhoneNumberService = {
+  normalisePhoneNumber,
+}


### PR DESCRIPTION
## Problem

PR #573 did phone number normalisation and validation during the insertion into `sms_message` table (similar to Telegram). After moving validation of recipient to the worker, appending of +65 is no longer done as #573 removed the logic in the Twilio client. In addition, this might create an issue for campaigns that were created but not yet sent when merged into production.

This PR went with the approach for solving this by copying `PhoneNumberService` from the backend and using it as the validator and formatter for phone numbers in the worker. 

Alternative considered:
- Adopt same approach as Telegram and does normalisation in the backend. 
    - This wasn't chosen as I wanted to maintain the pattern of validating in the worker when possible. Telegram is not able to do this as it requires normalised phone numbers during the enqueue step to successfully retrieve `telegram_id`.
    - This will still require appending of `+65` in `TwilioClient` manually in order to be backward compatible

Closes #610 

## Solution

**Improvements**:

- Added `PhoneNumberService` in worker
- Replace regex validation with `PhoneNumberService` for formatting and validating `recipient`

## Tests
- Run unit tests in `backend` to confirm validation and formatting logic 
- Create SMS campaign with numbers with and without `+65`. 
- Create SMS campaign with invalid numbers (wrong length, does not start with 8/9/6). 

## Deploy Notes

**New environment variables**:

- `DEFAULT_COUNTRY` : default two-letter ISO country code to use in libphonenumber-js. Default value is set to 'SG' in config.

**New dependencies**:

- `libphonenumber-js ` : trimmed down version of `libphonenumber` without dependency on Closure