### PR TITLE
feat: add originating IP address for OTP email

### DIFF
--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express'
 import config from '@core/config'
 import logger from '@core/logger'
 import { AuthService } from '@core/services'
+import { getRequestIp } from '@core/utils/request'
 
 /**
  *  Determines if an email is whitelisted / enough time has elapsed since the last otp request,
@@ -18,7 +19,8 @@ const getOtp = async (req: Request, res: Response): Promise<Response> => {
     return res.status(401).json({ message: e.message })
   }
   try {
-    await AuthService.sendOtp(email)
+    const ipAddress = getRequestIp(req)
+    await AuthService.sendOtp(email, ipAddress)
   } catch (e) {
     logger.error(`Error sending OTP: ${e}. email=${email}`)
     return res.sendStatus(500)

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -178,8 +178,12 @@ const canSendOtp = async (email: string): Promise<void> => {
 /**
  * Sends an email containing the otp to the user
  * @param email
+ * @param ipAddress originating IP address that requests for OTP.
  */
-const sendOtp = async (email: string): Promise<string | void> => {
+const sendOtp = async (
+  email: string,
+  ipAddress: string
+): Promise<string | void> => {
   const otp = generateOtp()
   const hashValue = await bcrypt.hash(otp, SALT_ROUNDS)
   const hashedOtp: HashedOtp = {
@@ -189,15 +193,16 @@ const sendOtp = async (email: string): Promise<string | void> => {
   }
   await saveHashedOtp(email, hashedOtp)
 
+  const appName = config.get('APP_NAME')
   return MailService.mailClient.sendMail({
     recipients: [email],
     subject: `One-Time Password (OTP) for ${config.get('APP_NAME')}`,
     body: `Your OTP is <b>${otp}</b>. It will expire in ${Math.floor(
       OTP_EXPIRY / 60
     )} minutes.
-    Please use this to login to your ${config.get(
-      'APP_NAME'
-    )} account. <p>If your OTP does not work, please request for a new OTP.</p>`,
+    Please use this to login to your ${appName} account. <p>If your OTP does not work, please request for a new OTP.</p>
+    <p>This login attempt was made from the IP: ${ipAddress}. If you did not attempt to log in to ${appName}, you may choose to investigate this IP address further.</p>
+    <p>The ${appName} Support Team</p>`,
   })
 }
 

--- a/backend/src/core/utils/morgan.ts
+++ b/backend/src/core/utils/morgan.ts
@@ -1,19 +1,7 @@
 import { Request, Response } from 'express'
-import { isArray } from 'lodash'
+import { getRequestIp } from '@core/utils/request'
 
-const clientIp = (req: Request, _res: Response): string => {
-  /**
-   * @see: https://support.cloudflare.com/hc/en-us/articles/200170786
-   * @see: https://stackoverflow.com/a/52026771
-   */
-  const cfConnectingIp: string | undefined = isArray(
-    req.headers['cf-connecting-ip']
-  )
-    ? req.headers['cf-connecting-ip'].join(',')
-    : req.headers['cf-connecting-ip']
-
-  return cfConnectingIp || req.ip
-}
+const clientIp = (req: Request, _res: Response): string => getRequestIp(req)
 
 const userId = (req: Request, _res: Response): string | undefined => {
   const apiKey = req?.session?.apiKey

--- a/backend/src/core/utils/request.ts
+++ b/backend/src/core/utils/request.ts
@@ -1,0 +1,9 @@
+import { Request } from 'express'
+
+export const getRequestIp: (req: Request) => string = (req: Request) => {
+  /**
+   * @see: https://support.cloudflare.com/hc/en-us/articles/200170786
+   * @see: https://stackoverflow.com/a/52026771
+   */
+  return req.get('cf-connecting-ip') ?? req.ip
+}


### PR DESCRIPTION
## Problem

Closes #670

## Solution

**Features**:

Updated email copy as per #670

**Improvements**:

Simplify the logic to retrieve client ip address in [utils/morgan](https://github.com/opengovsg/postmangovsg/compare/develop...xming13:feature/ip-in-otp-email?expand=1#diff-11db5c924dfc4cc48b1707ce8134b79aL4). 

CF-Connecting-IP will always have one IP according to https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-
>To restore original visitor IP addresses at your origin web server, Cloudflare recommends your logs or applications look at CF-Connecting-IP or True-Client-IP instead of X-Forwarded-For since CF-Connecting-IP and True-Client-IP have a consistent format containing only one IP. 

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/6182649/91586006-64d8ad80-e987-11ea-86ca-23cc643096bf.png)

**AFTER**:
Note: There is no valid ip address in this screenshot as I am testing locally.

![image](https://user-images.githubusercontent.com/6182649/91586036-6dc97f00-e987-11ea-9876-fede75e990b2.png)

## Tests

Requires manual testing.
1. Login at login page to trigger OTP email
2. Verify that email should contain the updated copy with the correct ip address
