### PR TITLE
feat: Fetching secrets in Docker, from AWS Secrets Manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         - npm run lint-no-fix
         - npm run test
       before_deploy:
-        - cp -R ../modules ./
+        - ./before-deploy.sh
       deploy:
         - provider: elasticbeanstalk
           edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ jobs:
   include:
     - name: backend
       before_install:
-        - cd backend
+        - cd $TRAVIS_BUILD_DIR/backend
       install:
         - npm ci
       script:
         - npm run lint-no-fix
         - npm run test
       before_deploy:
-        - ./before-deploy.sh
+        - cd $TRAVIS_BUILD_DIR/backend && ./before-deploy.sh
       deploy:
         - provider: elasticbeanstalk
           edge: true
@@ -56,7 +56,7 @@ jobs:
             branch: $PRODUCTION_02_BRANCH
     - name: worker
       before_install:
-        - cd worker
+        - cd $TRAVIS_BUILD_DIR/worker
       install:
         - npm ci
       script:
@@ -84,7 +84,7 @@ jobs:
             condition: "$DEPLOY_WORKER = true"
     - name: frontend
       before_install:
-        - cd frontend
+        - cd $TRAVIS_BUILD_DIR/frontend
       install:
         - npm install
       script:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add py-pip && apk add jq
 RUN pip install awscli
 
 RUN aws configure set default.region ap-southeast-1
+
 WORKDIR /usr/home/postmangovsg
 
 COPY modules ../modules
@@ -22,6 +23,9 @@ COPY tsconfig.json ./
 RUN npm run build
 RUN npm prune --production
 
+COPY ./docker-entrypoint.sh ./
+RUN ["chmod", "+x", "docker-entrypoint.sh"]
+
 EXPOSE 4000
 ENTRYPOINT [ "tini", "--" ]
