### PR TITLE
fix: Use custom validation for Singapore numbers

### DIFF
--- a/backend/__tests__/phone-number.service.test.ts
+++ b/backend/__tests__/phone-number.service.test.ts
@@ -37,6 +37,10 @@ describe('Phone Number Service', () => {
         expectNormalised('80123456', '+6580123456')
       })
 
+      test('should normalise number starting with 802', () => {
+        expectNormalised('80223456', '+6580223456')
+      })
+
       test('should normalise number starting with 89', () => {
         expectNormalised('89123456', '+6589123456')
       })

--- a/backend/src/core/services/phone-number.service.ts
+++ b/backend/src/core/services/phone-number.service.ts
@@ -1,5 +1,7 @@
 import { parsePhoneNumber, CountryCode } from 'libphonenumber-js/max'
 
+const SG_NUMBER_FORMAT = /^(\+?65)?(6|8|9)\d{7}$/
+
 /**
  * Validate and normalise phone number format. Default country code will
  * be added if no country code is provided.
@@ -10,15 +12,17 @@ const normalisePhoneNumber = (
   phoneNumber: string,
   defaultCountry: string
 ): string => {
-  let parsed = parsePhoneNumber(phoneNumber, defaultCountry as CountryCode)
+  let normalised = parsePhoneNumber(phoneNumber, defaultCountry as CountryCode)
 
-  if (!parsed.isValid()) {
-    // If parsing fails with default country code, we retry by prepending a + sign.
-    parsed = parsePhoneNumber(`+${phoneNumber}`)
-    if (!parsed.isValid()) throw new Error('Phone number is invalid')
+  // Validate SG numbers with a custom regex because libphonenumber's validation is out of date
+  if (!SG_NUMBER_FORMAT.test(phoneNumber) && !normalised.isValid()) {
+    // If parsing fails with default country code and does not match a Singaporean number format,
+    // we retry by prepending a + sign.
+    normalised = parsePhoneNumber(`+${phoneNumber}`)
+    if (!normalised.isValid()) throw new Error('Phone number is invalid')
   }
 
-  return parsed.number.toString()
+  return normalised.number.toString()
 }
 
 export const PhoneNumberService = {

--- a/backend/src/core/services/phone-number.service.ts
+++ b/backend/src/core/services/phone-number.service.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumber, CountryCode } from 'libphonenumber-js/max'
 
-const SG_NUMBER_FORMAT = /^(\+?65)?(6|8|9)\d{7}$/
+const SG_NUMBER_FORMAT = /^(\+?65)?(8|9)\d{7}$/
 
 /**
  * Validate and normalise phone number format. Default country code will

--- a/backend/src/telegram/services/telegram.service.ts
+++ b/backend/src/telegram/services/telegram.service.ts
@@ -15,7 +15,7 @@ import { TelegramTemplateService } from '@telegram/services'
 
 import TelegramClient from './telegram-client.class'
 import { CSVParams } from '@core/types'
-import { UploadService } from '@core/services'
+import { PhoneNumberService, UploadService } from '@core/services'
 import logger from '@core/logger'
 
 /**
@@ -62,10 +62,10 @@ const getSubscriberTelegramId = async (
   phoneNumber: string,
   botId: string
 ): Promise<number> => {
-  // Append default country code if does not exists.
-  if (!phoneNumber.startsWith('+') && config.get('defaultCountryCode')) {
-    phoneNumber = `+${config.get('defaultCountryCode')}${phoneNumber}`
-  }
+  phoneNumber = PhoneNumberService.normalisePhoneNumber(
+    phoneNumber,
+    config.get('defaultCountry')
+  )
 
   const subscriber = await TelegramSubscriber.findOne({
     where: { phoneNumber },

--- a/worker/src/core/services/phone-number.service.ts
+++ b/worker/src/core/services/phone-number.service.ts
@@ -1,5 +1,7 @@
 import { parsePhoneNumber, CountryCode } from 'libphonenumber-js/max'
 
+const SG_NUMBER_FORMAT = /^(\+?65)?(6|8|9)\d{7}$/
+
 /**
  * Validate and normalise phone number format. Default country code will
  * be added if no country code is provided.
@@ -10,15 +12,17 @@ const normalisePhoneNumber = (
   phoneNumber: string,
   defaultCountry: string
 ): string => {
-  let parsed = parsePhoneNumber(phoneNumber, defaultCountry as CountryCode)
+  let normalised = parsePhoneNumber(phoneNumber, defaultCountry as CountryCode)
 
-  if (!parsed.isValid()) {
-    // If parsing fails with default country code, we retry by prepending a + sign.
-    parsed = parsePhoneNumber(`+${phoneNumber}`)
-    if (!parsed.isValid()) throw new Error('Phone number is invalid')
+  // Validate SG numbers with a custom regex because libphonenumber's validation is out of date
+  if (!SG_NUMBER_FORMAT.test(phoneNumber) && !normalised.isValid()) {
+    // If parsing fails with default country code and does not match a Singaporean number format,
+    // we retry by prepending a + sign.
+    normalised = parsePhoneNumber(`+${phoneNumber}`)
+    if (!normalised.isValid()) throw new Error('Phone number is invalid')
   }
 
-  return parsed.number.toString()
+  return normalised.number.toString()
 }
 
 export const PhoneNumberService = {

--- a/worker/src/core/services/phone-number.service.ts
+++ b/worker/src/core/services/phone-number.service.ts
@@ -1,6 +1,6 @@
 import { parsePhoneNumber, CountryCode } from 'libphonenumber-js/max'
 
-const SG_NUMBER_FORMAT = /^(\+?65)?(6|8|9)\d{7}$/
+const SG_NUMBER_FORMAT = /^(\+?65)?(8|9)\d{7}$/
 
 /**
  * Validate and normalise phone number format. Default country code will


### PR DESCRIPTION
## Problem

`libphonenumber` [regex for Singapore number](https://github.com/google/libphonenumber/blob/60c5863a4f0082448f42e4ecc49915003bb5f1e5/resources/PhoneNumberMetadata.xml#L24998) is out-of-date and treats numbers starting with `802` as invalid numbers ([link to tester](http://libphonenumber.appspot.com/phonenumberparser?number=80212345&country=SG)). This results in SMS/Telegram messages not being able to be sent to these numbers as they fail validation. 

Broadly, we want to support the following scenarios: 
- Local numbers - with `+65`, without `+65` and without `+` (e.g. `91234567`, `+6591234567`, `6591234567`)
- Foreign numbers - with `+` and without `+` (e.g. `+14128018888`, `14128018888`)

## Solution

**Bug Fixes**:

- Use a custom regex to validate Singapore numbers ([regex tester for proposed regex](https://regex101.com/r/NdNs9N/2))
- Apply same validation for Telegram campaign test message for consistency

## Alternatives considered
**Fallback to isPossible**
An alternative approach [taken by FormSG](https://github.com/datagovsg/formsg/pull/2489/files) is to fallback to `isPossible` for Singapore numbers if `isValid` is `false` for a given phone number. However, this was not chosen for the following reasons: 
- `isPossible` [only checks for length](https://github.com/catamphetamine/libphonenumber-js#ispossible-boolean) of the number and not the regex. As such numbers such as `+6511234567` will pass validation. 
- Postman defaults all numbers without a country code to a Singaporean number by prepending a `+65`. So, even though FormSG's `isPhoneNumber` will return `false` for an invalid number like `11234567`, it will become `true` after prepending `+65`.

**Relax validation completely**
Another alternative will be to completely relax the validation of phone numbers and instead rely on the respective client APIs (Twilio/Telegram) to raise an error when the phone number is invalid. In this option, we will just use `isPossible` to ensure that the numbers are the right length. Errors for each channel will be raised in the following manner:
- For SMS, Twilio would return an [error code](https://www.twilio.com/docs/api/errors/21211) on send for invalid numbers. This [should not incur a charge](https://support.twilio.com/hc/en-us/articles/223181728-Will-I-be-charged-if-Twilio-encounters-an-error-when-sending-an-SMS-) (need to confirm).
- For Telegram, no match will be found in the `telegram_subscribers` table during the enqueue step and the message will be marked as invalid. Since the numbers in `telegram_subscribers` are provided from the user's Telegram client, we can be reasonably sure that they are valid phone numbers. 

This was not chosen mainly because it deviates away from the current behaviour by quite a bit.

## Tests
- Run unit tests. All prior tests should pass along with the new test for numbers starting with `802`. 
- Create a Telegram campaign and upload the following recipient list:
```
recipient
80223456
+6580223456
6580223456
```
- No error should be raised.
- Send a test message for number `11234567`. This should raise an error that it's an invalid number.
