### PR TITLE
Convert recipient email addresses to lowercase before saving to DB

### DIFF
--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -192,9 +192,10 @@ const uploadCompleteOnChunk = ({
 }): ((data: CSVParams[]) => Promise<void>) => {
   return async (data: CSVParams[]): Promise<void> => {
     const records: Array<MessageBulkInsertInterface> = data.map((entry) => {
+      const { recipient } = entry
       return {
         campaignId,
-        recipient: entry['recipient'],
+        recipient: recipient.toLowerCase(),
         params: entry,
       }
     })

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -1,5 +1,4 @@
-import { difference, keys, chunk } from 'lodash'
-import { Transaction } from 'sequelize'
+import { difference, keys } from 'lodash'
 
 import logger from '@core/logger'
 import { isSuperSet } from '@core/utils'
@@ -194,39 +193,6 @@ const getFilledTemplate = async (
 }
 
 /**
- * 1. delete existing entries
- * 2. bulk insert
- * @param campaignId
- * @param records
- * @param transaction
- */
-const addToMessageLogs = async (
-  campaignId: number,
-  records: Array<object>,
-  transaction: Transaction | undefined
-): Promise<void> => {
-  try {
-    logger.info({ message: `Started populateSmsTemplate for ${campaignId}` })
-    // delete message_logs entries
-    await SmsMessage.destroy({
-      where: { campaignId },
-      transaction,
-    })
-
-    const chunks = chunk(records, 5000)
-    for (let idx = 0; idx < chunks.length; idx++) {
-      const batch = chunks[idx]
-      await SmsMessage.bulkCreate(batch, { transaction })
-    }
-
-    logger.info({ message: `Finished populateSmsTemplate for ${campaignId}` })
-  } catch (err) {
-    logger.error(`SmsMessage: destroy / bulkcreate failure. ${err.stack}`)
-    throw new Error('SmsMessage: destroy / bulkcreate failure')
-  }
-}
-
-/**
  * Attempts to hydrate the first record.
  * @param records
  * @param templateBody
@@ -242,7 +208,6 @@ const testHydration = (
 export const SmsTemplateService = {
   storeTemplate,
   getFilledTemplate,
-  addToMessageLogs,
   testHydration,
   client,
 }

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -1,5 +1,4 @@
-import { chunk, difference, keys } from 'lodash'
-import { Transaction } from 'sequelize'
+import { difference, keys } from 'lodash'
 
 import config from '@core/config'
 import logger from '@core/logger'
@@ -169,42 +168,6 @@ const getFilledTemplate = async (
 }
 
 /**
- * 1. delete existing entries
- * 2. bulk insert
- * @param campaignId
- * @param records
- * @param transaction
- */
-const addToMessageLogs = async (
-  campaignId: number,
-  records: Array<object>,
-  transaction: Transaction | undefined
-): Promise<void> => {
-  try {
-    logger.info({
-      message: `Started populateTelegramTemplate for ${campaignId}`,
-    })
-    // delete message_logs entries
-    await TelegramMessage.destroy({
-      where: { campaignId },
-      transaction,
-    })
-
-    const chunks = chunk(records, 5000)
-    for (let idx = 0; idx < chunks.length; idx++) {
-      const batch = chunks[idx]
-      await TelegramMessage.bulkCreate(batch, { transaction })
-    }
-    logger.info({
-      message: `Finished populateTelegramTemplate for ${campaignId}`,
-    })
-  } catch (err) {
-    logger.error(`SmsMessage: destroy / bulkcreate failure. ${err.stack}`)
-    throw new Error('SmsMessage: destroy / bulkcreate failure')
-  }
-}
-
-/**
  * Validate that recipient is a valid phone number and format it.
  */
 const validateAndFormatNumber = (
@@ -243,7 +206,6 @@ const testHydration = (
 export const TelegramTemplateService = {
   storeTemplate,
   getFilledTemplate,
-  addToMessageLogs,
   validateAndFormatNumber,
   testHydration,
   client,


### PR DESCRIPTION
## Problem

Recipient email addresses are not converted to lowercase before saving them to the db. Some invalid email addresses are not caught by the blacklist as there is discrepancy in matching to the similar uppercase/mixed-case recipients in the `email_blacklist` table.

Closes #678 

## Solution

- Convert recipients to lowercase before saving them to `email_messages`

### Lowercase existing blacklist emails
`UPDATE email_blacklist SET recipient= LOWER(recipient);`
- Tested locally
- To be run on prod when approved

### Minor code cleanup
- Removed unused functions in channel template services