### PR TITLE
feat: add secrets from AWS Secrets Manager to EB's config

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -19,7 +19,7 @@ const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 convict.addFormats({
   'secret-from-SM': {
     validate: (val: any): void => {
-      if (val === '') {
+      if (val === undefined) {
         throw new Error('Required value cannot be empty')
       }
     },
@@ -70,7 +70,7 @@ const config = convict({
     secretManagerSalt: {
       doc:
         'Secret used to generate names of credentials to be stored in AWS Secrets Manager',
-      default: '',
+      default: undefined,
       format: 'secret-from-SM',
       sensitive: true,
     },
@@ -78,13 +78,13 @@ const config = convict({
   database: {
     databaseUri: {
       doc: 'URI to the postgres database',
-      default: '',
+      default: undefined,
       format: 'secret-from-SM',
       sensitive: true,
     },
     databaseReadReplicaUri: {
       doc: 'URI to the postgres read replica database',
-      default: '',
+      default: undefined,
       format: 'secret-from-SM',
       sensitive: true,
     },
@@ -129,7 +129,7 @@ const config = convict({
   jwtSecret: {
     doc:
       'Secret used to sign pre-signed urls for uploading CSV files to AWS S3',
-    default: '',
+    default: undefined,
     format: 'secret-from-SM',
     sensitive: true,
   },
@@ -162,7 +162,7 @@ const config = convict({
     },
     secret: {
       doc: 'Secret used to sign the session ID cookie',
-      default: '',
+      default: undefined,
       format: 'secret-from-SM',
       sensitive: true,
     },
@@ -223,13 +223,13 @@ const config = convict({
   },
   redisOtpUri: {
     doc: 'URI to the redis cache for storing one time passwords',
-    default: '',
+    default: undefined,
     format: 'secret-from-SM',
     sensitive: true,
   },
   redisSessionUri: {
     doc: 'URI to the redis cache for storing login sessions',
-    default: '',
+    default: undefined,
     format: 'secret-from-SM',
     sensitive: true,
   },
@@ -300,7 +300,7 @@ const config = convict({
   apiKey: {
     salt: {
       doc: 'Secret used to hash API Keys before storing them in the database',
-      default: '',
+      default: undefined,
       format: 'secret-from-SM',
       sensitive: true,
     },
@@ -343,7 +343,7 @@ const config = convict({
       },
       key: {
         doc: 'V1 HMAC key',
-        default: '',
+        default: undefined,
         format: 'secret-from-SM',
         sensitive: true,
       },

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -32,6 +32,11 @@ convict.addFormats({
 })
 
 const config = convict({
+  test: {
+    doc: 'For testing purposes',
+    default: '',
+    format: 'required-string',
+  },
   env: {
     doc: 'The application environment.',
     format: ['production', 'staging', 'development'],

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -36,6 +36,7 @@ const config = convict({
     doc: 'For testing purposes',
     default: '',
     format: 'required-string',
+    sensitive: true,
   },
   env: {
     doc: 'The application environment.',

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -74,6 +74,12 @@ const config = convict({
       format: 'secret-from-SM',
       sensitive: true,
     },
+    configSecretName: {
+      doc:
+        'Name of the secret in Secrets Manager that holds all the secret env vars',
+      default: undefined,
+      env: 'AWS_CONFIG_SECRET_NAME',
+    },
   },
   database: {
     databaseUri: {

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -9,14 +9,15 @@ import path from 'path'
 import { isSupportedCountry } from 'libphonenumber-js'
 const rdsCa = fs.readFileSync(path.join(__dirname, '../assets/db-ca.pem'))
 /**
- * To require an env var without setting a default,
+ * To require a config from Secrets Manager
+ * Please add the secrets in secrets.loader.ts
  * use
  *    default: '',
- *    format: 'required-string',
+ *    format: 'secret-from-SM',
  *    sensitive: true,
  */
 convict.addFormats({
-  'required-string': {
+  'secret-from-SM': {
     validate: (val: any): void => {
       if (val === '') {
         throw new Error('Required value cannot be empty')
@@ -32,12 +33,6 @@ convict.addFormats({
 })
 
 const config = convict({
-  test: {
-    doc: 'For testing purposes',
-    default: '',
-    format: 'required-string',
-    sensitive: true,
-  },
   env: {
     doc: 'The application environment.',
     format: ['production', 'staging', 'development'],
@@ -76,8 +71,7 @@ const config = convict({
       doc:
         'Secret used to generate names of credentials to be stored in AWS Secrets Manager',
       default: '',
-      env: 'SECRET_MANAGER_SALT',
-      format: 'required-string',
+      format: 'secret-from-SM',
       sensitive: true,
     },
   },
@@ -85,15 +79,13 @@ const config = convict({
     databaseUri: {
       doc: 'URI to the postgres database',
       default: '',
-      env: 'DB_URI',
-      format: 'required-string',
+      format: 'secret-from-SM',
       sensitive: true,
     },
     databaseReadReplicaUri: {
       doc: 'URI to the postgres read replica database',
       default: '',
-      env: 'DB_READ_REPLICA_URI',
-      format: 'required-string',
+      format: 'secret-from-SM',
       sensitive: true,
     },
     dialectOptions: {
@@ -138,8 +130,7 @@ const config = convict({
     doc:
       'Secret used to sign pre-signed urls for uploading CSV files to AWS S3',
     default: '',
-    env: 'JWT_SECRET',
-    format: 'required-string',
+    format: 'secret-from-SM',
     sensitive: true,
   },
   MORGAN_LOG_FORMAT: {
@@ -172,8 +163,7 @@ const config = convict({
     secret: {
       doc: 'Secret used to sign the session ID cookie',
       default: '',
-      env: 'SESSION_SECRET',
-      format: 'required-string',
+      format: 'secret-from-SM',
       sensitive: true,
     },
     cookieSettings: {
@@ -234,15 +224,13 @@ const config = convict({
   redisOtpUri: {
     doc: 'URI to the redis cache for storing one time passwords',
     default: '',
-    env: 'REDIS_OTP_URI',
-    format: 'required-string',
+    format: 'secret-from-SM',
     sensitive: true,
   },
   redisSessionUri: {
     doc: 'URI to the redis cache for storing login sessions',
     default: '',
-    env: 'REDIS_SESSION_URI',
-    format: 'required-string',
+    format: 'secret-from-SM',
     sensitive: true,
   },
   mailOptions: {
@@ -313,8 +301,7 @@ const config = convict({
     salt: {
       doc: 'Secret used to hash API Keys before storing them in the database',
       default: '',
-      env: 'API_KEY_SALT_V1',
-      format: 'required-string',
+      format: 'secret-from-SM',
       sensitive: true,
     },
     version: {
@@ -357,8 +344,7 @@ const config = convict({
       key: {
         doc: 'V1 HMAC key',
         default: '',
-        format: 'required-string',
-        env: 'UNSUBSCRIBE_HMAC_KEY_V1',
+        format: 'secret-from-SM',
         sensitive: true,
       },
     },

--- a/backend/src/core/loaders/index.ts
+++ b/backend/src/core/loaders/index.ts
@@ -5,8 +5,10 @@ import swaggerLoader from './swagger.loader'
 import sessionLoader from './session.loader'
 import sequelizeLoader from './sequelize.loader'
 import cloudwatchLoader from './cloudwatch.loader'
+import loader from './secrets.loader'
 
 const loaders = async ({ app }: { app: Application }): Promise<void> => {
+  await loader()
   securityHeadersLoader({ app })
   await cloudwatchLoader()
   await sequelizeLoader()

--- a/backend/src/core/loaders/index.ts
+++ b/backend/src/core/loaders/index.ts
@@ -5,10 +5,10 @@ import swaggerLoader from './swagger.loader'
 import sessionLoader from './session.loader'
 import sequelizeLoader from './sequelize.loader'
 import cloudwatchLoader from './cloudwatch.loader'
-import loader from './secrets.loader'
+import secretsLoader from './secrets.loader'
 
 const loaders = async ({ app }: { app: Application }): Promise<void> => {
-  await loader()
+  await secretsLoader()
   securityHeadersLoader({ app })
   await cloudwatchLoader()
   await sequelizeLoader()

--- a/backend/src/core/loaders/secrets.loader.ts
+++ b/backend/src/core/loaders/secrets.loader.ts
@@ -4,7 +4,7 @@ import AWS from 'aws-sdk'
 const REGION = 'ap-southeast-1'
 const NAME = 'develop/shaowei/test'
 
-const loader = async (): Promise<void> => {
+const secretsLoader = async (): Promise<void> => {
   const client = new AWS.SecretsManager({
     region: REGION,
   })
@@ -18,4 +18,4 @@ const loader = async (): Promise<void> => {
   config.validate()
 }
 
-export default loader
+export default secretsLoader

--- a/backend/src/core/loaders/secrets.loader.ts
+++ b/backend/src/core/loaders/secrets.loader.ts
@@ -6,12 +6,37 @@ const REGION = 'ap-southeast-1'
 const NAME = 'develop/shaowei/test'
 
 const secretsLoader = async (): Promise<void> => {
-  const client = new AWS.SecretsManager({
+  const secretsManager = new AWS.SecretsManager({
     region: REGION,
   })
   try {
-    const data = await client.getSecretValue({ SecretId: NAME }).promise()
-    config.set('test', data.SecretString)
+    const data = await secretsManager
+      .getSecretValue({ SecretId: NAME })
+      .promise()
+    const secretString = data.SecretString
+    if (secretString === undefined)
+      throw new Error('Secret string from AWS Secrets Manager is undefined.')
+    const {
+      databaseUri,
+      databaseReadReplicaUri,
+      sessionSecret,
+      redisOtpUri,
+      redisSessionUri,
+      jwtSecret,
+      secretManagerSalt,
+      apiKeySaltV1,
+      unsubscribeHmacKeyV1,
+    } = JSON.parse(secretString)
+
+    config.set('aws.secretManagerSalt', secretManagerSalt)
+    config.set('database.databaseUri', databaseUri)
+    config.set('database.databaseReadReplicaUri', databaseReadReplicaUri)
+    config.set('jwtSecret', jwtSecret)
+    config.set('session.secret', sessionSecret)
+    config.set('redisOtpUri', redisOtpUri)
+    config.set('redisSessionUri', redisSessionUri)
+    config.set('apiKey.salt', apiKeySaltV1)
+    config.set('unsubscribeHmac.v1.key', unsubscribeHmacKeyV1)
   } catch (err) {
     process.exit(1)
   }

--- a/backend/src/core/loaders/secrets.loader.ts
+++ b/backend/src/core/loaders/secrets.loader.ts
@@ -1,17 +1,13 @@
 import logger from '@core/logger'
 import config from '@core/config'
 import AWS from 'aws-sdk'
-
-const REGION = 'ap-southeast-1'
-const NAME = 'develop/shaowei/test'
+import { configureEndpoint } from '@core/utils/aws-endpoint'
 
 const secretsLoader = async (): Promise<void> => {
-  const secretsManager = new AWS.SecretsManager({
-    region: REGION,
-  })
+  const secretsManager = new AWS.SecretsManager(configureEndpoint(config))
   try {
     const data = await secretsManager
-      .getSecretValue({ SecretId: NAME })
+      .getSecretValue({ SecretId: config.get('aws.configSecretName') })
       .promise()
     const secretString = data.SecretString
     if (secretString === undefined)
@@ -28,13 +24,13 @@ const secretsLoader = async (): Promise<void> => {
       unsubscribeHmacKeyV1,
     } = JSON.parse(secretString)
 
-    config.set('aws.secretManagerSalt', secretManagerSalt)
     config.set('database.databaseUri', databaseUri)
     config.set('database.databaseReadReplicaUri', databaseReadReplicaUri)
-    config.set('jwtSecret', jwtSecret)
     config.set('session.secret', sessionSecret)
     config.set('redisOtpUri', redisOtpUri)
     config.set('redisSessionUri', redisSessionUri)
+    config.set('jwtSecret', jwtSecret)
+    config.set('aws.secretManagerSalt', secretManagerSalt)
     config.set('apiKey.salt', apiKeySaltV1)
     config.set('unsubscribeHmac.v1.key', unsubscribeHmacKeyV1)
   } catch (err) {

--- a/backend/src/core/loaders/secrets.loader.ts
+++ b/backend/src/core/loaders/secrets.loader.ts
@@ -1,3 +1,4 @@
+import logger from '@core/logger'
 import config from '@core/config'
 import AWS from 'aws-sdk'
 
@@ -16,6 +17,8 @@ const secretsLoader = async (): Promise<void> => {
   }
   // Validate to make sure all the required env vars have been set
   config.validate()
+
+  logger.info({ message: 'Secrets loaded' })
 }
 
 export default secretsLoader

--- a/backend/src/core/loaders/secrets.loader.ts
+++ b/backend/src/core/loaders/secrets.loader.ts
@@ -1,0 +1,21 @@
+import config from '@core/config'
+import AWS from 'aws-sdk'
+
+const REGION = 'ap-southeast-1'
+const NAME = 'develop/shaowei/test'
+
+const loader = async (): Promise<void> => {
+  const client = new AWS.SecretsManager({
+    region: REGION,
+  })
+  try {
+    const data = await client.getSecretValue({ SecretId: NAME }).promise()
+    config.set('test', data.SecretString)
+  } catch (err) {
+    process.exit(1)
+  }
+  // Validate to make sure all the required env vars have been set
+  config.validate()
+}
+
+export default loader

--- a/backend/src/core/loaders/sequelize.loader.ts
+++ b/backend/src/core/loaders/sequelize.loader.ts
@@ -30,19 +30,18 @@ import {
 
 import logger from '@core/logger'
 
-const DB_URI = config.get('database.databaseUri')
-const DB_READ_REPLICA_URI = config.get('database.databaseReadReplicaUri')
-
 function parseDBUri(uri: string): any {
   const config = parse(uri)
   return { ...config, username: config.user }
 }
 
 const sequelizeLoader = async (): Promise<void> => {
-  const dialectOptions =
-    config.get('env') !== 'development'
-      ? config.get('database.dialectOptions')
-      : {}
+  const DB_URI = config.get('database.databaseUri')
+  const DB_READ_REPLICA_URI = config.get('database.databaseReadReplicaUri')
+
+  const dialectOptions = config.get('IS_PROD')
+    ? config.get('database.dialectOptions')
+    : {}
   const sequelize = new Sequelize({
     dialect: 'postgres',
     logging: false,

--- a/backend/src/core/services/redis.service.ts
+++ b/backend/src/core/services/redis.service.ts
@@ -2,10 +2,6 @@ import redis from 'redis'
 import config from '@core/config'
 import logger from '@core/logger'
 
-if (!config.get('redisOtpUri')) {
-  throw new Error('otpClient: redisOtpUri not found')
-}
-
 /**
  * Client to redis cache for storing otps
  */
@@ -17,10 +13,6 @@ const otpClient = redis
   .on('error', (err: Error) => {
     logger.error(String(err))
   })
-
-if (!config.get('redisSessionUri')) {
-  throw new Error('sessionClient: redisSessionUri not found')
-}
 
 /**
  * Client to redis cache for storing sessions

--- a/backend/src/core/utils/jwt.ts
+++ b/backend/src/core/utils/jwt.ts
@@ -2,11 +2,19 @@ import jwt from 'jsonwebtoken'
 
 import config from '@core/config'
 
-const JWT_SECRET = config.get('jwtSecret')
+const sign = (payload: any): string => {
+  const secret = config.get('jwtSecret')
+  if (secret === undefined) throw new Error('jwtSecret should not be undefined')
+  return jwt.sign(payload, secret, { algorithm: 'HS256' })
+}
+
+const verify = (token: any): string | object => {
+  const secret = config.get('jwtSecret')
+  if (secret === undefined) throw new Error('jwtSecret should not be undefined')
+  return jwt.verify(token, secret, { algorithms: ['HS256'] })
+}
 
 export const jwtUtils = {
-  sign: (payload: any): string =>
-    jwt.sign(payload, JWT_SECRET, { algorithm: 'HS256' }),
-  verify: (token: string): string | object =>
-    jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }),
+  sign,
+  verify,
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,6 @@
 require('dotenv').config()
 require('module-alias/register')
 
-import config from '@core/config'
-// Validate to make sure all the required env vars have been set
-config.validate()
-
 /** Load the app after all env vars are set */
 import 'source-map-support/register'
 import express from 'express'


### PR DESCRIPTION
## Problem

We are considering centralising our secrets in AWS Secrets Manager (SM), and this draft PR is to explore and discuss how we can pull secrets from Secrets Manager into Elastic Beanstalk.

## Solution

Please take note that this PR will fetch my development configs from SM and use them. 

The main struggle here is how to fetch the secrets from Secrets Manager before any other code needs the config object.

This is because fetching secrets from SM is an asynchronous operation while setting up the config object with convict in `config.ts` is a synchronous operation, meaning that 

What I have done here is to declare what secrets we will need in the config file, and then add a `secretsLoader` as the function to run in the loaders function.

`secretsLoader`:
- Fetch secrets from secretsManager
- Add these secrets into `config` through `config.set`
- Validate the config to ensure that all required secrets are filled using `config.validate`.

Pros:
- No major changes to the existing config object

Cons:
- There will be alot of `config.set`
- More rooms for errors, since it would be slightly more complicated to add secrets as compared to just env vars.

This is just a proof of concept and I'm not intending to get this in anytime soon. Do let me know your thoughts on this!

## Permissions for Secrets Manager
Developers should be given read/write access to development/staging/production secrets, or making changes to the codebase that deals with secrets would be painful. Events that happen in Secrets Manager are logged in CloudTrail.

Ideally, developers should not have access to any secrets that they do not need (agency's twilio credentials). We have to tag the secrets accordingly and set up the proper IAM access policies.

## TODO
- [ ] Decide whether to fetch secrets from SM for local dev or use env var

### Testing on staging
- [ ] Add staging secrets to secrets manager, tag it to environment: staging. Secret's name: staging/eb/postmangovsg
- [ ] Add `AWS_CONFIG_SECRET_NAME` to env vars
- [ ] Test on staging

### Production
- [ ] Add production secrets to secrets manager, environment: production, production/eb/postmangovsg (Does production 2 use the same secrets?)
- [ ] Add `AWS_CONFIG_SECRET_NAME` to env vars for both instances

### IAM for developers
- [ ] Grant permission for staging/eb/postmangovsg & production/eb/postmangovsg



## Tests
Check if values are fetched and working correctly on localhost: 
- [x] databaseUri
- [x] databaseReadReplicaUri
- [x] sessionSecret
- [x] redisOtpUri
- [x] redisSessionUri
- [x] jwtSecret
- [x] secretManagerSalt
- [x] apiKeySaltV1
- [x] unsubscribeHmacKeyV1

## Deploy Notes
Detailed checklist and contingencies for deployment will be in postman internal docs repo.

**New environment variables**:
- `AWS_CONFIG_SECRET_NAME` : Name of secret that holds all the secret env vars

## Alternatives
### Top Level Await 
This looks straight forward, the idea being that i could just do :

```
require('dotenv').config()
require('module-alias/register')

import secretsLoader from '@core/loaders/secrets.loader'
await secretsLoader()
```
https://v8.dev/features/top-level-await

Unfortunately, our current `tsconfig` is unable to support this, and I'm not familiar with it so I'm not sure if it make sense to change our configs to enable this.

This is only available in Node 14 and we had some issues upgrading to Node 14 previously.

## Concerns

### Global Variables

Because of the asynchronous process that we are retrieving our secrets, global variables that make use of secrets will cause bugs. Consider: 
```
import jwt from 'jsonwebtoken'

import config from '@core/config'

const JWT_SECRET = config.get('jwtSecret')

export const jwtUtils = {
  sign: (payload: any): string =>
    jwt.sign(payload, JWT_SECRET, { algorithm: 'HS256' }),
  verify: (token: string): string | object =>
    jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }),
}
```
This seems to be an ok pattern and quite easy to reason about. However, this will break because the secret is asynchronously fetched in the `secret-loader`, while `JWT_SECRET` and `jwtUtils` are initiated before the secret is fetched.


### Diving deep
Im still trying to find the best way to explain what's going on so I'm just gonna try my best and write down things. 

Lets start with `server.ts`: 
```
require('dotenv').config()
require('module-alias/register')

/** Load the app after all env vars are set */
import 'source-map-support/register'
import express from 'express'
import { loaders } from '@core/loaders'
const port = Number(process.env.PORT) || 4000
const app: express.Application = express()

const start = async (): Promise<void> => {
  await loaders({ app })
  // eslint-disable-next-line no-console
  app.listen(port, () => console.log(`Listening on port ${port}!`))
}

start().catch((err) => {
  console.error(err)
})
```
Let's focus on the things related to `environment variables`, `convict` and `config.ts`. 
`require('dotenv').config()` loads our `environment variables`, so that it is in `process.env`.

`import { loaders } from '@core/loaders'` is the next interesting part. This is the content: 

```
import { Application } from 'express'
import securityHeadersLoader from './security-headers.loader'
import expressLoader from './express.loader'
import swaggerLoader from './swagger.loader'
import sessionLoader from './session.loader'
import sequelizeLoader from './sequelize.loader'
import cloudwatchLoader from './cloudwatch.loader'
import secretsLoader from './secrets.loader'

const loaders = async ({ app }: { app: Application }): Promise<void> => {
  await secretsLoader()
  securityHeadersLoader({ app })
  await cloudwatchLoader()
  await sequelizeLoader()
  await sessionLoader({ app })
  await expressLoader({ app })
  await swaggerLoader({ app })
}

export { loaders }
```
In `sequelize.loader.ts`, 

```
import logger from '@core/logger'

const DB_URI = config.get('database.databaseUri')
const DB_READ_REPLICA_URI = config.get('database.databaseReadReplicaUri')
```

At this point, `secretsLoader()` has not been called yet, which means that `config.get('database.databaseUri')` is going to get the default value. 

The default value is important here because if it is an empty string, sequelize will just create a db connection with an empty db uri. 

```
new Sequelize({
    dialect: 'postgres',
    logging: false,
    pool: config.get('database.poolOptions'),
    replication: {
      read: [parseDBUri(DB_READ_REPLICA_URI)], // DB_READ_REPLICA_URI = ''
      write: parseDBUri(DB_URI), // DB_URI= ''
    },
```

Refer to https://github.com/opengovsg/postmangovsg/pull/666/commits/03cf57b419009ef92c393b5b2edd3c6d39a93e18.