### PR TITLE
Delay processing callbacks

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -423,6 +423,26 @@ const config = convict({
       format: 'required-string',
     },
   },
+  callbackJitterOptions: {
+    windowMs: {
+      doc: 'Window',
+      default: 60000,
+      env: 'CALLBACK_WINDOW_MS',
+      format: 'int',
+    },
+    maxJitterMs: {
+      doc: 'max jitter',
+      default: 10000,
+      env: 'CALLBACK_MAX_JITTER_MS',
+      format: 'int',
+    },
+    delayAfter: {
+      doc: 'Delay after this number of requests within the window',
+      default: 120,
+      env: 'CALLBACK_DELAY_AFTER',
+      format: 'int',
+    },
+  },
 })
 
 // If mailFrom was not set in an env var, set it using the app_name

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -117,7 +117,8 @@ const expressApp = ({ app }: { app: express.Application }): void => {
       _next: express.NextFunction
     ) => {
       logger.error(`${JSON.stringify(err.stack, null, 4)}`)
-      return res.sendStatus(500)
+      if (!res.headersSent) return res.sendStatus(500)
+      return
     }
   )
 

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -1,4 +1,10 @@
-import { Router, Request, Response, NextFunction } from 'express'
+import {
+  Router,
+  Request,
+  Response,
+  NextFunction,
+  RequestHandler,
+} from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { ChannelType } from '@core/constants'
 import { Campaign } from '@core/models'
@@ -28,6 +34,7 @@ import {
   telegramSettingsRoutes,
   telegramCallbackRoutes,
 } from '@telegram/routes'