-CMD ["npm", "start"]
+CMD ["./docker-entrypoint.sh"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,11 @@ FROM node:12-alpine
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
   g++ make python tini
 
+RUN apk add py-pip && apk add jq
+
+RUN pip install awscli
+
+RUN aws configure set default.region ap-southeast-1
 WORKDIR /usr/home/postmangovsg
 
 COPY modules ../modules

--- a/backend/before-deploy.sh
+++ b/backend/before-deploy.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Copy local module
+cp -R ../modules ./
+echo $STAGING_SECRET_ID
+# Replace the secret id according to the right branch
+# Using '#' as a delimiter for SED instead of '/'
+# '/' will clash with secret id names, eg: 'staging/eb/postmangovsg-staging-40ffadb'
+if [ "$TRAVIS_BRANCH" == "$STAGING_BRANCH" ]; then
+  sed -i "" -e "s#@SECRET_ID#$STAGING_SECRET_ID#g" docker-entrypoint.sh
+elif [ "$TRAVIS_BRANCH" == "$PRODUCTION_BRANCH" ]; then
+  sed -i "" -e "s#@SECRET_ID#$PRODUCTION_SECRET_ID#g" docker-entrypoint.sh
+elif [ "$TRAVIS_BRANCH" == "$PRODUCTION_02_BRANCH" ]; then
+  sed -i "" -e "s#@SECRET_ID#$PRODUCTION_02_SECRET_ID#g" docker-entrypoint.sh
+fi

--- a/backend/before-deploy.sh
+++ b/backend/before-deploy.sh
@@ -9,6 +9,4 @@ if [ "$TRAVIS_BRANCH" == "$STAGING_BRANCH" ]; then
   sed -i "" -e "s#@SECRET_ID#$STAGING_SECRET_ID#g" docker-entrypoint.sh
 elif [ "$TRAVIS_BRANCH" == "$PRODUCTION_BRANCH" ]; then
   sed -i "" -e "s#@SECRET_ID#$PRODUCTION_SECRET_ID#g" docker-entrypoint.sh
-elif [ "$TRAVIS_BRANCH" == "$PRODUCTION_02_BRANCH" ]; then
-  sed -i "" -e "s#@SECRET_ID#$PRODUCTION_02_SECRET_ID#g" docker-entrypoint.sh
 fi

--- a/backend/before-deploy.sh
+++ b/backend/before-deploy.sh
@@ -2,7 +2,6 @@
 
 # Copy local module
 cp -R ../modules ./
-echo $STAGING_SECRET_ID
 # Replace the secret id according to the right branch
 # Using '#' as a delimiter for SED instead of '/'
 # '/' will clash with secret id names, eg: 'staging/eb/postmangovsg-staging-40ffadb'

--- a/backend/before-deploy.sh
+++ b/backend/before-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copy local module
 cp -R ../modules ./
@@ -6,7 +6,7 @@ cp -R ../modules ./
 # Using '#' as a delimiter for SED instead of '/'
 # '/' will clash with secret id names, eg: 'staging/eb/postmangovsg-staging-40ffadb'
 if [ "$TRAVIS_BRANCH" == "$STAGING_BRANCH" ]; then
-  sed -i "" -e "s#@SECRET_ID#$STAGING_SECRET_ID#g" docker-entrypoint.sh
+  sed -i -e "s#@SECRET_ID#$STAGING_SECRET_ID#g" docker-entrypoint.sh
 elif [ "$TRAVIS_BRANCH" == "$PRODUCTION_BRANCH" ]; then
-  sed -i "" -e "s#@SECRET_ID#$PRODUCTION_SECRET_ID#g" docker-entrypoint.sh
+  sed -i -e "s#@SECRET_ID#$PRODUCTION_SECRET_ID#g" docker-entrypoint.sh
 fi

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Get the secrets from aws secrets manager
+# transform them into KEY=value pairing, and store in temp file
+aws secretsmanager get-secret-value --secret-id '@SECRET_ID' --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > /tmp/secrets.env
+# Export all the key value pairings in the temp file
+eval $(cat /tmp/secrets.env | sed 's/^/export /')
+rm -f /tmp/secrets.env
+npm start

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 # Get the secrets from aws secrets manager
 # transform them into KEY=value pairing, and store in temp file
-aws secretsmanager get-secret-value --secret-id '@SECRET_ID' --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > /tmp/secrets.env
-# Export all the key value pairings in the temp file
-export "$(cat /tmp/secrets.env)"
-rm -f /tmp/secrets.env
+aws secretsmanager get-secret-value --secret-id '@SECRET_ID' --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > .env
+# rely on dotenv to add the environment variables to the node process
 npm start

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -3,6 +3,6 @@
 # transform them into KEY=value pairing, and store in temp file
 aws secretsmanager get-secret-value --secret-id '@SECRET_ID' --query SecretString --output text | jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' > /tmp/secrets.env
 # Export all the key value pairings in the temp file
-eval $(cat /tmp/secrets.env | sed 's/^/export /')
+export "$(cat /tmp/secrets.env)"
 rm -f /tmp/secrets.env
 npm start


### PR DESCRIPTION
## Problem

We want to centralize our AWS related secrets in AWS Secrets Manager (SM). 

Needed a way to fetch the secrets from SM in Elastic Beanstalk.


## Solution

Initially we wanted to fetch the secrets at the app level (#666), but we decided that it is added too much complexity. 

Instead, we will fetch the secrets & export them as environment variables in Docker, after the container has started. 

### Dockerfile
We replaced the `npm start` cmd with a bash script `docker-entrypoint.sh`.

In order to fetch the secrets from SM and export them as environment variables, we have to install `aws-cli` & `jq` on the image. 

**Features**:

- Installed aws-cli & jq on the docker image
- Added a travis before-deploy script to replace the secret id according to the travis branch
- Added a script to be used as a entry point
- Script fetches the secrets from SM & export them as environment variables

## TODO
- [ ] Add staging secrets to SM
- [ ] Add production secrets to SM
- [ ] Test on staging. Save one of the env vars from staging in 1password, remove it from EB env vars and then see if it works. Alternatively, we can create a separate env to test this.

Add travis env vars: 
- [ ] STAGING_SECRET_ID
- [ ] PRODUCTION_SECRET_ID

## Deploy Notes

**New Travis environments variables**:

- `STAGING_SECRET_ID` 
- `PRODUCTION_SECRET_ID`

**New scripts**:

- `before-deploy.sh` : For Travis to run before deploying EB
- `docker-entrypoint.sh` :  Entry point for docker image 
