### PR TITLE
chore: trim recipients before saving

### DIFF
--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -195,7 +195,7 @@ const uploadCompleteOnChunk = ({
       const { recipient } = entry
       return {
         campaignId,
-        recipient: recipient.toLowerCase(),
+        recipient: recipient.trim().toLowerCase(),
         params: entry,
       }
     })

--- a/backend/src/sms/services/sms.service.ts
+++ b/backend/src/sms/services/sms.service.ts
@@ -188,9 +188,10 @@ const uploadCompleteOnChunk = ({
 }): ((data: CSVParams[]) => Promise<void>) => {
   return async (data: CSVParams[]): Promise<void> => {
     const records: Array<MessageBulkInsertInterface> = data.map((entry) => {
+      const { recipient } = entry
       return {
         campaignId,
-        recipient: entry['recipient'],
+        recipient: recipient.trim(),
         params: entry,
       }
     })

--- a/backend/src/telegram/services/telegram.service.ts
+++ b/backend/src/telegram/services/telegram.service.ts
@@ -262,9 +262,10 @@ const uploadCompleteOnChunk = ({
 }): ((data: CSVParams[]) => Promise<void>) => {
   return async (data: CSVParams[]): Promise<void> => {
     const records: Array<MessageBulkInsertInterface> = data.map((entry) => {
+      const { recipient } = entry
       return {
         campaignId,
-        recipient: entry['recipient'],
+        recipient: recipient.trim(),
         params: entry,
       }
     })


### PR DESCRIPTION
## Problem

Noticed that many emails with leading/trailing spaces were being marked with the error code "Recipient is incorrectly formatted"

## Solution

Trim the recipients before saving
