### PR TITLE
refactor: split serverless builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,21 +91,11 @@ jobs:
         - npm run compile
         - npm run lint-no-fix
         - CI=false npm run build
-    - name: serverless
+    - name: serverless-log-twilio-callback
       before_deploy:
         - cd $TRAVIS_BUILD_DIR/serverless/log-twilio-callback
         - npm install && npm run build
         - zip -qr code.zip build package.json node_modules/
-        - cd $TRAVIS_BUILD_DIR/serverless/postman-api-gateway-authorizer && zip -qr code.zip *
-        - cd $TRAVIS_BUILD_DIR/serverless/log-email-sns
-        - npm install && npm run build
-        - zip -qr code.zip build package.json node_modules/
-        - cd $TRAVIS_BUILD_DIR/serverless/telegram-handler
-        - npm install && npm run build
-        - zip -qr code.zip build src package.json node_modules/
-        - cd $TRAVIS_BUILD_DIR/serverless/unsubscribe-digest
-        - npm install && npm run build
-        - zip -qr code.zip build src package.json node_modules/
       deploy:
         - provider: lambda
           edge: true
@@ -139,6 +129,10 @@ jobs:
             - DB_URI=$PRODUCTION_TWILIO_DB_URI
           on:
             branch: $PRODUCTION_BRANCH
+    - name: serverless-postman-api-gateway-authorizer
+      before_deploy:
+        - cd $TRAVIS_BUILD_DIR/serverless/postman-api-gateway-authorizer && zip -qr code.zip *
+      deploy:
         - provider: lambda
           edge: true
           function_name: authorizer
@@ -150,6 +144,12 @@ jobs:
           zip: "../postman-api-gateway-authorizer/code.zip"
           on:
             branch: $PRODUCTION_BRANCH
+    - name: serverless-log-email-callback
+      before_deploy:
+        - cd $TRAVIS_BUILD_DIR/serverless/log-email-sns
+        - npm install && npm run build
+        - zip -qr code.zip build package.json node_modules/
+      deploy:
         - provider: lambda
           edge: true
           function_name: log-email-callback-staging
@@ -207,6 +207,12 @@ jobs:
             - MIN_HALT_PERCENTAGE=$PRODUCTION_EMAIL_MIN_HALT_PERCENTAGE
             - SENDGRID_PUBLIC_KEY=$PRODUCTION_EMAIL_SENDGRID_PUBLIC_KEY
             - CALLBACK_SECRET=$PRODUCTION_EMAIL_CALLBACK_SECRET
+    - name: serverless-telegram-handler
+      before_deploy:
+        - cd $TRAVIS_BUILD_DIR/serverless/telegram-handler
+        - npm install && npm run build
+        - zip -qr code.zip build src package.json node_modules/
+      deploy:
         - provider: lambda
           edge: true
           function_name: telegram-handler-production
@@ -246,6 +252,12 @@ jobs:
             - NODE_ENV=staging
             - TELEGRAM_BOT_CONTACT_US_URL=$TELEGRAM_BOT_CONTACT_US_URL
             - TELEGRAM_BOT_GUIDE_URL=$TELEGRAM_BOT_GUIDE_URL
+    - name: serverless-unsubscribe-digest
+      before_deploy:
+        - cd $TRAVIS_BUILD_DIR/serverless/unsubscribe-digest
+        - npm install && npm run build
+        - zip -qr code.zip build src package.json node_modules/
+      deploy:
         - provider: lambda
           edge: true
           function_name: unsubscribe-digest-production


### PR DESCRIPTION
## Problem

Travis builds for the serverless functions were taking pretty long as the pre-deploy build process was being repeated for every function.

## Solution

Split the builds into separate jobs