### PR TITLE
fix: wrong column name in twilio callback

### DIFF
--- a/serverless/log-twilio-callback/src/index.ts
+++ b/serverless/log-twilio-callback/src/index.ts
@@ -54,7 +54,7 @@ exports.handler = async (event: any) => {
     console.log(`Updating messageId ${messageId} in sms_messages`)
     if (twilioErrorCode) {
       await sequelize.query(
-        `UPDATE sms_messages SET errorCode=:twilioErrorCode, updated_at = clock_timestamp(), status = 'ERROR' WHERE id=:messageId AND campaign_id=:campaignId`,
+        `UPDATE sms_messages SET error_code=:twilioErrorCode, updated_at = clock_timestamp(), status = 'ERROR' WHERE id=:messageId AND campaign_id=:campaignId`,
         {
           replacements: { twilioErrorCode, messageId, campaignId },
           type: QueryTypes.UPDATE,


### PR DESCRIPTION
## Problem
User reported discrepancy between twilio logs and Postman's logs. Turns out we weren't updating the error_code column correctly.

## Solution

Update the correct column

## Tests
- Locally: Post an event to your lambda running locally

Before
<img width="687" alt="Screenshot " src="https://user-images.githubusercontent.com/33819199/91538627-ac8d1400-e94a-11ea-9221-d6073e0fbf87.png">


After
<img width="696" alt="Screenshot " src="https://user-images.githubusercontent.com/33819199/91538593-a0a15200-e94a-11ea-95b9-9efc233e05f2.png">

- End to end : I've built it on the staging lambda, and sent a message with the id '300643'. Twilio still reports the message as 'Sent', not 'Failed' (it's expected to fail because that number doesn't exist). When it returns the failed callback, the message status should change from 'SUCCESS' to 'ERROR'. 
