### PR TITLE
Poll export status to prevent being stuck in loading status

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -50,8 +50,8 @@ export interface CampaignDetails {
 
 export interface CampaignStats extends CampaignStatsCount {
   status: string
-  updated_at: Date
   halted?: boolean
+  status_updated_at?: Date
 }
 
 export interface CampaignStatsCount {
@@ -59,7 +59,7 @@ export interface CampaignStatsCount {
   unsent: number
   sent: number
   invalid: number
-  updatedAt?: Date
+  updated_at: Date
 }
 
 export interface CampaignInvalidRecipient {

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -21,6 +21,7 @@ const getStatsFromArchive = async (
       sent: 0,
       unsent: 0,
       invalid: 0,
+      updated_at: new Date(),
     }
   }
   return {
@@ -28,7 +29,7 @@ const getStatsFromArchive = async (
     sent: stats?.sent,
     unsent: stats?.unsent,
     invalid: stats?.invalid,
-    updatedAt: stats?.updatedAt,
+    updated_at: stats?.updatedAt,
   }
 }
 
@@ -92,6 +93,7 @@ const getStatsFromTable = async (
     sent: +data.sent,
     unsent: +data.unsent,
     invalid: +data.invalid,
+    updated_at: new Date(),
   }
 }
 
@@ -148,8 +150,9 @@ const getCurrentStats = async (
     invalid: archivedStats.invalid,
     status: job.status,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    updated_at: archivedStats.updatedAt!,
+    updated_at: archivedStats.updated_at,
     halted: job.campaign.halted,
+    status_updated_at: job.updatedAt, // Timestamp when job was logged
   }
 }
 

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -142,7 +142,10 @@ const getCurrentStats = async (
   }
   // else, return archived stats
   return {
-    ...archivedStats,
+    error: archivedStats.error,
+    unsent: archivedStats.unsent,
+    sent: archivedStats.sent,
+    invalid: archivedStats.invalid,
     status: job.status,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     updated_at: archivedStats.updatedAt!,

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -71,7 +71,8 @@ export class CampaignStats {
   sent: number
   invalid: number
   status: Status
-  updatedAt: Date
+  statusUpdatedAt: Date // Timestamp when job's status was changed to this status
+  updatedAt: Date // Timestamp when statistic was updated
   halted?: boolean
 
   constructor(input: any) {
@@ -80,6 +81,7 @@ export class CampaignStats {
     this.sent = +input['sent']
     this.invalid = input['invalid']
     this.status = input['status']
+    this.statusUpdatedAt = input['status_updated_at']
     this.updatedAt = input['updated_at']
     this.halted = input['halted']
   }

--- a/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
@@ -31,3 +31,25 @@
 .disabled {
   opacity: 0.5;
 }
+
+.actionButton {
+  @include flex-horizontal;
+  justify-content: flex-end;
+  margin: 3rem 0;
+
+  .disableActiveState {
+    cursor: not-allowed;
+
+    &:active {
+      span,
+      i {
+        color: $indigo-blue;
+      }
+    }
+
+    &:hover {
+      border-width: 1px;
+      background-color: white;
+    }
+  }
+}

--- a/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
@@ -5,12 +5,13 @@
   color: $indigo-blue;
   padding: 0.5rem;
 
-  .ready {
-    cursor: pointer;
+  &.unavailable {
+    color: $light-grey;
+    cursor: not-allowed;
   }
 
-  .unavailable {
-    color: $light-grey;
+  &.ready {
+    cursor: pointer;
   }
 
   .icon {

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -145,11 +145,7 @@ const ExportRecipients = ({
         className={cx(
           styles.export,
           { [styles.ready]: exportStatus === CampaignExportStatus.Ready },
-          {
-            [styles.unavailable]:
-              exportStatus === CampaignExportStatus.NoError ||
-              exportStatus === CampaignExportStatus.Unavailable,
-          },
+          { [styles.unavailable]: exportStatus !== CampaignExportStatus.Ready },
           { [styles.disabled]: disabled }
         )}
         onClick={(e) =>
@@ -171,10 +167,7 @@ const ExportRecipients = ({
       {isButton ? (
         <div className={styles.actionButton}>
           <ActionButton
-            disabled={
-              exportStatus === CampaignExportStatus.NoError ||
-              exportStatus === CampaignExportStatus.Unavailable
-            }
+            disabled={exportStatus !== CampaignExportStatus.Ready}
             className={cx({
               [styles.disableActiveState]:
                 exportStatus === CampaignExportStatus.Loading,

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -79,30 +79,3 @@
     font-size: 1rem;
   }
 }
-
-.statsLastUpdated {
-  @include flex-horizontal;
-  justify-content: space-between;
-}
-
-.actionButton {
-  @include flex-horizontal;
-  justify-content: flex-end;
-  margin: 3rem 0;
-
-  .disableActiveState {
-    cursor: not-allowed;
-
-    &:active {
-      span,
-      i {
-        color: $indigo-blue;
-      }
-    }
-
-    &:hover {
-      border-width: 1px;
-      background-color: white;
-    }
-  }
-}

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -79,3 +79,8 @@
     font-size: 1rem;
   }
 }
+
+.statsLastUpdated {
+  @include flex-horizontal;
+  justify-content: space-between;
+}

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -27,7 +27,16 @@ const ProgressDetails = ({
   handleRetry: () => Promise<void>
   handleRefreshStats: () => Promise<void>
 }) => {
-  const { status, error, unsent, sent, invalid, updatedAt, halted } = stats
+  const {
+    status,
+    statusUpdatedAt,
+    error,
+    unsent,
+    sent,
+    invalid,
+    updatedAt,
+    halted,
+  } = stats
   const [isSent, setIsSent] = useState(status === Status.Sent)
   const [isComplete, setIsComplete] = useState(!error && !unsent)
   const [isHalted, setIsHalted] = useState(!!halted)
@@ -92,8 +101,7 @@ const ProgressDetails = ({
       return (
         <div className={styles.statsLastUpdated}>
           <span>
-            Stats last retrieved on{' '}
-            <Moment format="LLL">{stats.updatedAt}</Moment>
+            Stats last retrieved on <Moment format="LLL">{updatedAt}</Moment>
           </span>
           <PrimaryButton onClick={handleRefreshStats}>
             Refresh stats
@@ -138,9 +146,9 @@ const ProgressDetails = ({
         iconPosition="right"
         campaignId={campaignId}
         campaignName={campaignName}
-        status={status}
         sentAt={sentAt}
-        updatedAt={updatedAt}
+        status={status}
+        statusUpdatedAt={statusUpdatedAt}
         hasFailedRecipients={error + invalid > 0}
         isButton
       />

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -13,7 +13,7 @@ import {
   PrimaryButton,
   ExportRecipients,
 } from 'components/common'
-import { getCampaigns, getExportStatus } from 'services/campaign.service'
+import { getCampaigns } from 'services/campaign.service'
 import { Campaign, channelIcons, Status } from 'classes'
 import CreateCampaign from 'components/dashboard/create/create-modal'
 
@@ -114,11 +114,8 @@ const Campaigns = () => {
             campaignName={campaign.name}
             status={campaign.status}
             sentAt={campaign.sentAt}
-            exportStatus={getExportStatus(
-              campaign.status,
-              campaign.statusUpdatedAt,
-              +campaign.hasFailedRecipients
-            )}
+            updatedAt={campaign.statusUpdatedAt}
+            hasFailedRecipients={campaign.hasFailedRecipients}
           />
         )
       },

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -112,9 +112,9 @@ const Campaigns = () => {
             iconPosition="left"
             campaignId={campaign.id}
             campaignName={campaign.name}
-            status={campaign.status}
             sentAt={campaign.sentAt}
-            updatedAt={campaign.statusUpdatedAt}
+            status={campaign.status}
+            statusUpdatedAt={campaign.statusUpdatedAt}
             hasFailedRecipients={campaign.hasFailedRecipients}
           />
         )

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -11,15 +11,6 @@ import {
 } from 'classes'
 import moment from 'moment'
 
-const EXPORT_LINK_DISPLAY_WAIT_TIME = 1 * 60 * 1000 // 1 min
-
-export enum CampaignExportStatus {
-  Unavailable = 'Unavailable',
-  Loading = 'Loading',
-  Ready = 'Ready',
-  NoError = 'No Error',
-}
-
 function getJobTimestamps(
   jobs: Array<{ sent_at: Date; status_updated_at: Date }>
 ): { sentAt: Date; statusUpdatedAt: Date } {
@@ -27,26 +18,6 @@ function getJobTimestamps(
   const jobsUpdatedAt = jobs.map((x) => x.status_updated_at).sort()
   // returns job with the earliest sentAt time
   return { sentAt: jobsSentAt[0], statusUpdatedAt: jobsUpdatedAt[0] }
-}
-
-export function getExportStatus(
-  status: Status,
-  updatedAt: Date,
-  failedCount: number
-): CampaignExportStatus {
-  if (status === Status.Sending) {
-    return CampaignExportStatus.Unavailable
-  }
-
-  const updatedAtTimestamp = +new Date(updatedAt)
-  const campaignAge = Date.now() - updatedAtTimestamp
-  if (campaignAge <= EXPORT_LINK_DISPLAY_WAIT_TIME) {
-    return CampaignExportStatus.Loading
-  }
-
-  return failedCount > 0
-    ? CampaignExportStatus.Ready
-    : CampaignExportStatus.NoError
 }
 
 export async function getCampaigns(params: {


### PR DESCRIPTION
## Problem

Export button is stuck in loading status after campaign has been sent out, until page is refreshed.

Closes #623 

## Solution

After campaign status became `Status.Sent`, `ExportRecipients` component stopped checking for the export status. To ensure that the export status is updated after campaign has been sent, poll the export status until it returns a finalised status.
