### PR TITLE
refactor(callback): sms

### DIFF
--- a/backend/.env-example
+++ b/backend/.env-example
@@ -10,6 +10,7 @@ JWT_SECRET="secret"
 API_KEY_SALT_V1="APIKEYSALTV1"
 UNSUBSCRIBE_HMAC_ALGO_V1="sha256"
 UNSUBSCRIBE_HMAC_KEY_V1="secret"
+TWILIO_CALLBACK_SECRET="abcde"
 
 ##### Email callback #####
 # Generate a fake public key using

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -397,6 +397,14 @@ const config = convict({
       doc: 'Secret for basic auth',
       env: 'CALLBACK_SECRET',
       default: '',
+    },
+  },
+  smsCallback: {
+    callbackSecret: {
+      doc:
+        'Secret used to generate the basic auth credentials for twilio callback',
+      default: '',
+      env: 'TWILIO_CALLBACK_SECRET',
       format: 'required-string',
       sensitive: true,
     },

--- a/backend/src/sms/middlewares/index.ts
+++ b/backend/src/sms/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from './sms.middleware'
 export * from './sms-stats.middleware'
 export * from './sms-template.middleware'
+export * from './sms-callback.middleware'

--- a/backend/src/sms/middlewares/sms-callback.middleware.ts
+++ b/backend/src/sms/middlewares/sms-callback.middleware.ts
@@ -22,9 +22,17 @@ const isAuthenticated = (
   return res.sendStatus(403)
 }
 
-const parseEvent = async (req: Request, res: Response): Promise<Response> => {
-  await SmsCallbackService.parseEvent(req)
-  return res.sendStatus(200)
+const parseEvent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  try {
+    await SmsCallbackService.parseEvent(req)
+    return res.sendStatus(200)
+  } catch (err) {
+    return next(err)
+  }
 }
 
 export const SmsCallbackMiddleware = {

--- a/backend/src/sms/middlewares/sms-callback.middleware.ts
+++ b/backend/src/sms/middlewares/sms-callback.middleware.ts
@@ -1,13 +1,29 @@
-import { Request, Response } from 'express'
-const isAuthenticated = (req: Request, res: Response): Response => {
+import { Request, Response, NextFunction } from 'express'
+import { SmsCallbackService } from '@sms/services'
+const isAuthenticated = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Response | void => {
   if (!req.get('authorization')) {
     res.set('WWW-Authenticate', 'Basic realm="Twilio"')
     res.sendStatus(401)
   }
-  return res.sendStatus(401)
+  const { messageId, campaignId } = req.params
+  if (
+    SmsCallbackService.isAuthenticated(
+      messageId,
+      campaignId,
+      req.get('authorization')
+    )
+  ) {
+    return next()
+  }
+  return res.sendStatus(403)
 }
 
-const parseEvent = (_req: Request, res: Response): Response => {
+const parseEvent = async (req: Request, res: Response): Promise<Response> => {
+  await SmsCallbackService.parseEvent(req)
   return res.sendStatus(200)
 }
 

--- a/backend/src/sms/middlewares/sms-callback.middleware.ts
+++ b/backend/src/sms/middlewares/sms-callback.middleware.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express'
+const isAuthenticated = (req: Request, res: Response): Response => {
+  if (!req.get('authorization')) {
+    res.set('WWW-Authenticate', 'Basic realm="Twilio"')
+    res.sendStatus(401)
+  }
+  return res.sendStatus(401)
+}
+
+const parseEvent = (_req: Request, res: Response): Response => {
+  return res.sendStatus(200)
+}
+
+export const SmsCallbackMiddleware = {
+  isAuthenticated,
+  parseEvent,
+}

--- a/backend/src/sms/middlewares/sms-callback.middleware.ts
+++ b/backend/src/sms/middlewares/sms-callback.middleware.ts
@@ -7,7 +7,7 @@ const isAuthenticated = (
 ): Response | void => {
   if (!req.get('authorization')) {
     res.set('WWW-Authenticate', 'Basic realm="Twilio"')
-    res.sendStatus(401)
+    return res.sendStatus(401)
   }
   const { messageId, campaignId } = req.params
   if (

--- a/backend/src/sms/routes/sms-callback.routes.ts
+++ b/backend/src/sms/routes/sms-callback.routes.ts
@@ -1,9 +1,5 @@
-import { Request, Response } from 'express'
 import { Router } from 'express'
-import axios from 'axios'
-import querystring from 'querystring'
-import config from '@core/config'
-import logger from '@core/logger'
+import { SmsCallbackMiddleware } from '@sms/middlewares'
 const router = Router()
 
 /**
@@ -31,33 +27,8 @@ const router = Router()
  */
 router.post(
   '/:campaignId(\\d+)/:messageId(\\d+)',
-  (req: Request, res: Response) => {
-    if (!req.headers.authorization) {
-      return res
-        .header('WWW-Authenticate', 'Basic realm="Sms callback"')
-        .sendStatus(401)
-    }
-    const { campaignId, messageId } = req.params
-    const redirectTo = `https://callback.postman.gov.sg/${config.get(
-      'env'
-    )}/v1/campaign/${campaignId}/message/${messageId}`
-    return axios
-      .post(redirectTo, querystring.stringify(req.body), {
-        headers: { Authorization: req.headers.authorization },
-      })
-      .then(() => res.sendStatus(200))
-      .catch((err) => {
-        if (err.response) {
-          logger.error(
-            `${err.response.status}: ${JSON.stringify(err.response.headers)}`
-          )
-          return res.sendStatus(err.response.status)
-        } else {
-          logger.error(err)
-          return res.sendStatus(500)
-        }
-      })
-  }
+  SmsCallbackMiddleware.isAuthenticated,
+  SmsCallbackMiddleware.parseEvent
 )
 
 export default router

--- a/backend/src/sms/services/index.ts
+++ b/backend/src/sms/services/index.ts
@@ -1,3 +1,4 @@
 export * from './sms.service'
 export * from './sms-stats.service'
 export * from './sms-template.service'
+export * from './sms-callback.service'

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -2,6 +2,7 @@ import { Request } from 'express'
 import bcrypt from 'bcrypt'
 import { QueryTypes } from 'sequelize'
 import config from '@core/config'
+import logger from '@core/logger'
 import { SmsMessage } from '@sms/models'
 const FINALIZED_STATUS = ['sent', 'delivered', 'undelivered', 'failed']
 
@@ -32,7 +33,7 @@ const parseEvent = async (req: Request): Promise<void> => {
   if (FINALIZED_STATUS.indexOf(twilioMessageStatus as string) === -1) {
     return
   }
-  console.log(`Updating messageId ${messageId} in sms_messages`)
+  logger.info(`Updating messageId ${messageId} in sms_messages`)
   if (twilioErrorCode) {
     await SmsMessage?.sequelize?.query(
       `UPDATE sms_messages SET error_code=:twilioErrorCode, updated_at = clock_timestamp(), status = 'ERROR' WHERE id=:messageId AND campaign_id=:campaignId`,

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -1,6 +1,57 @@
-const parseEvent = async (_event: any): Promise<void> => {
-  return
+import { Request } from 'express'
+import bcrypt from 'bcrypt'
+import { QueryTypes } from 'sequelize'
+import config from '@core/config'
+import { SmsMessage } from '@sms/models'
+const FINALIZED_STATUS = ['sent', 'delivered', 'undelivered', 'failed']
+
+const isAuthenticated = (
+  messageId: string,
+  campaignId: string,
+  authHeader?: string
+): boolean => {
+  const headerKey = 'Basic'
+  if (!authHeader) return false
+
+  const [header, secret] = authHeader.trim().split(' ')
+  if (headerKey !== header) return false
+
+  const credentials = Buffer.from(secret, 'base64').toString('utf8')
+  const [username, password] = credentials.split(':')
+  const plainTextPassword =
+    username + messageId + campaignId + config.get('smsCallback.callbackSecret')
+  return bcrypt.compareSync(plainTextPassword, password)
+}
+const parseEvent = async (req: Request): Promise<void> => {
+  const { messageId, campaignId } = req.params
+  const {
+    MessageStatus: twilioMessageStatus,
+    ErrorCode: twilioErrorCode,
+  } = req.body
+  // Do not process message if it's not of a finalized delivery status
+  if (FINALIZED_STATUS.indexOf(twilioMessageStatus as string) === -1) {
+    return
+  }
+  console.log(`Updating messageId ${messageId} in sms_messages`)
+  if (twilioErrorCode) {
+    await SmsMessage?.sequelize?.query(
+      `UPDATE sms_messages SET error_code=:twilioErrorCode, updated_at = clock_timestamp(), status = 'ERROR' WHERE id=:messageId AND campaign_id=:campaignId`,
+      {
+        replacements: { twilioErrorCode, messageId, campaignId },
+        type: QueryTypes.UPDATE,
+      }
+    )
+  } else {
+    await SmsMessage?.sequelize?.query(
+      `UPDATE sms_messages SET received_at = clock_timestamp(), updated_at = clock_timestamp(), status = 'SUCCESS' WHERE id=:messageId AND campaign_id=:campaignId`,
+      {
+        replacements: { messageId, campaignId },
+        type: QueryTypes.UPDATE,
+      }
+    )
+  }
 }
 export const SmsCallbackService = {
+  isAuthenticated,
   parseEvent,
 }

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -1,0 +1,6 @@
+const parseEvent = async (_event: any): Promise<void> => {
+  return
+}
+export const SmsCallbackService = {
+  parseEvent,
+}

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -1,6 +1,5 @@
 import { Request } from 'express'
 import bcrypt from 'bcrypt'
-import { QueryTypes } from 'sequelize'
 import config from '@core/config'
 import logger from '@core/logger'
 import { SmsMessage } from '@sms/models'
@@ -35,19 +34,29 @@ const parseEvent = async (req: Request): Promise<void> => {
   }
   logger.info(`Updating messageId ${messageId} in sms_messages`)
   if (twilioErrorCode) {
-    await SmsMessage?.sequelize?.query(
-      `UPDATE sms_messages SET error_code=:twilioErrorCode, updated_at = clock_timestamp(), status = 'ERROR' WHERE id=:messageId AND campaign_id=:campaignId`,
+    await SmsMessage.update(
       {
-        replacements: { twilioErrorCode, messageId, campaignId },
-        type: QueryTypes.UPDATE,
+        errorCode: twilioErrorCode,
+        status: 'ERROR',
+      },
+      {
+        where: {
+          id: messageId,
+          campaignId,
+        },
       }
     )
   } else {
-    await SmsMessage?.sequelize?.query(
-      `UPDATE sms_messages SET received_at = clock_timestamp(), updated_at = clock_timestamp(), status = 'SUCCESS' WHERE id=:messageId AND campaign_id=:campaignId`,
+    await SmsMessage.update(
       {
-        replacements: { messageId, campaignId },
-        type: QueryTypes.UPDATE,
+        receivedAt: new Date(),
+        status: 'SUCCESS',
+      },
+      {
+        where: {
+          id: messageId,
+          campaignId,
+        },
       }
     )
   }

--- a/worker/.env-example
+++ b/worker/.env-example
@@ -1,7 +1,5 @@
 # Required env vars
 NODE_ENV="development"
-BACKEND_URL="http://localhost:4000/v1"
-TWILIO_CALLBACK_SECRET="TWILIOCALLBACKSECRET"
 DB_URI="postgres://localhost:5432/postmangovsg_dev"
 SECRET_MANAGER_SALT="SECRETMANAGERSALT"
 MESSAGE_WORKER_SENDER="1"
@@ -9,6 +7,12 @@ MESSAGE_WORKER_LOGGER="1"
 ECS_SERVICE_NAME="dev"
 UNSUBSCRIBE_HMAC_ALGO_V1="sha256"
 UNSUBSCRIBE_HMAC_KEY_V1="secret"
+
+##### Twilio callback #####
+# For Twilio to update the local environment, use a publicly exposed ip or a tunnel 
+BACKEND_URL="https://abc.ngrok.io/v1/callback/sms"
+# Same secret as backend
+TWILIO_CALLBACK_SECRET="abcde"
 
 # You can override other config too
 # See config.ts for the full list

--- a/worker/src/sms/services/twilio-client.class.ts
+++ b/worker/src/sms/services/twilio-client.class.ts
@@ -79,7 +79,7 @@ export default class TwilioClient {
     callbackUrl.username = username
     // encode password as the hash contains special characters
     callbackUrl.password = encodeURIComponent(hashedPwd)
-    callbackUrl.pathname = `${callbackUrl.pathname}/campaign/${campaignId}/message/${messageId}`
+    callbackUrl.pathname = `${callbackUrl.pathname}/${campaignId}/${messageId}`
     logger.info(`Status callback url for ${messageId}: ${callbackUrl}`)
     return callbackUrl.toString()
   }


### PR DESCRIPTION
How to test?

```bash
npm run dev # spins up server on localhost:4000
ngrok http 4000 # creates a tunnel
```

Then set the webhook and twilio credentials in your worker env vars
```
TWILIO_API_SECRET=123
TWILIO_MESSAGING_SERVICE_SID=MG123
TWILIO_API_KEY=SK123
TWILIO_ACCOUNT_SID=AC123
TWILIO_CALLBACK_SECRET='abcde' # same as backend
BACKEND_URL=https://98d448999539.ngrok.io/v1/callback/sms
```

Send a message - the status of the sms message should be success/error. 


This is an example of a request sent for a successfully delivered message from Twilio. 
```bash
curl -L -k -X POST  --header "Content-Type:application/x-www-form-urlencoded; charset=utf-8" -d "To=%2B6580000000&AccountSid=AC123&ApiVersion=2010-04-01&MessageStatus=delivered&SmsSid=SM123&MessagingServiceSid=MG123&From=postman&MessageSid=SM123&SmsStatus=delivered" https://iau3q0czvw:%242b%2410%24lerHqlvOeTplFq4e0dk8PurFa%2FdJiFyqVAqw1oKZ1Tg0Ls%2FHdOXDS@98d448999539.ngrok.io/v1/callback/sms/52/377
```