### PR TITLE
fix: Save template draft when choosing to finish later

### DIFF
--- a/frontend/src/components/common/confirm-modal/ConfirmModal.module.scss
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.module.scss
@@ -33,4 +33,9 @@
   font-weight: normal;
   margin-top: 0;
   margin-bottom: 3rem;
+  text-align: center;
+}
+
+.options {
+  display: flex;
 }

--- a/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from 'react'
 import cx from 'classnames'
 
-import { PrimaryButton, ErrorBlock } from 'components/common'
+import { PrimaryButton, TextButton, ErrorBlock } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'
 
 import ConfirmImage from 'assets/img/confirm-modal.svg'
@@ -12,15 +12,19 @@ const ConfirmModal = ({
   subtitle,
   buttonText,
   buttonIcon,
+  cancelText,
   destructive,
   onConfirm,
+  onCancel,
 }: {
   title: string
   subtitle: string
   buttonText: string
   buttonIcon?: string
+  cancelText?: string
   destructive?: boolean
-  onConfirm: () => Promise<any>
+  onConfirm: () => Promise<any> | any
+  onCancel?: () => Promise<any> | any
 }) => {
   const modalContext = useContext(ModalContext)
   const [errorMessage, setErrorMessage] = useState('')
@@ -34,6 +38,16 @@ const ConfirmModal = ({
       setErrorMessage(err.message)
     }
   }
+
+  async function onCancelClicked(): Promise<void> {
+    try {
+      if (onCancel) await onCancel()
+      // Closes the modal
+      modalContext.setModalContent(null)
+    } catch (err) {
+      setErrorMessage(err.message)
+    }
+  }
   return (
     <div className={styles.confirm}>
       <div className={styles.modalImg}>
@@ -41,13 +55,20 @@ const ConfirmModal = ({
       </div>
       <h2 className={styles.title}>{title}</h2>
       <h4 className={styles.subtitle}>{subtitle}</h4>
-      <PrimaryButton
-        className={destructive ? styles.redButton : styles.greenButton}
-        onClick={onConfirmedClicked}
-      >
-        {buttonText}
-        {buttonIcon && <i className={cx('bx', styles.icon, buttonIcon)}></i>}
-      </PrimaryButton>
+      <div className={styles.options}>
+        <PrimaryButton
+          className={destructive ? styles.redButton : styles.greenButton}
+          onClick={onConfirmedClicked}
+        >
+          {buttonText}
+          {buttonIcon && <i className={cx('bx', styles.icon, buttonIcon)}></i>}
+        </PrimaryButton>
+        {cancelText && (
+          <TextButton minButtonWidth onClick={onCancelClicked}>
+            {cancelText}
+          </TextButton>
+        )}
+      </div>
       <ErrorBlock>{errorMessage}</ErrorBlock>
     </div>
   )

--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -62,6 +62,7 @@ const Create = () => {
           <TelegramCreate
             campaign={campaign as TelegramCampaign}
             onCampaignChange={setCampaign}
+            finishLaterCallbackRef={finishLaterCallbackRef}
           />
         )
       default:

--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -46,6 +46,7 @@ const Create = () => {
           <SMSCreate
             campaign={campaign as SMSCampaign}
             onCampaignChange={setCampaign}
+            finishLaterCallbackRef={finishLaterCallbackRef}
           />
         )
       case ChannelType.Email:

--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -27,7 +27,7 @@ const Create = () => {
   const [campaign, setCampaign] = useState(new Campaign({}))
   const [isLoading, setLoading] = useState(true)
   const finishLaterCallbackRef: React.MutableRefObject<
-    (() => Promise<void>) | undefined
+    (() => void) | undefined
   > = useRef()
 
   async function loadProject(id: string) {
@@ -46,21 +46,7 @@ const Create = () => {
       sendUserEvent(GA_USER_EVENTS.FINISH_CAMPAIGN_LATER, campaign.type)
 
       if (finishLaterCallbackRef.current) {
-        return modalContext.setModalContent(
-          <ConfirmModal
-            title="Would you like to save your draft?"
-            subtitle='Your current template will be saved and you can return to it later by selecting the "Create message" step on the navigation bar at the side.'
-            buttonText="Save draft"
-            cancelText="Skip saving draft"
-            onConfirm={async () => {
-              if (finishLaterCallbackRef.current) {
-                await finishLaterCallbackRef.current()
-              }
-              history.push('/campaigns')
-            }}
-            onCancel={() => history.push('/campaigns')}
-          />
-        )
+        return finishLaterCallbackRef.current()
       }
     }
     history.push('/campaigns')

--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState, useRef } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useParams, useHistory } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -10,8 +10,7 @@ import {
   TelegramCampaign,
   Status,
 } from 'classes'
-import { ModalContext } from 'contexts/modal.context'
-import { TitleBar, PrimaryButton, ConfirmModal } from 'components/common'
+import { TitleBar, PrimaryButton } from 'components/common'
 import { getCampaignDetails } from 'services/campaign.service'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 import SMSCreate from './sms/SMSCreate'
@@ -23,7 +22,6 @@ const Create = () => {
   const { id } = useParams()
   const history = useHistory()
 
-  const modalContext = useContext(ModalContext)
   const [campaign, setCampaign] = useState(new Campaign({}))
   const [isLoading, setLoading] = useState(true)
   const finishLaterCallbackRef: React.MutableRefObject<

--- a/frontend/src/components/dashboard/create/email/EmailCreate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCreate.tsx
@@ -79,6 +79,7 @@ const CreateEmail = ({
               numRecipients={campaign.numRecipients}
               isProcessing={campaign.isCsvProcessing}
               onNext={onNext}
+              finishLaterCallbackRef={finishLaterCallbackRef}
             />
           )
         }

--- a/frontend/src/components/dashboard/create/email/EmailCreate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCreate.tsx
@@ -27,9 +27,7 @@ const CreateEmail = ({
 }: {
   campaign: EmailCampaign
   onCampaignChange: (c: Campaign) => void
-  finishLaterCallbackRef: React.MutableRefObject<
-    (() => Promise<void>) | undefined
-  >
+  finishLaterCallbackRef: React.MutableRefObject<(() => void) | undefined>
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)

--- a/frontend/src/components/dashboard/create/email/EmailCreate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCreate.tsx
@@ -23,9 +23,13 @@ const EMAIL_PROGRESS_STEPS = [
 const CreateEmail = ({
   campaign: initialCampaign,
   onCampaignChange,
+  finishLaterCallbackRef,
 }: {
   campaign: EmailCampaign
   onCampaignChange: (c: Campaign) => void
+  finishLaterCallbackRef: React.MutableRefObject<
+    (() => Promise<void>) | undefined
+  >
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
@@ -66,6 +70,7 @@ const CreateEmail = ({
             replyTo={campaign.replyTo}
             protect={campaign.protect}
             onNext={onNext}
+            finishLaterCallbackRef={finishLaterCallbackRef}
           />
         )
       case EmailProgress.UploadRecipients:

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -36,7 +36,7 @@ const EmailTemplate = ({
     'Dear {{ name }}, your next appointment at {{ clinic }} is on {{ date }} at {{ time }}'
 
   const handleSaveTemplate = useCallback(
-    async (next = true): Promise<void> => {
+    async (propagateError = false): Promise<void> => {
       setErrorMsg(null)
       try {
         if (!campaignId) {
@@ -48,23 +48,16 @@ const EmailTemplate = ({
           body,
           replyTo
         )
-        onNext(
-          {
-            subject: updatedTemplate?.subject,
-            body: updatedTemplate?.body,
-            replyTo: updatedTemplate?.reply_to,
-            params: updatedTemplate?.params,
-            numRecipients,
-          },
-          next
-        )
+        onNext({
+          subject: updatedTemplate?.subject,
+          body: updatedTemplate?.body,
+          replyTo: updatedTemplate?.reply_to,
+          params: updatedTemplate?.params,
+          numRecipients,
+        })
       } catch (err) {
         setErrorMsg(err.message)
-
-        // Rethrow error to be handled elsewhere
-        if (!next) {
-          throw err
-        }
+        if (propagateError) throw err
       }
     },
     [body, campaignId, onNext, replyTo, subject]
@@ -78,7 +71,7 @@ const EmailTemplate = ({
           saveable
           onSave={async () => {
             if (subject && body) {
-              await handleSaveTemplate(false)
+              await handleSaveTemplate(true)
             }
           }}
         />

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -72,12 +72,14 @@ const EmailTemplate = ({
   // Set callback for finish later button
   useEffect(() => {
     finishLaterCallbackRef.current = async () => {
-      await handleSaveTemplate(false)
+      if (subject && body) {
+        await handleSaveTemplate(false)
+      }
     }
     return () => {
       finishLaterCallbackRef.current = undefined
     }
-  }, [finishLaterCallbackRef, handleSaveTemplate])
+  }, [body, finishLaterCallbackRef, handleSaveTemplate, subject])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n') || ''

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -75,6 +75,7 @@ const EmailTemplate = ({
     finishLaterCallbackRef.current = () => {
       modalContext.setModalContent(
         <SaveDraftModal
+          saveable
           onSave={async () => {
             if (subject && body) {
               await handleSaveTemplate(false)

--- a/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import { useParams } from 'react-router-dom'
 import isEmail from 'validator/lib/isEmail'
 
@@ -11,6 +11,8 @@ import {
   ProtectedPreview,
   Checkbox,
 } from 'components/common'
+import SaveDraftModal from 'components/dashboard/create/save-draft-modal'
+import { ModalContext } from 'contexts/modal.context'
 import EmailRecipients from './EmailRecipients'
 import { EmailCampaign } from 'classes'
 import { sendTiming } from 'services/ga.service'
@@ -31,12 +33,15 @@ const ProtectedEmailRecipients = ({
   numRecipients,
   isProcessing,
   onNext,
+  finishLaterCallbackRef,
 }: {
   csvFilename: string
   numRecipients: number
   isProcessing: boolean
   onNext: (changes: Partial<EmailCampaign>, next?: boolean) => void
+  finishLaterCallbackRef: React.MutableRefObject<(() => void) | undefined>
 }) => {
+  const modalContext = useContext(ModalContext)
   const [template, setTemplate] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
   const [selectedFile, setSelectedFile] = useState<File>()
@@ -51,6 +56,16 @@ const ProtectedEmailRecipients = ({
   useEffect(() => {
     setPhase(computePhase(numRecipients, isProcessing))
   }, [numRecipients, isProcessing])
+
+  // Set callback for finish later button
+  useEffect(() => {
+    finishLaterCallbackRef.current = () => {
+      modalContext.setModalContent(<SaveDraftModal />)
+    }
+    return () => {
+      finishLaterCallbackRef.current = undefined
+    }
+  }, [template, finishLaterCallbackRef, modalContext])
 
   function computePhase(
     numRecipients: number,

--- a/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
+++ b/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+import { ConfirmModal } from 'components/common'
+
+const SaveDraftModal = ({
+  onSave,
+}: {
+  onSave?: () => Promise<void> | undefined
+}) => {
+  const history = useHistory()
+
+  async function handleOnSaveClicked(): Promise<void> {
+    if (onSave) await onSave()
+    history.push('/campaigns')
+  }
+
+  return (
+    <ConfirmModal
+      title="Would you like to save your draft?"
+      subtitle='Your current template will be saved and you can return to it later by selecting the "Create message" step on the navigation bar at the side.'
+      buttonText="Save draft"
+      cancelText="Skip saving draft"
+      onConfirm={handleOnSaveClicked}
+      onCancel={() => history.push('/campaigns')}
+    />
+  )
+}
+
+export default SaveDraftModal

--- a/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
+++ b/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
@@ -4,8 +4,10 @@ import { ConfirmModal } from 'components/common'
 
 const SaveDraftModal = ({
   onSave,
+  saveable,
 }: {
   onSave?: () => Promise<void> | undefined
+  saveable?: boolean
 }) => {
   const history = useHistory()
 
@@ -14,7 +16,7 @@ const SaveDraftModal = ({
     history.push('/campaigns')
   }
 
-  return (
+  return saveable ? (
     <ConfirmModal
       title="Would you like to save your draft?"
       subtitle='Your current template will be saved and you can return to it later by selecting the "Create message" step on the navigation bar at the side.'
@@ -22,6 +24,13 @@ const SaveDraftModal = ({
       cancelText="Skip saving draft"
       onConfirm={handleOnSaveClicked}
       onCancel={() => history.push('/campaigns')}
+    />
+  ) : (
+    <ConfirmModal
+      title="Draft cannot be saved"
+      subtitle="Drafts for encrypted messages are not saved. Make sure you have stored the template draft somewhere if you would like to keep it."
+      buttonText="Back to campaigns"
+      onConfirm={() => history.push('/campaigns')}
     />
   )
 }

--- a/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
+++ b/frontend/src/components/dashboard/create/save-draft-modal/SaveDraftModal.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useState, useContext } from 'react'
 import { useHistory } from 'react-router-dom'
 import { ConfirmModal } from 'components/common'
+import { ModalContext } from 'contexts/modal.context'
 
 const SaveDraftModal = ({
   onSave,
@@ -10,19 +11,32 @@ const SaveDraftModal = ({
   saveable?: boolean
 }) => {
   const history = useHistory()
+  const modalContext = useContext(ModalContext)
+  const [error, setError] = useState()
 
   async function handleOnSaveClicked(): Promise<void> {
-    if (onSave) await onSave()
-    history.push('/campaigns')
+    try {
+      if (onSave) await onSave()
+      history.push('/campaigns')
+    } catch (err) {
+      setError(err)
+      // Propagate error so that ConfirmModal will display the error message
+      throw err
+    }
+  }
+
+  function handleEditDraft(): void {
+    // Dismiss modal
+    modalContext.setModalContent(null)
   }
 
   return saveable ? (
     <ConfirmModal
       title="Would you like to save your draft?"
       subtitle='Your current template will be saved and you can return to it later by selecting the "Create message" step on the navigation bar at the side.'
-      buttonText="Save draft"
+      buttonText={error ? 'Edit draft' : 'Save draft'}
       cancelText="Skip saving draft"
-      onConfirm={handleOnSaveClicked}
+      onConfirm={error ? handleEditDraft : handleOnSaveClicked}
       onCancel={() => history.push('/campaigns')}
     />
   ) : (

--- a/frontend/src/components/dashboard/create/save-draft-modal/index.ts
+++ b/frontend/src/components/dashboard/create/save-draft-modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SaveDraftModal'

--- a/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
@@ -25,9 +25,7 @@ const CreateSMS = ({
 }: {
   campaign: SMSCampaign
   onCampaignChange: (c: Campaign) => void
-  finishLaterCallbackRef: React.MutableRefObject<
-    (() => Promise<void>) | undefined
-  >
+  finishLaterCallbackRef: React.MutableRefObject<(() => void) | undefined>
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)

--- a/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
@@ -21,9 +21,13 @@ const SMS_PROGRESS_STEPS = [
 const CreateSMS = ({
   campaign: initialCampaign,
   onCampaignChange,
+  finishLaterCallbackRef,
 }: {
   campaign: SMSCampaign
   onCampaignChange: (c: Campaign) => void
+  finishLaterCallbackRef: React.MutableRefObject<
+    (() => Promise<void>) | undefined
+  >
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
@@ -57,7 +61,13 @@ const CreateSMS = ({
   function renderStep() {
     switch (activeStep) {
       case SMSProgress.CreateTemplate:
-        return <SMSTemplate body={campaign.body} onNext={onNext} />
+        return (
+          <SMSTemplate
+            body={campaign.body}
+            onNext={onNext}
+            finishLaterCallbackRef={finishLaterCallbackRef}
+          />
+        )
       case SMSProgress.UploadRecipients:
         return (
           <SMSRecipients

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -69,6 +69,7 @@ const SMSTemplate = ({
     finishLaterCallbackRef.current = () => {
       modalContext.setModalContent(
         <SaveDraftModal
+          saveable
           onSave={async () => {
             if (body) await handleSaveTemplate(false)
           }}

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -39,7 +39,7 @@ const SMSTemplate = ({
   }, [body])
 
   const handleSaveTemplate = useCallback(
-    async (next = true): Promise<void> => {
+    async (propagateError = false): Promise<void> => {
       setErrorMsg(null)
       try {
         if (!campaignId) {
@@ -49,16 +49,14 @@ const SMSTemplate = ({
           +campaignId,
           body
         )
-        onNext(
-          {
-            body: updatedTemplate?.body,
-            params: updatedTemplate?.params,
-            numRecipients,
-          },
-          next
-        )
+        onNext({
+          body: updatedTemplate?.body,
+          params: updatedTemplate?.params,
+          numRecipients,
+        })
       } catch (err) {
         setErrorMsg(err.message)
+        if (propagateError) throw err
       }
     },
     [body, campaignId, onNext]
@@ -71,7 +69,7 @@ const SMSTemplate = ({
         <SaveDraftModal
           saveable
           onSave={async () => {
-            if (body) await handleSaveTemplate(false)
+            if (body) await handleSaveTemplate(true)
           }}
         />
       )

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 
 import { TextArea, NextButton, ErrorBlock } from 'components/common'
 import { useParams } from 'react-router-dom'
@@ -8,9 +8,13 @@ import styles from '../Create.module.scss'
 const SMSTemplate = ({
   body: initialBody,
   onNext,
+  finishLaterCallbackRef,
 }: {
   body: string
   onNext: (changes: any, next?: boolean) => void
+  finishLaterCallbackRef: React.MutableRefObject<
+    (() => Promise<void>) | undefined
+  >
 }) => {
   const [body, setBody] = useState(replaceNewLines(initialBody))
   const [errorMsg, setErrorMsg] = useState(null)
@@ -33,25 +37,43 @@ const SMSTemplate = ({
     }
   }, [body])
 
-  async function handleSaveTemplate(): Promise<void> {
-    setErrorMsg(null)
-    try {
-      if (!campaignId) {
-        throw new Error('Invalid campaign id')
+  const handleSaveTemplate = useCallback(
+    async (next = true): Promise<void> => {
+      setErrorMsg(null)
+      try {
+        if (!campaignId) {
+          throw new Error('Invalid campaign id')
+        }
+        const { updatedTemplate, numRecipients } = await saveTemplate(
+          +campaignId,
+          body
+        )
+        onNext(
+          {
+            body: updatedTemplate?.body,
+            params: updatedTemplate?.params,
+            numRecipients,
+          },
+          next
+        )
+      } catch (err) {
+        setErrorMsg(err.message)
       }
-      const { updatedTemplate, numRecipients } = await saveTemplate(
-        +campaignId,
-        body
-      )
-      onNext({
-        body: updatedTemplate?.body,
-        params: updatedTemplate?.params,
-        numRecipients,
-      })
-    } catch (err) {
-      setErrorMsg(err.message)
+    },
+    [body, campaignId, onNext]
+  )
+
+  // Set callback for finish later button
+  useEffect(() => {
+    finishLaterCallbackRef.current = async () => {
+      if (body) {
+        await handleSaveTemplate(false)
+      }
     }
-  }
+    return () => {
+      finishLaterCallbackRef.current = undefined
+    }
+  }, [body, finishLaterCallbackRef, handleSaveTemplate])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n')

--- a/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
@@ -21,9 +21,13 @@ const TELEGRAM_PROGRESS_STEPS = [
 const CreateTelegram = ({
   campaign: initialCampaign,
   onCampaignChange,
+  finishLaterCallbackRef,
 }: {
   campaign: TelegramCampaign
   onCampaignChange: (c: Campaign) => void
+  finishLaterCallbackRef: React.MutableRefObject<
+    (() => Promise<void>) | undefined
+  >
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)
@@ -57,7 +61,13 @@ const CreateTelegram = ({
   function renderStep() {
     switch (activeStep) {
       case TelegramProgress.CreateTemplate:
-        return <TelegramTemplate body={campaign.body} onNext={onNext} />
+        return (
+          <TelegramTemplate
+            body={campaign.body}
+            onNext={onNext}
+            finishLaterCallbackRef={finishLaterCallbackRef}
+          />
+        )
       case TelegramProgress.UploadRecipients:
         return (
           <TelegramRecipients

--- a/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
@@ -25,9 +25,7 @@ const CreateTelegram = ({
 }: {
   campaign: TelegramCampaign
   onCampaignChange: (c: Campaign) => void
-  finishLaterCallbackRef: React.MutableRefObject<
-    (() => Promise<void>) | undefined
-  >
+  finishLaterCallbackRef: React.MutableRefObject<(() => void) | undefined>
 }) => {
   const [activeStep, setActiveStep] = useState(initialCampaign.progress)
   const [campaign, setCampaign] = useState(initialCampaign)

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -51,6 +51,7 @@ const TelegramTemplate = ({
     finishLaterCallbackRef.current = () => {
       modalContext.setModalContent(
         <SaveDraftModal
+          saveable
           onSave={async () => {
             if (body) await handleSaveTemplate(false)
           }}

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -21,7 +21,7 @@ const TelegramTemplate = ({
   const { id: campaignId } = useParams()
 
   const handleSaveTemplate = useCallback(
-    async (next = true): Promise<void> => {
+    async (propagateError = false): Promise<void> => {
       setErrorMsg(null)
       try {
         if (!campaignId) {
@@ -31,16 +31,14 @@ const TelegramTemplate = ({
           +campaignId,
           body
         )
-        onNext(
-          {
-            body: updatedTemplate?.body,
-            params: updatedTemplate?.params,
-            numRecipients,
-          },
-          next
-        )
+        onNext({
+          body: updatedTemplate?.body,
+          params: updatedTemplate?.params,
+          numRecipients,
+        })
       } catch (err) {
         setErrorMsg(err.message)
+        if (propagateError) throw err
       }
     },
     [body, campaignId, onNext]
@@ -53,7 +51,7 @@ const TelegramTemplate = ({
         <SaveDraftModal
           saveable
           onSave={async () => {
-            if (body) await handleSaveTemplate(false)
+            if (body) await handleSaveTemplate(true)
           }}
         />
       )


### PR DESCRIPTION
## Problem

Clicking the "Finish this later" button does not save the campaign, causing the user to lose their template draft.

Closes #622.

## Solution

- Add a ref to hold a callback that is executed when the finish later button is clicked
    - Allow child components to set the ref
- If errors occur when executing the callback, navigation back to `/campaigns` is aborted

## Tests

1. Create a new campaign, populate the subject and body
2. Click "Finish this later"
    - Should make a network call to save the template
    - Should navigate back to campaigns dashboard
3. Select the same campaign, the template draft should be there

## TODO

- Draft saving is only done when the current campaign state complies with backend validation rules - is this ok? 
    - Email / Protected email: `subject` and `body` not null, `body` contains `{{ protectedlink }}` for protected email
    - SMS / Telegram: `body` not null
- Protected email: Message B is not persisted since it's not sent to the backend - `localStorage/sessionStorage` maybe?