### PR TITLE
feat: Add unsubscribe footer in test email

### DIFF
--- a/backend/src/core/services/unsubscriber.service.ts
+++ b/backend/src/core/services/unsubscriber.service.ts
@@ -55,7 +55,24 @@ const findOrCreateUnsubscriber = ({
   })
 }
 
+const appendTestEmailUnsubLink = (body: string): string => {
+  const testUnsubUrl = new URL(`/unsubscribe/test`, config.get('frontendUrl'))
+
+  return `${body} <br><hr> 
+  <p style="font-size:12px;color:#818284;line-height:2em">\
+    <a href="https://postman.gov.sg" style="color:#edae49" target="_blank">Postman.gov.sg</a>
+    is a mass messaging platform used by the Singapore Government to communicate with stakeholders.
+    For more information, please visit our <a href="https://guide.postman.gov.sg/faqs/faq-recipients" style="color:#edae49" target="_blank">site</a>. 
+  </p>
+  <p style="font-size:12px;color:#818284;line-height:2em">
+    If you wish to unsubscribe from similar emails from your sender, please click <a href="${testUnsubUrl}" style="color:#edae49" target="_blank">here</a>
+    to unsubscribe and we will inform the respective agency.
+  </p>
+  `
+}
+
 export const UnsubscriberService = {
   validateHash,
   findOrCreateUnsubscriber,
+  appendTestEmailUnsubLink,
 }

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -1,7 +1,11 @@
 import logger from '@core/logger'
 import { ChannelType } from '@core/constants'
 import { Campaign } from '@core/models'
-import { MailService, CampaignService } from '@core/services'
+import {
+  MailService,
+  CampaignService,
+  UnsubscriberService,
+} from '@core/services'
 import { MailToSend, CampaignDetails } from '@core/interfaces'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
@@ -66,7 +70,7 @@ const getCampaignMessage = async (
     const { body, subject, replyTo } = message
     const mailToSend: MailToSend = {
       recipients: [recipient],
-      body,
+      body: UnsubscriberService.appendTestEmailUnsubLink(body),
       subject,
       ...(replyTo ? { replyTo } : {}),
     }

--- a/frontend/src/components/unsubscribe/Unsubscribe.tsx
+++ b/frontend/src/components/unsubscribe/Unsubscribe.tsx
@@ -32,12 +32,16 @@ const Unsubscribe = () => {
 
       const { c: campaignId, r: recipient, h: hash } = params
 
-      await unsubscribeRequest({
-        campaignId: +campaignId,
-        recipient: recipient as string,
-        hash: hash as string,
-        version,
-      })
+      // Version is set to 'test' when the unsub link is generated from a campaign
+      // test email. As such, we should not make any API calls.
+      if (version !== 'test') {
+        await unsubscribeRequest({
+          campaignId: +campaignId,
+          recipient: recipient as string,
+          hash: hash as string,
+          version,
+        })
+      }
       setUnsubscribed(true)
     } catch (err) {
       setErrorMsg('Invalid subscribe request')


### PR DESCRIPTION
## Problem

Test emails did not include the unsubscribe footer. Users might be interested to test out the unsub user flow without trigger an actual unsub. 

## Solution

**Features**:

- Appended a test unsubscribe footer to test emails. Link direct to `/unsubscribe/test`. 
- Skip actual API call if the version is set to `test` on the frontend 

## Tests
- Create an email campaign
- Send a test email to yourself
- Click on unsubscribe link in test email footer and go through unsubscribe flow
- `unsubscribers` table should remain unchanged