### PR TITLE
chore: Restrict Telegram bot token access

### DIFF
--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -16,13 +16,13 @@ const secretsManager = new AWS.SecretsManager(configureEndpoint(config))
  * Upserts credential into AWS SecretsManager
  * @param name
  * @param secret
- * @param isBotToken
+ * @param restrictEnvironment
  * @throws error if update fails
  */
 const upsertCredential = async (
   name: string,
   secret: string,
-  isBotToken: boolean
+  restrictEnvironment: boolean
 ): Promise<void> => {
   // If credential doesn't exist, upload credential to secret manager, unless in development
   if (!config.get('IS_PROD') && !config.get('aws.awsEndpoint')) {
@@ -50,7 +50,7 @@ const upsertCredential = async (
         .createSecret({
           Name: name,
           SecretString: secret,
-          ...(isBotToken
+          ...(restrictEnvironment
             ? { Tags: [{ Key: 'environment', Value: config.get('env') }] }
             : {}),
         })
@@ -68,17 +68,17 @@ const upsertCredential = async (
  * Save a credential into secrets manager and the credential table
  * @param name
  * @param secret
- * @param isBotToken
+ * @param restrictEnvironment
  */
 const storeCredential = async (
   name: string,
   secret: string,
-  isBotToken = false
+  restrictEnvironment = false
 ): Promise<void> => {
   // If adding a credential to secrets manager throws an error, db will not be updated
   // If adding a credential to secrets manager succeeds, but the db call fails, it is ok because the credential will not be associated with a campaign
   // It results in orphan secrets manager credentials, which is acceptable.
-  await upsertCredential(name, secret, isBotToken)
+  await upsertCredential(name, secret, restrictEnvironment)
   logger.info('Storing credential in DB')
   await Credential.findCreateFind({
     where: { name },

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -57,6 +57,7 @@ const upsertCredential = async (
         .promise()
       logger.info('Successfully stored credential in AWS secrets manager')
     } else {
+      logger.error(err)
       throw err
     }
   }

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -115,7 +115,11 @@ const validateAndStoreCredentials = async (
       // botId.
       credentialName = telegramBotToken.split(':')[0]
 
-      await CredentialService.storeCredential(credentialName, telegramBotToken)
+      await CredentialService.storeCredential(
+        credentialName,
+        telegramBotToken,
+        true
+      )
     } catch (err) {
       return res.status(400).json({ message: `${err.message}` })
     }

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -121,7 +121,7 @@ const validateAndStoreCredentials = async (
         true
       )
     } catch (err) {
-      return res.status(400).json({ message: `${err.message}` })
+      return res.status(400).json({ message: 'Error storing credentials' })
     }
   }
 


### PR DESCRIPTION
## Problem

Storing a bot token repeatedly in staging/production causes the webhook URL to keep changing - difficult to debug. 

Closes #594. 

## Solution

This PR:

- Tags new bot token secrets with a `environment` tag set to `staging` or `production`
- Relies on IAM policies to restrict access 
- Displays generic error message to users

## Tests

Deploy this to staging to test: 

1. Create a new Telegram bot, store on staging
2. Check that `environment` is set to `staging` in the stored secret on Secrets Manager
3. Change the `environment` value to something else
4. Delete the credential in Postman and try storing again
    - You should get "Error storing credentials" on the frontend
    - In CloudWatch, there should be an entry like: 
    ```
    error - User: arn:<beanstalk instance role> is not authorized to perform: secretsmanager:PutSecretValue
    ```

## Deploy Notes

- Manually tag all existing bot tokens in Secrets Manager with their respective environments
- Update Secrets Manager policy for production EB instance - refer to staging's as an example
    - Add `secretsmanager:TagResource` action
    - Add condition to only allow access to production secrets
    ```
    "Condition": {
        "StringEqualsIfExists": {
            "secretsmanager:ResourceTag/environment": "production"
        }
    }
    ```
