### PR TITLE
feat: Include successfully sent messages in export

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -62,10 +62,11 @@ export interface CampaignStatsCount {
   updated_at: Date
 }
 
-export interface CampaignInvalidRecipient {
+export interface CampaignRecipient {
   recipient: string
   status: string
   updated_at: Date
+  error_code?: string
 }
 
 /**

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -73,12 +73,6 @@ const listCampaigns = ({
           ['updated_at', 'status_updated_at'],
         ],
       },
-      {
-        model: Statistic,
-        attributes: [
-          [literal('(errored + invalid) > 0'), 'has_failed_recipients'],
-        ],
-      },
     ],
   }
   if (offset) {

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -3,7 +3,7 @@ import { Statistic, JobQueue, Campaign } from '@core/models'
 import {
   CampaignStats,
   CampaignStatsCount,
-  CampaignInvalidRecipient,
+  CampaignRecipient,
 } from '@core/interfaces'
 import { MessageStatus, JobStatus } from '@core/constants'
 
@@ -168,20 +168,20 @@ const getTotalSentCount = async (): Promise<number> => {
 }
 
 /**
- * Helper method to get sent_at, status and recipients for failed messages from logs table
+ * Helper method to get delivered messages from logs table
  * @param campaignId
  * @param logsTable
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   campaignId: number,
   logsTable: any
-): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+): Promise<Array<CampaignRecipient>> => {
   const data = await logsTable.findAll({
     raw: true,
     where: {
       campaignId,
       status: {
-        [Op.or]: [MessageStatus.Error, MessageStatus.InvalidRecipient],
+        [Op.not]: MessageStatus.Sending,
       },
     },
     attributes: ['recipient', 'status', 'error_code', 'updated_at'],
@@ -196,5 +196,5 @@ export const StatsService = {
   getTotalSentCount,
   getNumRecipients,
   setNumRecipients,
-  getFailedRecipients,
+  getDeliveredRecipients,
 }

--- a/backend/src/email/middlewares/email-stats.middleware.ts
+++ b/backend/src/email/middlewares/email-stats.middleware.ts
@@ -42,19 +42,21 @@ const updateAndGetStats = async (
 }
 
 /**
- * Gets failed recipients for sms campaign
+ * Get delivered recipients for email campaign
  * @param req
  * @param res
  * @param next
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
   try {
-    const recipients = await EmailStatsService.getFailedRecipients(+campaignId)
+    const recipients = await EmailStatsService.getDeliveredRecipients(
+      +campaignId
+    )
     return res.json(recipients)
   } catch (err) {
     next(err)
@@ -63,6 +65,6 @@ const getFailedRecipients = async (
 
 export const EmailStatsMiddleware = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   updateAndGetStats,
 }

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -764,7 +764,7 @@ router.post('/refresh-stats', EmailStatsMiddleware.updateAndGetStats)
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/export', EmailStatsMiddleware.getFailedRecipients)
+router.get('/export', EmailStatsMiddleware.getDeliveredRecipients)
 
 /**
  * @swagger

--- a/backend/src/email/services/email-stats.service.ts
+++ b/backend/src/email/services/email-stats.service.ts
@@ -2,7 +2,7 @@ import { QueryTypes } from 'sequelize'
 
 import logger from '@core/logger'
 import { StatsService } from '@core/services'
-import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
+import { CampaignStats, CampaignRecipient } from '@core/interfaces'
 
 import { EmailOp, EmailMessage } from '@email/models'
 
@@ -31,18 +31,18 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 }
 
 /**
- * Gets failed recipients for email project
+ * Gets delivered recipients for email campaign
  * @param campaignId
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   campaignId: number
-): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+): Promise<Array<CampaignRecipient>> => {
   await refreshStats(+campaignId)
-  return StatsService.getFailedRecipients(campaignId, EmailMessage)
+  return StatsService.getDeliveredRecipients(campaignId, EmailMessage)
 }
 
 export const EmailStatsService = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   refreshStats,
 }

--- a/backend/src/sms/middlewares/sms-stats.middleware.ts
+++ b/backend/src/sms/middlewares/sms-stats.middleware.ts
@@ -42,19 +42,19 @@ const updateAndGetStats = async (
 }
 
 /**
- * Gets invalid recipients for sms campaign
+ * Get delivered recipients for sms campaign
  * @param req
  * @param res
  * @param next
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
   try {
-    const recipients = await SmsStatsService.getFailedRecipients(+campaignId)
+    const recipients = await SmsStatsService.getDeliveredRecipients(+campaignId)
     return res.json(recipients)
   } catch (err) {
     next(err)
@@ -63,6 +63,6 @@ const getFailedRecipients = async (
 
 export const SmsStatsMiddleware = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   updateAndGetStats,
 }

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -791,6 +791,6 @@ router.post('/refresh-stats', SmsStatsMiddleware.updateAndGetStats)
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/export', SmsStatsMiddleware.getFailedRecipients)
+router.get('/export', SmsStatsMiddleware.getDeliveredRecipients)
 
 export default router

--- a/backend/src/sms/services/sms-stats.service.ts
+++ b/backend/src/sms/services/sms-stats.service.ts
@@ -2,7 +2,7 @@ import { QueryTypes } from 'sequelize'
 
 import logger from '@core/logger'
 import { StatsService } from '@core/services'
-import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
+import { CampaignStats, CampaignRecipient } from '@core/interfaces'
 
 import { SmsOp, SmsMessage } from '@sms/models'
 
@@ -28,18 +28,18 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 }
 
 /**
- * Gets failed recipients for sms project
+ * Gets delivered recipients for sms campaign
  * @param campaignId
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   campaignId: number
-): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+): Promise<Array<CampaignRecipient>> => {
   await refreshStats(+campaignId)
-  return StatsService.getFailedRecipients(campaignId, SmsMessage)
+  return StatsService.getDeliveredRecipients(campaignId, SmsMessage)
 }
 
 export const SmsStatsService = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   refreshStats,
 }

--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -42,19 +42,19 @@ const updateAndGetStats = async (
 }
 
 /**
- * Gets invalid recipients for Telegram campaign
+ * Get delivered recipients for Telegram campaign
  * @param req
  * @param res
  * @param next
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
   const { campaignId } = req.params
   try {
-    const recipients = await TelegramStatsService.getFailedRecipients(
+    const recipients = await TelegramStatsService.getDeliveredRecipients(
       +campaignId
     )
     return res.json(recipients)
@@ -65,6 +65,6 @@ const getFailedRecipients = async (
 
 export const TelegramStatsMiddleware = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   updateAndGetStats,
 }

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -865,6 +865,6 @@ router.post('/refresh-stats', TelegramStatsMiddleware.updateAndGetStats)
  *        "500":
  *           description: Internal Server Error
  */
-router.get('/export', TelegramStatsMiddleware.getFailedRecipients)
+router.get('/export', TelegramStatsMiddleware.getDeliveredRecipients)
 
 export default router

--- a/backend/src/telegram/services/telegram-stats.service.ts
+++ b/backend/src/telegram/services/telegram-stats.service.ts
@@ -1,7 +1,7 @@
 import { QueryTypes } from 'sequelize'
 import logger from '@core/logger'
 import { StatsService } from '@core/services'
-import { CampaignStats, CampaignInvalidRecipient } from '@core/interfaces'
+import { CampaignStats, CampaignRecipient } from '@core/interfaces'
 
 import { TelegramOp, TelegramMessage } from '@telegram/models'
 
@@ -30,18 +30,18 @@ const refreshStats = async (campaignId: number): Promise<void> => {
 }
 
 /**
- * Gets failed recipients for Telegram project
+ * Gets delivered recipients for Telegram campaign
  * @param campaignId
  */
-const getFailedRecipients = async (
+const getDeliveredRecipients = async (
   campaignId: number
-): Promise<Array<CampaignInvalidRecipient> | undefined> => {
+): Promise<Array<CampaignRecipient>> => {
   await refreshStats(+campaignId)
-  return StatsService.getFailedRecipients(campaignId, TelegramMessage)
+  return StatsService.getDeliveredRecipients(campaignId, TelegramMessage)
 }
 
 export const TelegramStatsService = {
   getStats,
-  getFailedRecipients,
+  getDeliveredRecipients,
   refreshStats,
 }

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -27,7 +27,6 @@ export class Campaign {
   isCsvProcessing: boolean
   statusUpdatedAt: Date
   protect: boolean
-  hasFailedRecipients: boolean
 
   constructor(input: any) {
     this.id = input['id']
@@ -41,7 +40,6 @@ export class Campaign {
     this.sentAt = input['sentAt']
     this.statusUpdatedAt = input['statusUpdatedAt']
     this.protect = input['protect']
-    this.hasFailedRecipients = this.getFailedRecipients(input['statistic'])
   }
 
   getStatus(jobs: Array<{ status: string }>): Status {
@@ -58,10 +56,6 @@ export class Campaign {
       }
     }
     return Status.Draft
-  }
-
-  getFailedRecipients(statistic: { has_failed_recipients: boolean }): boolean {
-    return statistic && statistic.has_failed_recipients
   }
 }
 

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -81,7 +81,7 @@ export class CampaignStats {
   }
 }
 
-export class CampaignInvalidRecipient {
+export class CampaignRecipient {
   recipient: string
   status: string
   errorCode: string

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -12,7 +12,6 @@ export enum CampaignExportStatus {
   Unavailable = 'Unavailable',
   Loading = 'Loading',
   Ready = 'Ready',
-  NoError = 'No Error',
 }
 
 const EXPORT_LINK_DISPLAY_WAIT_TIME = 1 * 60 * 1000 // 1 min
@@ -23,7 +22,6 @@ const ExportRecipients = ({
   sentAt,
   status,
   statusUpdatedAt,
-  hasFailedRecipients,
   iconPosition,
   isButton = false,
 }: {
@@ -32,7 +30,6 @@ const ExportRecipients = ({
   sentAt: Date
   status: Status
   statusUpdatedAt: Date
-  hasFailedRecipients: boolean
   iconPosition: 'left' | 'right'
   isButton?: boolean
 }) => {
@@ -52,16 +49,12 @@ const ExportRecipients = ({
       const updatedAtTimestamp = +new Date(statusUpdatedAt)
       const campaignAge = Date.now() - updatedAtTimestamp
       if (campaignAge <= EXPORT_LINK_DISPLAY_WAIT_TIME) {
-        // poll export status until it has reached finalised status (Ready or No Error)
+        // poll export status until it has reached finalised status (Ready)
         timeoutId = setTimeout(getExportStatus, 2000)
         return setExportStatus(CampaignExportStatus.Loading)
       }
 
-      return setExportStatus(
-        hasFailedRecipients
-          ? CampaignExportStatus.Ready
-          : CampaignExportStatus.NoError
-      )
+      return setExportStatus(CampaignExportStatus.Ready)
     }
 
     getExportStatus()
@@ -107,13 +100,11 @@ const ExportRecipients = ({
   function renderTitle() {
     switch (exportStatus) {
       case CampaignExportStatus.Unavailable:
-        return 'The error list would be available for download after sending is complete'
+        return 'The delivery report would be available for download after sending is complete'
       case CampaignExportStatus.Loading:
-        return 'The error list is being generated and would be available in a few minutes'
+        return 'The delivery report is being generated and would be available in a few minutes'
       case CampaignExportStatus.Ready:
-        return 'Download list of recipients with failed deliveries'
-      case CampaignExportStatus.NoError:
-        return 'There are no failed deliveries for this campaign'
+        return 'Download delivery report'
     }
   }
 
@@ -123,17 +114,15 @@ const ExportRecipients = ({
         return (
           <>
             <i className={cx(styles.icon, 'bx bx-loader-alt bx-spin')}></i>
-            <span>Error list</span>
+            <span>Delivery report</span>
           </>
         )
-      case CampaignExportStatus.NoError:
-        return <span>No error</span>
       case CampaignExportStatus.Unavailable:
       case CampaignExportStatus.Ready:
         return (
           <>
             <i className={cx(styles.icon, 'bx bx-download')}></i>
-            <span>Error list</span>
+            <span>Delivery report</span>
           </>
         )
     }

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -12,6 +12,7 @@ export enum CampaignExportStatus {
   Unavailable = 'Unavailable',
   Loading = 'Loading',
   Ready = 'Ready',
+  Exporting = 'Exporting',
 }
 
 const EXPORT_LINK_DISPLAY_WAIT_TIME = 1 * 60 * 1000 // 1 min
@@ -54,7 +55,9 @@ const ExportRecipients = ({
         return setExportStatus(CampaignExportStatus.Loading)
       }
 
-      return setExportStatus(CampaignExportStatus.Ready)
+      if (exportStatus !== CampaignExportStatus.Exporting) {
+        setExportStatus(CampaignExportStatus.Ready)
+      }
     }
 
     getExportStatus()
@@ -69,6 +72,7 @@ const ExportRecipients = ({
     try {
       event.stopPropagation()
       setDisabled(true)
+      setExportStatus(CampaignExportStatus.Exporting)
 
       const list = await exportCampaignStats(campaignId)
 
@@ -101,6 +105,8 @@ const ExportRecipients = ({
         `${campaignName}_${sentAtTime.toLocaleDateString()}_${sentAtTime.toLocaleTimeString()}.csv`,
         'text/csv'
       )
+
+      setExportStatus(CampaignExportStatus.Ready)
     } catch (error) {
       console.error(error)
     } finally {
@@ -114,6 +120,8 @@ const ExportRecipients = ({
         return 'The delivery report would be available for download after sending is complete'
       case CampaignExportStatus.Loading:
         return 'The delivery report is being generated and would be available in a few minutes'
+      case CampaignExportStatus.Exporting:
+        return 'The delivery report is being exported and the download will begin shortly'
       case CampaignExportStatus.Ready:
         return 'Download delivery report'
     }
@@ -122,6 +130,7 @@ const ExportRecipients = ({
   function renderExportButtonContent() {
     switch (exportStatus) {
       case CampaignExportStatus.Loading:
+      case CampaignExportStatus.Exporting:
         return (
           <>
             <i className={cx(styles.icon, 'bx bx-loader-alt bx-spin')}></i>

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -144,7 +144,6 @@ const ProgressDetails = ({
         sentAt={sentAt}
         status={status}
         statusUpdatedAt={statusUpdatedAt}
-        hasFailedRecipients={error + invalid > 0}
         isButton
       />
 

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -115,7 +115,6 @@ const Campaigns = () => {
             sentAt={campaign.sentAt}
             status={campaign.status}
             statusUpdatedAt={campaign.statusUpdatedAt}
-            hasFailedRecipients={campaign.hasFailedRecipients}
           />
         )
       },

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -92,9 +92,8 @@ const EmailDetail = ({
             to send again.
           </p>
           <p>
-            If you encounter failed deliveries, you can download the error list
-            from this page or the dashboard few minutes after sending has
-            completed.
+            An export button will appear for you to download a report with the
+            recipient’s mobile number and delivery status when it is ready.
           </p>
         </>
       )}

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -90,10 +90,10 @@ const SMSDetail = ({
           <p>
             If there are errors with sending your messages, you can click Retry
             to send again.
-            <br />
-            If you encounter failed deliveries, you can download the error list
-            from this page or the dashboard few minutes after sending has
-            completed.
+          </p>
+          <p>
+            An export button will appear for you to download a report with the
+            recipient’s mobile number and delivery status when it is ready.
           </p>
         </>
       )}

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -88,10 +88,12 @@ const TelegramDetail = ({
         <>
           <h2>Your campaign has been sent!</h2>
           <p>
-            A retry button will appear if some messages had an error while
-            sending. You can click on retry to try sending the message(s) again.
-            An export button will appear for you to download a list of failed
-            deliveries with the recipient’s mobile number.
+            If there are errors with sending your messages, you can click Retry
+            to send again.
+          </p>
+          <p>
+            An export button will appear for you to download a report with the
+            recipient’s mobile number and delivery status when it is ready.
           </p>
         </>
       )}

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -7,7 +7,7 @@ import {
   SMSCampaign,
   EmailCampaign,
   TelegramCampaign,
-  CampaignInvalidRecipient,
+  CampaignRecipient,
 } from 'classes'
 import moment from 'moment'
 
@@ -141,16 +141,16 @@ export async function retryCampaign(campaignId: number): Promise<void> {
 
 export async function exportCampaignStats(
   campaignId: number
-): Promise<Array<CampaignInvalidRecipient>> {
+): Promise<Array<CampaignRecipient>> {
   return axios.get(`/campaign/${campaignId}/export`).then((response) => {
-    const invalidRecipients = response.data?.map(
-      (record: any) => new CampaignInvalidRecipient(record)
+    const campaignRecipients = response.data?.map(
+      (record: any) => new CampaignRecipient(record)
     )
-    for (const invalidRecipient of invalidRecipients) {
-      invalidRecipient.updatedAt = moment(invalidRecipient.updatedAt)
+    for (const campaignRecipient of campaignRecipients) {
+      campaignRecipient.updatedAt = moment(campaignRecipient.updatedAt)
         .format('LLL')
         .replace(',', '')
     }
-    return invalidRecipients
+    return campaignRecipients
   })
 }


### PR DESCRIPTION
## Problem

Add successfully sent messages in the exported recipient list.

Closes #489 

## Solution
**Features**:
- Include messages with "SUCCESS" status in `GET /export` endpoint
- Show export button on frontend even if there are no failed recipients

**Improvements**
- Added loading spinner for "Delivery report" Button while exporting

**Bug fixes**
- Standardised the copywriting on the campaign details page for all channels. Telegram was different previously.

### Backend generation of CSV
Decided not to implement backend generation/streaming of the responses to the frontend as the added complexity was not worth it given the following reasons:
- Typical number of recipients for our campaigns are < 1000
- Even in the worst case (200k recipients), memory usage in the browser maxes out at ~130MB
- Shifting the CSV generation to the backend is just shifting the memory load to the backed. Multiple concurrent large requests can degrade the performance of the backend. Decentralising the generation of the CSV to the frontend would be a better choice.

![image](https://user-images.githubusercontent.com/3666479/95709337-06466500-0c91-11eb-8ced-5da0448eba8e.png)

## Tests
_Note: Since this feature identify successfully sent messages using the `SUCCESS` status, it's easiest to test with Telegram campaign locally as the other channels relies on a callback to update the final status to `SUCCESS`._

- Send a new campaign with only successful recipients
- Download CSV by clicking "Delivery report"
- Verify that CSV report has SUCCESS recipients 