### PR TITLE
fix: Disable campaign pagination arrow when there is only a single page

### DIFF
--- a/frontend/src/components/common/pagination/Pagination.tsx
+++ b/frontend/src/components/common/pagination/Pagination.tsx
@@ -9,7 +9,7 @@ const MARGIN_PAGES_DISPLAYED = 2 // number of pages displayed after ellipsis
 const Pagination = (props: any) => {
   const { itemsCount, selectedPage, setSelectedPage, itemsPerPage } = props
 
-  const pageCount = itemsCount / itemsPerPage
+  const pageCount = Math.ceil(itemsCount / itemsPerPage)
 
   const previousButton = (
     <span className={styles.icon}>

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import Moment from 'react-moment'
 import cx from 'classnames'
 


### PR DESCRIPTION
## Problem

Closes #687 

## Solution

**Bug Fixes**:

- `pageCount` wasn't rounded up to an integer

**Improvements**
- Removed unused `useState` and `useEffect` imports that were raising a warning

## Before & After Screenshots
![image](https://user-images.githubusercontent.com/3666479/91929213-7ff14780-ed10-11ea-8a1f-5a41a538f429.png)

## Tests
- Have <= 10 campaigns 
- Check that both arrows for pagination component are disabled