### PR TITLE
chore: update docs to include installation of detect-secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ brew services start redis
 # Check that redis is running
 redis-cli ping
 
+# Install detect-secrets in order to make commits
+pip install detect-secrets
+
 # Have localstack running
 docker pull localstack/localstack
 


### PR DESCRIPTION
## Problem

Without `detect-secrets` installed, no commits can be made and husky will just throw a generic error. 
