### PR TITLE
chore: force sms for numbers starting with +6580 to be delivered

### DIFF
--- a/backend/src/sms/services/twilio-client.class.ts
+++ b/backend/src/sms/services/twilio-client.class.ts
@@ -11,12 +11,17 @@ export default class TwilioClient {
     this.messagingServiceSid = messagingServiceSid
   }
 
-  public send(recipient: string, message: string): Promise<string | void> {
+  public send(
+    recipient: string,
+    message: string,
+    forceDelivery = false
+  ): Promise<string | void> {
     return this.client.messages
       .create({
         to: recipient,
         body: this.replaceNewLines(message),
         from: this.messagingServiceSid,
+        forceDelivery: forceDelivery,
       })
       .then((result: { [key: string]: string }) => {
         const { status, sid, error_code: errorCode, code } = result
@@ -29,6 +34,16 @@ export default class TwilioClient {
         } else {
           return Promise.reject(new Error(`${status};Unknown error`))
         }
+      })
+      .catch((error: Error) => {
+        // Handle +65802 errors by forcing delivery once
+        if (
+          /\+65802\d+ is not a valid phone number/.test(error.message) &&
+          !forceDelivery
+        ) {
+          return this.send(recipient, message, true)
+        }
+        return Promise.reject(new Error(error.message))
       })
   }
 

--- a/worker/src/sms/services/twilio-client.class.ts
+++ b/worker/src/sms/services/twilio-client.class.ts
@@ -27,7 +27,8 @@ export default class TwilioClient {
     messageId: number,
     recipient: string,
     message: string,
-    campaignId?: number
+    campaignId?: number,
+    forceDelivery = false
   ): Promise<string | void> {
     return this.generateStatusCallbackUrl(messageId, campaignId)
       .then((callbackUrl) => {
@@ -35,6 +36,7 @@ export default class TwilioClient {
           to: recipient,
           body: this.replaceNewLines(message),
           from: this.messagingServiceSid,
+          forceDelivery: forceDelivery,
           ...(callbackUrl ? { statusCallback: callbackUrl } : {}),
         })
       })
@@ -51,6 +53,13 @@ export default class TwilioClient {
         }
       })
       .catch((error) => {
+        // Handle +65802 errors by forcing delivery once
+        if (
+          /\+65802\d+ is not a valid phone number/.test(error.message) &&
+          !forceDelivery
+        ) {
+          return this.send(messageId, recipient, message, campaignId, true)
+        }
         return Promise.reject(new Error(error.message))
       })
   }


### PR DESCRIPTION
## Problem

Closes #672 

## Solution

This parameter is undocumented in Twilio, but recommended by Twilio Support to get past the validation issue

<img width="1003" alt="Screenshot 2020-08-28 at 2 33 21 PM" src="https://user-images.githubusercontent.com/33819199/91529208-785e2700-e93b-11ea-8196-5b84e70353f8.png">
