### PR TITLE
Compute queue position and wait time for queued campaigns

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -4,7 +4,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-08-12T16:52:26Z",
+  "generated_at": "2020-10-14T10:56:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -65,7 +65,7 @@
       }
     ]
   },
-  "version": "0.14.2",
+  "version": "0.14.3",
   "word_list": {
     "file": null,
     "hash": null

--- a/backend/.env-example
+++ b/backend/.env-example
@@ -16,8 +16,7 @@ TWILIO_CALLBACK_SECRET="abcde"
 # Generate a fake public key using
 # openssl ecparam -name secp256k1 -genkey -out privateKey.pem
 # openssl ec -in privateKey.pem -pubout
-SENDGRID_PUBLIC_KEY="MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEKWFCI/58CSJe4uz9WX7VZZBIoeb3c1UE
-J+pe3HL0ywyGA6c3Bq92+1YVKv0HHxf5mjm+t47P672gcaYarlp2LA=="
+SENDGRID_PUBLIC_KEY="MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEKWFCI/58CSJe4uz9WX7VZZBIoeb3c1UEJ+pe3HL0ywyGA6c3Bq92+1YVKv0HHxf5mjm+t47P672gcaYarlp2LA=="
 CALLBACK_SECRET="abc:xyz"
 
 TELEGRAM_BOT_CONTACT_US_URL="https://go.gov.sg/postman-contact-us-recipient"

--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -52,10 +52,7 @@ export interface CampaignStats extends CampaignStatsCount {
   status: string
   halted?: boolean
   status_updated_at?: Date
-  queueStatus?: {
-    position: number
-    time: number
-  }
+  queue_time?: number
 }
 
 export interface CampaignStatsCount {

--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -52,7 +52,7 @@ export interface CampaignStats extends CampaignStatsCount {
   status: string
   halted?: boolean
   status_updated_at?: Date
-  queue_time?: number
+  wait_time?: number
 }
 
 export interface CampaignStatsCount {

--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -52,6 +52,10 @@ export interface CampaignStats extends CampaignStatsCount {
   status: string
   halted?: boolean
   status_updated_at?: Date
+  queueStatus?: {
+    position: number
+    time: number
+  }
 }
 
 export interface CampaignStatsCount {

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -74,6 +74,7 @@ export class CampaignStats {
   statusUpdatedAt: Date // Timestamp when job's status was changed to this status
   updatedAt: Date // Timestamp when statistic was updated
   halted?: boolean
+  waitTime?: number
 
   constructor(input: any) {
     this.error = +input['error']
@@ -84,6 +85,7 @@ export class CampaignStats {
     this.statusUpdatedAt = input['status_updated_at']
     this.updatedAt = input['updated_at']
     this.halted = input['halted']
+    this.waitTime = input['wait_time']
   }
 }
 

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
+import { i18n } from 'locales'
 
 const EmailDetail = ({
   id,
@@ -73,18 +74,38 @@ const EmailDetail = ({
     }
   }, [id, stats.status])
 
-  return (
-    <>
-      {stats.status === Status.Sending ? (
+  function renderProgressHeader() {
+    if (stats.waitTime && stats.waitTime > 0) {
+      return (
+        <>
+          <h2>Other campaigns are queued ahead of this campaign.</h2>
+          <p>
+            Your campaign should start in approximately{' '}
+            <b>
+              {i18n.plural({
+                value: Math.ceil(stats.waitTime / 60),
+                one: '# minute',
+                other: '# minutes',
+              })}
+            </b>
+            . You can leave this page in the meantime, and check on the progress
+            by returning to this page from the Campaigns tab.
+          </p>
+        </>
+      )
+    } else if (stats.status === Status.Sending) {
+      return (
         <>
           <h2>Your campaign is being sent out now!</h2>
           <p>
-            It may take a few minutes to complete. You can leave this page in
-            the meantime, and check on the progress by returning to this page
-            from the Campaigns tab.
+            It may take some time to complete. You can leave this page in the
+            meantime, and check on the progress by returning to this page from
+            the Campaigns tab.
           </p>
         </>
-      ) : (
+      )
+    } else {
+      return (
         <>
           <h2>Your campaign has been sent!</h2>
           <p>
@@ -97,20 +118,33 @@ const EmailDetail = ({
             completed.
           </p>
         </>
-      )}
-      <div className="separator"></div>
-      {stats.status && (
-        <ProgressDetails
-          campaignId={id}
-          campaignName={name}
-          sentAt={sentAt}
-          numRecipients={numRecipients}
-          stats={stats}
-          handlePause={handlePause}
-          handleRetry={handleRetry}
-          handleRefreshStats={handleRefreshStats}
-        />
-      )}
+      )
+    }
+  }
+
+  function renderProgressDetails() {
+    return (
+      <>
+        <div className="separator"></div>
+        {stats.status && (
+          <ProgressDetails
+            campaignId={id}
+            campaignName={name}
+            sentAt={sentAt}
+            numRecipients={numRecipients}
+            stats={stats}
+            handlePause={handlePause}
+            handleRetry={handleRetry}
+            handleRefreshStats={handleRefreshStats}
+          />
+        )}
+      </>
+    )
+  }
+  return (
+    <>
+      {renderProgressHeader()}
+      {renderProgressDetails()}
     </>
   )
 }

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -8,8 +8,7 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
-import { i18n } from 'locales'
-import { plural } from '@lingui/macro'
+
 const EmailDetail = ({
   id,
   name,
@@ -76,21 +75,14 @@ const EmailDetail = ({
 
   function renderProgressHeader() {
     if (stats.waitTime && stats.waitTime > 0) {
+      const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <>
           <h2>Other campaigns are queued ahead of this campaign.</h2>
           <p>
             Your campaign should start in approximately{' '}
-            <b>
-              {i18n._(
-                plural({
-                  value: Math.ceil(stats.waitTime / 60),
-                  one: '# minute',
-                  other: '# minutes',
-                })
-              )}
-            </b>
-            . You can leave this page in the meantime, and check on the progress
+            <b>{waitMin > 1 ? `${waitMin} minutes` : `${waitMin} minute`}</b>.
+            You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.
           </p>
         </>

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -9,7 +9,7 @@ import {
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 import { i18n } from 'locales'
-
+import { plural } from '@lingui/macro'
 const EmailDetail = ({
   id,
   name,
@@ -82,11 +82,13 @@ const EmailDetail = ({
           <p>
             Your campaign should start in approximately{' '}
             <b>
-              {i18n.plural({
-                value: Math.ceil(stats.waitTime / 60),
-                one: '# minute',
-                other: '# minutes',
-              })}
+              {i18n._(
+                plural({
+                  value: Math.ceil(stats.waitTime / 60),
+                  one: '# minute',
+                  other: '# minutes',
+                })
+              )}
             </b>
             . You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
+import { i18n } from 'locales'
 
 const SMSDetail = ({
   id,
@@ -73,45 +74,77 @@ const SMSDetail = ({
     }
   }, [id, stats.status])
 
-  return (
-    <>
-      {stats.status === Status.Sending ? (
+  function renderProgressHeader() {
+    if (stats.waitTime && stats.waitTime > 0) {
+      return (
+        <>
+          <h2>Other campaigns are queued ahead of this campaign.</h2>
+          <p>
+            Your campaign should start in approximately{' '}
+            <b>
+              {i18n.plural({
+                value: Math.ceil(stats.waitTime / 60),
+                one: '# minute',
+                other: '# minutes',
+              })}
+            </b>
+            . You can leave this page in the meantime, and check on the progress
+            by returning to this page from the Campaigns tab.
+          </p>
+        </>
+      )
+    } else if (stats.status === Status.Sending) {
+      return (
         <>
           <h2>Your campaign is being sent out now!</h2>
           <p>
-            It may take a few minutes to complete. You can leave this page in
-            the meantime, and check on the progress by returning to this page
-            from the Campaigns tab.
+            It may take some time to complete. You can leave this page in the
+            meantime, and check on the progress by returning to this page from
+            the Campaigns tab.
           </p>
         </>
-      ) : (
+      )
+    } else {
+      return (
         <>
           <h2>Your campaign has been sent!</h2>
           <p>
             If there are errors with sending your messages, you can click Retry
             to send again.
-            <br />
+          </p>
+          <p>
             If you encounter failed deliveries, you can download the error list
             from this page or the dashboard few minutes after sending has
             completed.
           </p>
         </>
-      )}
+      )
+    }
+  }
 
-      <div className="separator"></div>
-
-      {stats.status && (
-        <ProgressDetails
-          campaignId={id}
-          campaignName={name}
-          sentAt={sentAt}
-          numRecipients={numRecipients}
-          stats={stats}
-          handlePause={handlePause}
-          handleRetry={handleRetry}
-          handleRefreshStats={handleRefreshStats}
-        />
-      )}
+  function renderProgressDetails() {
+    return (
+      <>
+        <div className="separator"></div>
+        {stats.status && (
+          <ProgressDetails
+            campaignId={id}
+            campaignName={name}
+            sentAt={sentAt}
+            numRecipients={numRecipients}
+            stats={stats}
+            handlePause={handlePause}
+            handleRetry={handleRetry}
+            handleRefreshStats={handleRefreshStats}
+          />
+        )}
+      </>
+    )
+  }
+  return (
+    <>
+      {renderProgressHeader()}
+      {renderProgressDetails()}
     </>
   )
 }

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -8,8 +8,6 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
-import { i18n } from 'locales'
-import { plural } from '@lingui/macro'
 
 const SMSDetail = ({
   id,
@@ -77,21 +75,14 @@ const SMSDetail = ({
 
   function renderProgressHeader() {
     if (stats.waitTime && stats.waitTime > 0) {
+      const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <>
           <h2>Other campaigns are queued ahead of this campaign.</h2>
           <p>
             Your campaign should start in approximately{' '}
-            <b>
-              {i18n._(
-                plural({
-                  value: Math.ceil(stats.waitTime / 60),
-                  one: '# minute',
-                  other: '# minutes',
-                })
-              )}
-            </b>
-            . You can leave this page in the meantime, and check on the progress
+            <b>{waitMin > 1 ? `${waitMin} minutes` : `${waitMin} minute`}</b>.
+            You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.
           </p>
         </>

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -113,9 +113,8 @@ const SMSDetail = ({
             to send again.
           </p>
           <p>
-            If you encounter failed deliveries, you can download the error list
-            from this page or the dashboard few minutes after sending has
-            completed.
+            An export button will appear for you to download a report with the
+            recipient’s mobile number and delivery status when it is ready.
           </p>
         </>
       )

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -9,6 +9,7 @@ import {
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 import { i18n } from 'locales'
+import { plural } from '@lingui/macro'
 
 const SMSDetail = ({
   id,
@@ -82,11 +83,13 @@ const SMSDetail = ({
           <p>
             Your campaign should start in approximately{' '}
             <b>
-              {i18n.plural({
-                value: Math.ceil(stats.waitTime / 60),
-                one: '# minute',
-                other: '# minutes',
-              })}
+              {i18n._(
+                plural({
+                  value: Math.ceil(stats.waitTime / 60),
+                  one: '# minute',
+                  other: '# minutes',
+                })
+              )}
             </b>
             . You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -8,8 +8,6 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
-import { i18n } from 'locales'
-import { plural } from '@lingui/macro'
 
 const TelegramDetail = ({
   id,
@@ -77,21 +75,14 @@ const TelegramDetail = ({
 
   function renderProgressHeader() {
     if (stats.waitTime && stats.waitTime > 0) {
+      const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <>
           <h2>Other campaigns are queued ahead of this campaign.</h2>
           <p>
             Your campaign should start in approximately{' '}
-            <b>
-              {i18n._(
-                plural({
-                  value: Math.ceil(stats.waitTime / 60),
-                  one: '# minute',
-                  other: '# minutes',
-                })
-              )}
-            </b>
-            . You can leave this page in the meantime, and check on the progress
+            <b>{waitMin > 1 ? `${waitMin} minutes` : `${waitMin} minute`}</b>.
+            You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.
           </p>
         </>

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -113,9 +113,8 @@ const TelegramDetail = ({
             to send again.
           </p>
           <p>
-            If you encounter failed deliveries, you can download the error list
-            from this page or the dashboard few minutes after sending has
-            completed.
+            An export button will appear for you to download a report with the
+            recipient’s mobile number and delivery status when it is ready.
           </p>
         </>
       )

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from 'services/campaign.service'
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
+import { i18n } from 'locales'
 
 const TelegramDetail = ({
   id,
@@ -73,43 +74,77 @@ const TelegramDetail = ({
     }
   }, [id, stats.status])
 
-  return (
-    <>
-      {stats.status === Status.Sending ? (
+  function renderProgressHeader() {
+    if (stats.waitTime && stats.waitTime > 0) {
+      return (
+        <>
+          <h2>Other campaigns are queued ahead of this campaign.</h2>
+          <p>
+            Your campaign should start in approximately{' '}
+            <b>
+              {i18n.plural({
+                value: Math.ceil(stats.waitTime / 60),
+                one: '# minute',
+                other: '# minutes',
+              })}
+            </b>
+            . You can leave this page in the meantime, and check on the progress
+            by returning to this page from the Campaigns tab.
+          </p>
+        </>
+      )
+    } else if (stats.status === Status.Sending) {
+      return (
         <>
           <h2>Your campaign is being sent out now!</h2>
           <p>
-            It may take a few minutes to complete. You can leave this page in
-            the meantime, and check on the progress by returning to this page
-            from the Campaigns tab.
+            It may take some time to complete. You can leave this page in the
+            meantime, and check on the progress by returning to this page from
+            the Campaigns tab.
           </p>
         </>
-      ) : (
+      )
+    } else {
+      return (
         <>
           <h2>Your campaign has been sent!</h2>
           <p>
-            A retry button will appear if some messages had an error while
-            sending. You can click on retry to try sending the message(s) again.
-            An export button will appear for you to download a list of failed
-            deliveries with the recipient’s mobile number.
+            If there are errors with sending your messages, you can click Retry
+            to send again.
+          </p>
+          <p>
+            If you encounter failed deliveries, you can download the error list
+            from this page or the dashboard few minutes after sending has
+            completed.
           </p>
         </>
-      )}
+      )
+    }
+  }
 
-      <div className="separator"></div>
-
-      {stats.status && (
-        <ProgressDetails
-          campaignId={id}
-          campaignName={name}
-          sentAt={sentAt}
-          numRecipients={numRecipients}
-          stats={stats}
-          handlePause={handlePause}
-          handleRetry={handleRetry}
-          handleRefreshStats={handleRefreshStats}
-        />
-      )}
+  function renderProgressDetails() {
+    return (
+      <>
+        <div className="separator"></div>
+        {stats.status && (
+          <ProgressDetails
+            campaignId={id}
+            campaignName={name}
+            sentAt={sentAt}
+            numRecipients={numRecipients}
+            stats={stats}
+            handlePause={handlePause}
+            handleRetry={handleRetry}
+            handleRefreshStats={handleRefreshStats}
+          />
+        )}
+      </>
+    )
+  }
+  return (
+    <>
+      {renderProgressHeader()}
+      {renderProgressDetails()}
     </>
   )
 }

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -9,6 +9,7 @@ import {
 import { ProgressDetails } from 'components/common'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 import { i18n } from 'locales'
+import { plural } from '@lingui/macro'
 
 const TelegramDetail = ({
   id,
@@ -82,11 +83,13 @@ const TelegramDetail = ({
           <p>
             Your campaign should start in approximately{' '}
             <b>
-              {i18n.plural({
-                value: Math.ceil(stats.waitTime / 60),
-                one: '# minute',
-                other: '# minutes',
-              })}
+              {i18n._(
+                plural({
+                  value: Math.ceil(stats.waitTime / 60),
+                  one: '# minute',
+                  other: '# minutes',
+                })
+              )}
             </b>
             . You can leave this page in the meantime, and check on the progress
             by returning to this page from the Campaigns tab.


### PR DESCRIPTION
## Problem

It would be informative to users who have queued campaigns to know what is the queued status of their campaign and how long they it would take for their campaign to start sending out.

Backend changes to return metrics relevant to #658 

## Solution

- Extend the existing `/stats` endpoint to also return campaign queue status if campaign's job is in `READY` status
- Get the position of the job in the queue
- Compute an approximate time taken for preceding jobs to complete
