### PR TITLE
Speed up worker part 2

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2830,10 +2830,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-      "dev": true,
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+      "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -2845,6 +2844,17 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-map": {
@@ -2859,8 +2869,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "packet-reader": {
       "version": "1.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -31,6 +31,7 @@
     "module-alias": "^2.2.2",
     "nodemailer": "^6.4.6",
     "nodemailer-direct-transport": "^3.3.2",
+    "p-limit": "^3.0.2",
     "pg": "^8.2.1",
     "postman-templating": "file:../modules/postman-templating",
     "reflect-metadata": "^0.1.13",

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -137,7 +137,8 @@ const enqueueAndSend = async (): Promise<void> => {
         hasNext = false
       } else {
         const start = Date.now()
-        await Promise.all(messages.map((m) => sendMessage(m)))
+        // Fire and forget. This risks opening too many unresolved connections if the rate is high (Error: read ECONNRESET)
+        messages.forEach((m) => sendMessage(m))
         // Make sure at least 1 second has elapsed
         const wait = Math.max(0, 1000 - (Date.now() - start))
         await waitForMs(wait)

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -78,6 +78,16 @@ const sendMessage = (message: Message): Promise<void> => {
   return service().sendMessage(message)
 }
 
+const jobCanBeFinalized = (jobId: number): Promise<void> => {
+  return connection
+    .query('SELECT set_job_to_sent(:job_id);', {
+      replacements: { job_id: jobId },
+      type: QueryTypes.SELECT,
+    })
+    .catch((err) => {
+      logger.error(err)
+    })
+}
 const finalize = (): Promise<void> => {
   const logEmailJob = connection
     .query('SELECT log_next_job_email();')
@@ -160,6 +170,7 @@ const enqueueAndSend = async (): Promise<void> => {
       await waitForMs(1000)
       failSafe--
     }
+    await jobCanBeFinalized(jobId)
     await service().destroySendingService()
   }
 }

--- a/worker/src/core/resources/sql/set-job-to-sent.sql
+++ b/worker/src/core/resources/sql/set-job-to-sent.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION set_job_to_sent(job_id int) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+-- Set status to sent so that the logger will finalize it
+UPDATE job_queue SET status = 'SENT', updated_at = clock_timestamp() where id = job_id AND status = 'SENDING';
+END $$

--- a/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
+++ b/worker/src/sms/resources/sql/get-messages-to-send-sms.sql
@@ -20,14 +20,4 @@ BEGIN
     SELECT json_build_object('id', m.id, 'recipient', m.recipient, 'params', m.params, 'body', t.body, 'campaignId', m.campaign_id)
     FROM messages m, sms_templates t
     WHERE m.campaign_id = t.campaign_id;
-		
-	-- If there are no messages found, we assume the job is done
-	-- This is only correct because enqueue and send are serialized. All messages are enqueued before sending occurs
-
-	-- An edge case exists where the status of a job is set to 'SENT', but the sending client hasn't responded to all the sent messages
-	-- In that case, finalization of the job has to be deferred, so that the response can be updated in the ops table
-	-- The check for this edge case is carried out in the log_job_<channel> function. 
-	IF NOT FOUND THEN
-		UPDATE job_queue SET status = 'SENT', updated_at = clock_timestamp() where id = jid AND status = 'SENDING';
-	END IF;
 END $$;

--- a/worker/src/telegram/resources/sql/get-messages-telegram.sql
+++ b/worker/src/telegram/resources/sql/get-messages-telegram.sql
@@ -36,11 +36,5 @@ BEGIN
   )
   FROM messages m, telegram_templates t
   WHERE m.campaign_id = t.campaign_id;
-
-  IF NOT FOUND THEN
-    UPDATE job_queue
-    SET status = 'SENT', updated_at = clock_timestamp()
-    WHERE id = job_id
-      AND status = 'SENDING';
-  END IF;
+  
 END $$;


### PR DESCRIPTION
Fixing https://github.com/opengovsg/postmangovsg/pull/608

## Problem 

`SENT` state was prematurely set when messages were being retrieved faster than the network calls were resolving. 
This caused the logger to log messages early, resulting in a condition where the messages were actually sent, but not updated to the ops table (because the messages had already been transferred back from ops table to the messages table)

## Solution

Only set the state to `SENT` when all the promises have resolved / the failsafe is breached.

## Other considerations
The entire purpose of the initial design was to prevent the app from having to hold all the messages in memory (ie, make one getMessages call for all the messages, and send them out at the specified rate). This prevents OOM, and since it only dequeues messages as needed,, we would lose fewer messages (whose result would not be written to disk)  in the event of a crash. 

This new design consequentially loses those advantages as it is perfectly possible for all the messages to be dequeued before the promises are resolved. 