+import config from '@core/config'
 
 const CHANNEL_ROUTES = Object.values(ChannelType).map(
   (route) => `/${route.toLowerCase()}`
@@ -147,9 +154,39 @@ router.use(
   settingsRoutes
 )
 
-router.use('/callback/email', emailCallbackRoutes)
+const createJitter = ({
+  windowMs,
+  maxJitterMs,
+  delayAfter,
+}: {
+  windowMs: number
+  maxJitterMs: number
+  delayAfter: number
+}): RequestHandler => {
+  const status = { inWindow: 0 }
+  let currentTime = Date.now()
+  const jitter = (_req: Request, _res: Response, next: NextFunction): void => {
+    status.inWindow += 1
+    const now = Date.now()
+    if (now - currentTime > windowMs) {
+      currentTime = now
+      status.inWindow = Math.max(status.inWindow - delayAfter, 0)
+    }
+    if (status.inWindow > delayAfter) {
+      setTimeout(() => {
+        return next()
+      }, Math.ceil(Math.random() * maxJitterMs))
+    } else {
+      return next()
+    }
+  }
+  return jitter
+}
+const jitter = createJitter(config.get('callbackJitterOptions'))
 
-router.use('/callback/sms', smsCallbackRoutes)
+router.use('/callback/email', jitter, emailCallbackRoutes)
+
+router.use('/callback/sms', jitter, smsCallbackRoutes)
 
 router.use('/callback/telegram', telegramCallbackRoutes)
 export default router

--- a/backend/src/core/utils/request.ts
+++ b/backend/src/core/utils/request.ts
@@ -1,4 +1,5 @@
-import { Request } from 'express'
+import { Request, Response, NextFunction, RequestHandler } from 'express'
+import config from '@core/config'
 
 export const getRequestIp: (req: Request) => string = (req: Request) => {
   /**
@@ -7,3 +8,37 @@ export const getRequestIp: (req: Request) => string = (req: Request) => {
    */
   return req.get('cf-connecting-ip') ?? req.ip
 }
+
+const createJitter = ({
+  windowMs,
+  maxJitterMs,
+  delayAfter,
+}: {
+  windowMs: number
+  maxJitterMs: number
+  delayAfter: number
+}): RequestHandler => {
+  const status = { inWindow: 0 }
+  let currentTime = Date.now()
+  const jitter = (_req: Request, res: Response, next: NextFunction): void => {
+    status.inWindow += 1
+    const now = Date.now()
+    if (now - currentTime > windowMs) {
+      currentTime = now
+      status.inWindow = Math.max(status.inWindow - delayAfter, 0)
+    }
+    if (status.inWindow > delayAfter) {
+      // Acknowledge
+      res.sendStatus(202)
+      // Wait to process further
+      setTimeout(() => {
+        return next()
+      }, Math.ceil(Math.random() * maxJitterMs))
+    } else {
+      return next()
+    }
+  }
+  return jitter
+}
+
+export const jitter = createJitter(config.get('callbackJitterOptions'))

--- a/backend/src/email/middlewares/email-callback.middleware.ts
+++ b/backend/src/email/middlewares/email-callback.middleware.ts
@@ -25,7 +25,7 @@ const parseEvent = async (
 ): Promise<Response | void> => {
   try {
     await EmailCallbackService.parseEvent(req)
-    return res.sendStatus(200)
+    if (!res.headersSent) return res.sendStatus(200)
   } catch (err) {
     next(err)
   }

--- a/backend/src/email/routes/email-callback.routes.ts
+++ b/backend/src/email/routes/email-callback.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { EmailCallbackMiddleware } from '@email/middlewares'
+import { jitter } from '@core/utils/request'
 const router = Router()
 /**
  * @swagger
@@ -19,6 +20,7 @@ router.post(
   '/',
   EmailCallbackMiddleware.printConfirmSubscription,
   EmailCallbackMiddleware.isAuthenticated,
+  jitter,
   EmailCallbackMiddleware.parseEvent
 )
 

--- a/backend/src/sms/middlewares/sms-callback.middleware.ts
+++ b/backend/src/sms/middlewares/sms-callback.middleware.ts
@@ -29,7 +29,7 @@ const parseEvent = async (
 ): Promise<Response | void> => {
   try {
     await SmsCallbackService.parseEvent(req)
-    return res.sendStatus(200)
+    if (!res.headersSent) return res.sendStatus(200)
   } catch (err) {
     return next(err)
   }

--- a/backend/src/sms/routes/sms-callback.routes.ts
+++ b/backend/src/sms/routes/sms-callback.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { SmsCallbackMiddleware } from '@sms/middlewares'
+import { jitter } from '@core/utils/request'
 const router = Router()
 
 /**
@@ -28,6 +29,7 @@ const router = Router()
 router.post(
   '/:campaignId(\\d+)/:messageId(\\d+)',
   SmsCallbackMiddleware.isAuthenticated,
+  jitter,
   SmsCallbackMiddleware.parseEvent
 )
 


### PR DESCRIPTION
## Problem

Addresses #757 
Email/sms callbacks contend for database connections

## Solution

Add delay with jitter to the callback routes. 

The concept is given a window of 60s, delay with jitter of up to 10s will be added to subsequent requests after 120 requests/window. 

I'm not sure if I should keep track of fulfilled requests and decrement the counter when a request is fulfilled. 

*ok i think i should use a sliding window instead of a fixed window, will work on this further*

Example:
**First Window t1-t60**
1st request will not be delayed
120th request will not be delayed
121st request will be delayed by up to 10s
122nd request will be delayed by up to 10s

**Second Window t61-t120**
t61: 123rd request will not be delayed (inWindow = 123-120 = 3, which is < 120)

Example 2:
**First Window t1-t60**
1st request will not be delayed
120th request will not be delayed
121-240th request will be delayed by up to 10s

**Second Window t61-t120**
241st request will still be delayed (inWindow = 241-120 = 121 which is > 120)

Example 3:
**First Window t1-t60**
1st request will not be delayed
120th request will not be delayed
121-240th request will be delayed by up to 10s

**Second Window t61-t120**
241st request will still be delayed (inWindow = 241-120 = 121 which is > 120)
In fact, all the requests in this window will be delayed, because we already received more requests than could be handled in the first window. 

**Third Window t121-t180**
242nd request will not be delayed (inWindow = 121 - 120 =  1 which is < 120)

<img width="1378" alt="Screenshot 2020-10-06 at 11 29 35 AM" src="https://user-images.githubusercontent.com/33819199/95157135-c97af980-07ca-11eb-9fc5-c2a14a30453c.png">
