### PR TITLE
feat: support separate environment for MOM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,17 @@ jobs:
           bucket_name: "postmangovsg-elasticbeanstalk-appversion"
           on:
             branch: $PRODUCTION_BRANCH
+        - provider: elasticbeanstalk
+          edge: true
+          skip_cleanup: true
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          region: $AWS_DEFAULT_REGION
+          app: "postmangovsg"
+          env: "postmangovsg-production-02"
+          bucket_name: "postmangovsg-elasticbeanstalk-appversion"
+          on:
+            branch: $PRODUCTION_02_BRANCH
     - name: worker
       before_install:
         - cd worker
@@ -64,6 +75,12 @@ jobs:
           script: ./deploy.sh postmangovsg-workers prod-sending prod-logging
           on:
             branch: $PRODUCTION_BRANCH
+            condition: "$DEPLOY_WORKER = true"
+        - provider: script
+          skip_cleanup: true
+          script: ./deploy.sh postmangovsg-workers prod-sending-02 prod-logging-02
+          on:
+            branch: $PRODUCTION_02_BRANCH
             condition: "$DEPLOY_WORKER = true"
     - name: frontend
       before_install:
@@ -163,6 +180,25 @@ jobs:
             branch: $PRODUCTION_BRANCH
           environment_variables:
             - DB_URI=$PRODUCTION_EMAIL_DB_URI
+            - MIN_HALT_NUMBER=$PRODUCTION_EMAIL_MIN_HALT_NUMBER
+            - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
+            - SENDGRID_PUBLIC_KEY=$PRODUCTION_EMAIL_SENDGRID_PUBLIC_KEY
+            - CALLBACK_SECRET=$PRODUCTION_EMAIL_CALLBACK_SECRET
+        - provider: lambda
+          edge: true
+          function_name: log-email-callback-production-02
+          region: $AWS_DEFAULT_REGION
+          role: $PRODUCTION_CALLBACK_ROLE
+          runtime: nodejs12.x
+          module_name: build/index
+          handler_name: handler
+          timeout: 30
+          publish: true
+          zip: "../log-email-sns/code.zip"
+          on:
+            branch: $PRODUCTION_02_BRANCH
+          environment_variables:
+            - DB_URI=$PRODUCTION_02_EMAIL_DB_URI
             - MIN_HALT_NUMBER=$PRODUCTION_EMAIL_MIN_HALT_NUMBER
             - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
             - SENDGRID_PUBLIC_KEY=$PRODUCTION_EMAIL_SENDGRID_PUBLIC_KEY

--- a/amplify.yml
+++ b/amplify.yml
@@ -2,6 +2,7 @@ version: 0.1
 env:
   variables:
     BACKEND_URL_PRODUCTION: "https://api.postman.gov.sg/v1"
+    BACKEND_URL_PRODUCTION_MOM: "https://api-mom.postman.gov.sg/v1"
     BACKEND_URL_STAGING: "https://api-staging.postman.gov.sg/v1"
     SENTRY_ORG: "open-government-products-re"
     SENTRY_PROJECT: "postmangovsg-frontend"
@@ -29,6 +30,9 @@ frontend:
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
           export REACT_APP_SENTRY_ENVIRONMENT="production";
+          elif [ "${AWS_BRANCH}" = "momgovsg" ]; then
+          export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION_MOM} &&
+          export REACT_APP_SENTRY_ENVIRONMENT="production-02";
           else
           export REACT_APP_BACKEND_URL=${BACKEND_URL_STAGING} &&
           export REACT_APP_SENTRY_ENVIRONMENT="staging";

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -268,6 +268,12 @@ const config = convict({
     default: '',
     env: 'SES_FROM',
   },
+  mailDefaultRate: {
+    doc: 'The default rate at which an email campaign will be sent',
+    default: 35,
+    env: 'EMAIL_DEFAULT_RATE',
+    format: 'int',
+  },
   defaultCountry: {
     doc: 'Two-letter ISO country code to use in libphonenumber-js',
     default: 'SG',

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -11,6 +11,7 @@ import {
   EmailStatsMiddleware,
   EmailMiddleware,
 } from '@email/middlewares'
+import config from '@core/config'
 
 const router = Router({ mergeParams: true })
 
@@ -54,7 +55,10 @@ const storeCredentialsValidator = {
 
 const sendCampaignValidator = {
   [Segments.BODY]: Joi.object({
-    rate: Joi.number().integer().positive().default(35),
+    rate: Joi.number()
+      .integer()
+      .positive()
+      .default(config.get('mailDefaultRate')),
   }),
 }
 


### PR DESCRIPTION
## Problem

Closes #541

## Solution

Add deployment to separate environment for MOM

## Tests

- Test that emails can be sent from mom.postman.gov.sg
- Check that the status of these email messages are updated
- Corresponding email messages with the same id in prod postman must not be updated with status

## Deploy notes
- [x] Add a subscription to this lambda (SES-SNS) for V1 USEast-1
- [x] Add a subscription to this lambda (SES-SNS) for V2 Sydney
- [x] Add a constraint on the new db to prevent creation of sms and telegram campaigns. 
```
CREATE FUNCTION disallow_sms_telegram_campaigns()
  RETURNS trigger AS
$func$
BEGIN
	IF (NEW."type" = 'SMS' or NEW."type"='TELEGRAM') THEN
      RAISE EXCEPTION 'SMS and TELEGRAM campaigns are not allowed in this environment';
   END IF;
   RETURN NEW;
END
$func$  LANGUAGE plpgsql;

CREATE TRIGGER disallow_type_before_insert_campaigns
BEFORE INSERT ON "campaigns"
FOR EACH ROW EXECUTE PROCEDURE disallow_sms_telegram_campaigns();
```
- [ ] When this branch is merged into master, cut momgovsg from master and treat it as a release branch from then on. 
