### PR TITLE
chore: Improve error messages

### DIFF
--- a/backend/src/core/errors/s3.errors.ts
+++ b/backend/src/core/errors/s3.errors.ts
@@ -1,6 +1,9 @@
 export class RecipientColumnMissing extends Error {
   constructor() {
-    super("Column labelled 'recipient' is missing from uploaded file")
+    super(
+      "Error: 'recipient' column is missing from the uploaded recipient file. Please check the cell in your uploaded CSV file to ensure " +
+        "the recipient's contact info is correctly labelled as 'recipient'."
+    )
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
     Error.captureStackTrace(this)
   }

--- a/backend/src/core/errors/template.errors.ts
+++ b/backend/src/core/errors/template.errors.ts
@@ -2,7 +2,7 @@ export class MissingTemplateKeysError extends Error {
   public readonly missingKeys: string[]
   constructor(missingKeys: string[]) {
     super(
-      `The keyword(s) { ${missingKeys} } are not present in uploaded recipient list.`
+      `Error: The following keyword(s) { ${missingKeys} } are not found in the uploaded recipient list.`
     )
     this.missingKeys = missingKeys
     Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -60,7 +60,7 @@ const getHashedOtp = (email: string): Promise<HashedOtp> => {
         reject(new Error('Internal server error - request for otp again'))
       }
       if (value === null) {
-        reject(new Error('No otp found - request for otp again'))
+        reject(new Error('OTP has expired. Please request for a new OTP.'))
       }
       resolve(JSON.parse(value))
     })

--- a/backend/src/core/services/parse-csv.service.ts
+++ b/backend/src/core/services/parse-csv.service.ts
@@ -66,7 +66,11 @@ const parseAndProcessCsv = async (
           // If there are more or fewer headers than values in a row
           if (errors[0]?.type === 'FieldMismatch') {
             // Ignore other parsing errors https://www.papaparse.com/docs#errors
-            throw new UserError(errors[0].code, errors[0].message)
+            const { code, message, row } = errors[0]
+            throw new UserError(
+              code,
+              `Error: Invalid row detected at line ${row}. ${message}. Please fix the number of fields and try again.`
+            )
           }
 
           // Manually hold a number of rows in a buffer, because the config
@@ -98,7 +102,7 @@ const parseAndProcessCsv = async (
             if (numRecords === 0) {
               throw new UserError(
                 'NoRowsFound',
-                'No rows were found in the uploaded file.'
+                'Error: No rows were found in the uploaded recipient file. Please make sure you uploaded the correct file before sending.'
               )
             }
             await onComplete(numRecords)

--- a/backend/src/core/services/protected.service.ts
+++ b/backend/src/core/services/protected.service.ts
@@ -37,7 +37,7 @@ const checkTemplateVariables = (
   // Makes sure that all the required keywords are inside the template
   if (missing.length !== 0) {
     throw new Error(
-      `Required keywords are missing from the template: ${missing}`
+      `Error: There are missing keywords in the message template: ${missing}. Please return to the previous step to add in the keywords.`
     )
   }
 
@@ -46,7 +46,7 @@ const checkTemplateVariables = (
   // Should only contain the whitelisted keywords
   if (forbidden.length > 0) {
     throw new Error(
-      `Only these keywords are allowed: ${whitelist}.\nRemove the other keywords from the template: ${forbidden}`
+      `Error: Only these keywords are allowed in the template: ${whitelist}.\nRemove the other keywords from the template: ${forbidden}.`
     )
   }
 }

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -181,7 +181,7 @@ const getDeliveredRecipients = async (
     where: {
       campaignId,
       status: {
-        [Op.not]: MessageStatus.Sending,
+        [Op.ne]: null,
       },
     },
     attributes: ['recipient', 'status', 'error_code', 'updated_at'],

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -106,7 +106,9 @@ const uploadCompleteHandler = async (
     // check if template exists
     const template = await EmailTemplateService.getFilledTemplate(+campaignId)
     if (template === null) {
-      throw new Error('Template does not exist, please create a template')
+      throw new Error(
+        'Error: No message template found. Please create a message template before uploading a recipient file.'
+      )
     }
 
     // Store temp filename
@@ -261,7 +263,9 @@ const uploadProtectedCompleteHandler = async (
     // check if template exists
     const template = await EmailTemplateService.getFilledTemplate(+campaignId)
     if (template === null) {
-      throw new Error('Template does not exist, please create a template')
+      throw new Error(
+        'Error: No message template found. Please create a message template before uploading a recipient file.'
+      )
     }
 
     // Store temp filename

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -102,7 +102,9 @@ const uploadCompleteHandler = async (
     // check if template exists
     const template = await SmsTemplateService.getFilledTemplate(+campaignId)
     if (template === null) {
-      throw new Error('Template does not exist, please create a template')
+      throw new Error(
+        'Error: No message template found. Please create a message template before uploading a recipient file.'
+      )
     }
 
     // Store temp filename

--- a/backend/src/telegram/middlewares/telegram-template.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-template.middleware.ts
@@ -102,7 +102,9 @@ const uploadCompleteHandler = async (
       +campaignId
     )
     if (template === null) {
-      throw new Error('Template does not exist, please create a template')
+      throw new Error(
+        'Error: No message template found. Please create a message template before uploading a recipient file.'
+      )
     }
 
     // Store temp filename

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -1,3 +1,5 @@
+import moment from 'moment'
+
 export enum ChannelType {
   SMS = 'SMS',
   Email = 'EMAIL',
@@ -81,7 +83,7 @@ export class CampaignStats {
   }
 }
 
-export class CampaignRecipient {
+export abstract class CampaignRecipient {
   recipient: string
   status: string
   errorCode: string
@@ -90,7 +92,9 @@ export class CampaignRecipient {
   constructor(input: any) {
     this.recipient = input['recipient']
     this.status = input['status']
-    this.errorCode = input['error_code']
-    this.updatedAt = input['updated_at']
+    this.errorCode = this.formatErrorCode(input['error_code'])
+    this.updatedAt = moment(input['updated_at']).format('LLL').replace(',', '')
   }
+
+  protected abstract formatErrorCode(errorCode: string): string
 }

--- a/frontend/src/classes/EmailCampaign.ts
+++ b/frontend/src/classes/EmailCampaign.ts
@@ -1,4 +1,13 @@
-import { Campaign } from './Campaign'
+import { get } from 'lodash'
+import { t } from '@lingui/macro'
+import { i18n } from 'locales'
+import { Campaign, CampaignRecipient } from './Campaign'
+
+const emailErrors = {
+  'Hard bounce': t('errors.email.hardBounce')``,
+  'Soft bounce': t('errors.email.softBounce')``,
+  'Recipient is incorrectly formatted': t('errors.email.invalidFormat')``,
+}
 
 export enum EmailProgress {
   CreateTemplate,
@@ -48,5 +57,23 @@ export class EmailCampaign extends Campaign {
     } else {
       this.progress = EmailProgress.Send
     }
+  }
+}
+
+export class EmailCampaignRecipient extends CampaignRecipient {
+  formatErrorCode(errorCode: string): string {
+    if (this.status !== 'SUCCESS') {
+      const complaintMsg = t('errors.email.complaint')``
+      const blacklistMsg = t('errors.email.blacklist')``
+
+      // If error code is null and status is invalid, the email has been blacklisted. Otherwise, it's returned from a complaint.
+      const formatted =
+        errorCode !== null
+          ? get(emailErrors, errorCode, complaintMsg)
+          : blacklistMsg
+      return i18n._(formatted)
+    }
+
+    return errorCode
   }
 }

--- a/frontend/src/classes/EmailCampaign.ts
+++ b/frontend/src/classes/EmailCampaign.ts
@@ -7,6 +7,7 @@ const emailErrors = {
   'Hard bounce': t('errors.email.hardBounce')``,
   'Soft bounce': t('errors.email.softBounce')``,
   'Recipient is incorrectly formatted': t('errors.email.invalidFormat')``,
+  abuse: t('errors.email.complaint')``,
 }
 
 export enum EmailProgress {
@@ -62,16 +63,19 @@ export class EmailCampaign extends Campaign {
 
 export class EmailCampaignRecipient extends CampaignRecipient {
   formatErrorCode(errorCode: string): string {
-    if (this.status !== 'SUCCESS') {
-      const complaintMsg = t('errors.email.complaint')``
-      const blacklistMsg = t('errors.email.blacklist')``
-
-      // If error code is null and status is invalid, the email has been blacklisted. Otherwise, it's returned from a complaint.
-      const formatted =
-        errorCode !== null
-          ? get(emailErrors, errorCode, complaintMsg)
-          : blacklistMsg
-      return i18n._(formatted)
+    const blacklistMsg = t('errors.email.blacklist')``
+    let formatted = ''
+    switch (this.status) {
+      case 'SENDING':
+      case 'SUCCESS':
+        return ''
+      case 'INVALID_RECIPIENT':
+        // If error code is null and status is invalid, the email has been blacklisted. Otherwise, the error has not been mapped.
+        formatted =
+          errorCode !== null
+            ? get(emailErrors, errorCode, errorCode)
+            : blacklistMsg
+        return i18n._(formatted)
     }
 
     return errorCode

--- a/frontend/src/classes/SMSCampaign.ts
+++ b/frontend/src/classes/SMSCampaign.ts
@@ -46,12 +46,13 @@ export class SMSCampaign extends Campaign {
 
 export class SMSCampaignRecipient extends CampaignRecipient {
   formatErrorCode(errorCode: string): string {
-    if (errorCode && errorCode.startsWith("The 'To'")) {
-      return i18n._(t('errors.sms.invalidPhoneNumber')``)
-    } else if (errorCode === 'Recipient is incorrectly formatted') {
-      return i18n._(t('errors.sms.invalidFormat')``)
+    if (errorCode) {
+      if (errorCode.startsWith("The 'To'")) {
+        return i18n._(t('errors.sms.invalidPhoneNumber')``)
+      } else if (errorCode === 'Recipient is incorrectly formatted') {
+        return i18n._(t('errors.sms.invalidFormat')``)
+      }
     }
-
-    return errorCode
+    return errorCode || ''
   }
 }

--- a/frontend/src/classes/SMSCampaign.ts
+++ b/frontend/src/classes/SMSCampaign.ts
@@ -46,7 +46,7 @@ export class SMSCampaign extends Campaign {
 
 export class SMSCampaignRecipient extends CampaignRecipient {
   formatErrorCode(errorCode: string): string {
-    if (errorCode.startsWith("The 'To'")) {
+    if (errorCode && errorCode.startsWith("The 'To'")) {
       return i18n._(t('errors.sms.invalidPhoneNumber')``)
     } else if (errorCode === 'Recipient is incorrectly formatted') {
       return i18n._(t('errors.sms.invalidFormat')``)

--- a/frontend/src/classes/SMSCampaign.ts
+++ b/frontend/src/classes/SMSCampaign.ts
@@ -1,4 +1,6 @@
-import { Campaign } from './Campaign'
+import { t } from '@lingui/macro'
+import { i18n } from 'locales'
+import { Campaign, CampaignRecipient } from './Campaign'
 
 export enum SMSProgress {
   CreateTemplate,
@@ -39,5 +41,17 @@ export class SMSCampaign extends Campaign {
     } else {
       this.progress = SMSProgress.Send
     }
+  }
+}
+
+export class SMSCampaignRecipient extends CampaignRecipient {
+  formatErrorCode(errorCode: string): string {
+    if (errorCode.startsWith("The 'To'")) {
+      return i18n._(t('errors.sms.invalidPhoneNumber')``)
+    } else if (errorCode === 'Recipient is incorrectly formatted') {
+      return i18n._(t('errors.sms.invalidFormat')``)
+    }
+
+    return errorCode
   }
 }

--- a/frontend/src/classes/TelegramCampaign.ts
+++ b/frontend/src/classes/TelegramCampaign.ts
@@ -60,6 +60,6 @@ export class TelegramCampaignRecipient extends CampaignRecipient {
       }
     }
 
-    return errorCode
+    return errorCode || ''
   }
 }

--- a/frontend/src/classes/TelegramCampaign.ts
+++ b/frontend/src/classes/TelegramCampaign.ts
@@ -1,4 +1,6 @@
-import { Campaign } from './Campaign'
+import { t } from '@lingui/macro'
+import { i18n } from 'locales'
+import { Campaign, CampaignRecipient } from './Campaign'
 
 export enum TelegramProgress {
   CreateTemplate,
@@ -41,5 +43,23 @@ export class TelegramCampaign extends Campaign {
     } else {
       this.progress = TelegramProgress.Send
     }
+  }
+}
+
+export class TelegramCampaignRecipient extends CampaignRecipient {
+  formatErrorCode(errorCode: string): string {
+    if (errorCode) {
+      // Telegram errors has the following format: [code]: [error message]
+      const code = +errorCode.split(':')[0]
+      switch (code) {
+        case 1:
+        case 2:
+          return i18n._(t('errors.telegram.notSubscribed')``)
+        case 403:
+          return i18n._(t('errors.telegram.blocked')``)
+      }
+    }
+
+    return errorCode
   }
 }

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import cx from 'classnames'
 import download from 'downloadjs'
 
-import { Status } from 'classes/Campaign'
+import { ChannelType, Status } from 'classes/Campaign'
 import { ActionButton } from 'components/common'
 import { exportCampaignStats } from 'services/campaign.service'
 import styles from './ExportRecipients.module.scss'
@@ -20,6 +20,7 @@ const EXPORT_LINK_DISPLAY_WAIT_TIME = 1 * 60 * 1000 // 1 min
 const ExportRecipients = ({
   campaignId,
   campaignName,
+  campaignType,
   sentAt,
   status,
   statusUpdatedAt,
@@ -28,6 +29,7 @@ const ExportRecipients = ({
 }: {
   campaignId: number
   campaignName: string
+  campaignType: ChannelType
   sentAt: Date
   status: Status
   statusUpdatedAt: Date
@@ -74,7 +76,7 @@ const ExportRecipients = ({
       setDisabled(true)
       setExportStatus(CampaignExportStatus.Exporting)
 
-      const list = await exportCampaignStats(campaignId)
+      const list = await exportCampaignStats(campaignId, campaignType)
 
       const exportedAt = moment().format('LLL').replace(',', '')
       const explanation = `"This report was exported on ${exportedAt} and can change in the future when Postman receives notifications about the sent messages."\n`

--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -79,7 +79,7 @@ const ExportRecipients = ({
       const list = await exportCampaignStats(campaignId, campaignType)
 
       const exportedAt = moment().format('LLL').replace(',', '')
-      const explanation = `"This report was exported on ${exportedAt} and can change in the future when Postman receives notifications about the sent messages."\n`
+      const explanation = `"This report was exported on ${exportedAt} and can change in the future when Postman.gov.sg receives notifications about the sent messages. "\n`
 
       let content = [explanation]
 
@@ -97,8 +97,8 @@ const ExportRecipients = ({
 
         content = content.concat(headers, recipients)
       } else {
-        const emptyExplaination = `"Finalised delivery statuses for your messages are not yet available, try exporting again later."\n`
-        content = content.concat(emptyExplaination)
+        const emptyExplanation = `"Finalised delivery statuses for your messages are not yet available, try exporting again later."\n`
+        content = content.concat(emptyExplanation)
       }
 
       const sentAtTime = new Date(sentAt)
@@ -119,9 +119,9 @@ const ExportRecipients = ({
   function renderTitle() {
     switch (exportStatus) {
       case CampaignExportStatus.Unavailable:
-        return 'The delivery report would be available for download after sending is complete'
+        return 'The delivery report will be available for download after sending is complete'
       case CampaignExportStatus.Loading:
-        return 'The delivery report is being generated and would be available in a few minutes'
+        return 'The delivery report is being generated and will be available in a few minutes'
       case CampaignExportStatus.Exporting:
         return 'The delivery report is being exported and the download will begin shortly'
       case CampaignExportStatus.Ready:

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Moment from 'react-moment'
 import cx from 'classnames'
 
-import { CampaignStats, Status } from 'classes/Campaign'
+import { ChannelType, CampaignStats, Status } from 'classes/Campaign'
 import { ProgressBar, PrimaryButton, ExportRecipients } from 'components/common'
 import styles from './ProgressDetails.module.scss'
 import { OutboundLink } from 'react-ga'
@@ -11,6 +11,7 @@ import { i18n } from 'locales'
 const ProgressDetails = ({
   campaignId,
   campaignName,
+  campaignType,
   sentAt,
   numRecipients,
   stats,
@@ -20,6 +21,7 @@ const ProgressDetails = ({
 }: {
   campaignId: number
   campaignName: string
+  campaignType: ChannelType
   sentAt: Date
   numRecipients: number
   stats: CampaignStats
@@ -141,6 +143,7 @@ const ProgressDetails = ({
         iconPosition="right"
         campaignId={campaignId}
         campaignName={campaignName}
+        campaignType={campaignType}
         sentAt={sentAt}
         status={status}
         statusUpdatedAt={statusUpdatedAt}

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -112,6 +112,7 @@ const Campaigns = () => {
             iconPosition="left"
             campaignId={campaign.id}
             campaignName={campaign.name}
+            campaignType={campaign.type}
             sentAt={campaign.sentAt}
             status={campaign.status}
             statusUpdatedAt={campaign.statusUpdatedAt}

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -102,6 +102,7 @@ const EmailDetail = ({
         <ProgressDetails
           campaignId={id}
           campaignName={name}
+          campaignType={ChannelType.Email}
           sentAt={sentAt}
           numRecipients={numRecipients}
           stats={stats}

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -104,6 +104,7 @@ const SMSDetail = ({
         <ProgressDetails
           campaignId={id}
           campaignName={name}
+          campaignType={ChannelType.SMS}
           sentAt={sentAt}
           numRecipients={numRecipients}
           stats={stats}

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -104,6 +104,7 @@ const TelegramDetail = ({
         <ProgressDetails
           campaignId={id}
           campaignName={name}
+          campaignType={ChannelType.Telegram}
           sentAt={sentAt}
           numRecipients={numRecipients}
           stats={stats}

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -57,7 +57,7 @@ msgstr "Unsubscribe me"
 msgid "Verifying OTP..."
 msgstr "Verifying OTP..."
 
-#: src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:58
+#: src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:71
 #: src/config.ts:42
 msgid "defaultMailFrom"
 msgstr "donotreply@mail.postman.gov.sg"
@@ -65,6 +65,42 @@ msgstr "donotreply@mail.postman.gov.sg"
 #: src/components/login/login-input/LoginInput.tsx:86
 msgid "e.g. postman@agency.gov.sg"
 msgstr "e.g. postman@agency.gov.sg"
+
+#: src/classes/EmailCampaign.ts:51
+msgid "errors.email.blacklist"
+msgstr "Blacklisted: The email recipient is not valid and might not exist. You have sent to this invalid email address before and we have added this email address to postman's blocklist given that the email address is invalid."
+
+#: src/classes/EmailCampaign.ts:50
+msgid "errors.email.complaint"
+msgstr "Hard bounce: Your email has been delivered. The recipient decides that your message is unsolicited and clicks \"Mark as Spam\" in his or her email client."
+
+#: src/classes/EmailCampaign.ts:6
+msgid "errors.email.hardBounce"
+msgstr "Hard bounce: The email recipient is not valid and might not exist. We will be adding this recipient to our blacklist and we will not send to this recipient again for future campaign."
+
+#: src/classes/EmailCampaign.ts:8
+msgid "errors.email.invalidFormat"
+msgstr "Error: Incorrect email formatting. Please check for typo, space, and symbols and amend this email address."
+
+#: src/classes/EmailCampaign.ts:7
+msgid "errors.email.softBounce"
+msgstr "Soft bounce: The email inbox might be full or the person might have an out-of-office message."
+
+#: src/classes/SMSCampaign.ts:44
+msgid "errors.sms.invalidFormat"
+msgstr "Error: Incorrect phone number formatting. Please check for typo, space, and symbols and amend this phone number."
+
+#: src/classes/SMSCampaign.ts:41
+msgid "errors.sms.invalidPhoneNumber"
+msgstr "Invalid phone number in the recipient column."
+
+#: src/classes/TelegramCampaign.ts:49
+msgid "errors.telegram.blocked"
+msgstr "Bot has been blocked by the user. Please contact your user to reverse the action."
+
+#: src/classes/TelegramCampaign.ts:47
+msgid "errors.telegram.notSubscribed"
+msgstr "User has not subscribe to your agency's bot, please ask them to subscribe before sending a message."
 
 #: src/config.ts:35
 msgid "link.contactUsUrl"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -68,27 +68,27 @@ msgstr "e.g. postman@agency.gov.sg"
 
 #: src/classes/EmailCampaign.ts:51
 msgid "errors.email.blacklist"
-msgstr "Blacklisted: The email recipient is not valid and might not exist. You have sent to this invalid email address before and we have added this email address to postman's blocklist given that the email address is invalid."
+msgstr "Blacklisted: Your email will not be delivered to this recipient because Postman.gov.sg has determined that this recipient is not valid and might not exist."
 
-#: src/classes/EmailCampaign.ts:50
+#: src/classes/EmailCampaign.ts:9
 msgid "errors.email.complaint"
-msgstr "Hard bounce: Your email has been delivered. The recipient decides that your message is unsolicited and clicks \"Mark as Spam\" in his or her email client."
+msgstr "Hard bounce: Your email has been delivered, but the recipient marked it as spam."
 
 #: src/classes/EmailCampaign.ts:6
 msgid "errors.email.hardBounce"
-msgstr "Hard bounce: The email recipient is not valid and might not exist. We will be adding this recipient to our blacklist and we will not send to this recipient again for future campaign."
+msgstr "Hard bounce: The email recipient is not valid and might not exist. Postman.gov.sg will not send to this recipient again for future campaigns."
 
 #: src/classes/EmailCampaign.ts:8
 msgid "errors.email.invalidFormat"
-msgstr "Error: Incorrect email formatting. Please check for typo, space, and symbols and amend this email address."
+msgstr "Error: Incorrect email formatting. Please check for typos, spaces, and symbols and amend this email address."
 
 #: src/classes/EmailCampaign.ts:7
 msgid "errors.email.softBounce"
-msgstr "Soft bounce: The email inbox might be full or the person might have an out-of-office message."
+msgstr "Soft bounce: The email inbox might be full or the recipient might have an out-of-office message."
 
 #: src/classes/SMSCampaign.ts:44
 msgid "errors.sms.invalidFormat"
-msgstr "Error: Incorrect phone number formatting. Please check for typo, space, and symbols and amend this phone number."
+msgstr "Error: Incorrect phone number format. Please check for typos, spaces, and symbols and amend this phone number."
 
 #: src/classes/SMSCampaign.ts:41
 msgid "errors.sms.invalidPhoneNumber"
@@ -96,11 +96,11 @@ msgstr "Invalid phone number in the recipient column."
 
 #: src/classes/TelegramCampaign.ts:49
 msgid "errors.telegram.blocked"
-msgstr "Bot has been blocked by the user. Please contact your user to reverse the action."
+msgstr "Bot has been blocked by the recipient. Please contact the recipient via other means to reverse the action."
 
 #: src/classes/TelegramCampaign.ts:47
 msgid "errors.telegram.notSubscribed"
-msgstr "User has not subscribe to your agency's bot, please ask them to subscribe before sending a message."
+msgstr "Recipient has not subscribed to your agency's bot - please ask them to subscribe before sending a message."
 
 #: src/config.ts:35
 msgid "link.contactUsUrl"


### PR DESCRIPTION
## Problem

Improve both API error and message delivery errors wording to be more user-friendly. Changes were made with reference to [this spreadsheet](https://docs.google.com/spreadsheets/d/1z2hHa8uSuw1SVbgG29bfx3hCBQabRhLZ8o3nF1Jzwqk/edit#gid=1269298248).

Closes #336 

## Solution

**Improvements**:
Updated following error messages:
- Missing recipient column
- Expired OTP
- Missing keywords in recipient list
- Missing campaign template
- Invalid characters in template keyword
- No rows found in recipient list
- Mismatch in number of fields in the recipient list
- Invalid message A keywords

Updated following email delivery errors:
- Soft bounce
- Hard bounce
- Blacklisted email
- Complaint
- Incorrectly formatted email address

Updated following SMS delivery errors:
- Unreachable phone number
- Incorrectly formatted phone number

Updated following Telegram delivery errors:
- Phone number not subscribed to bot

## Tests
_Note: Run `npm run compile` in frontend to ensure that lingui catalog is updated before testing locally. Test both SMS and email channels on staging as they make use of the callbacks to update the finalised status._

**Email delivery errors**
- Send an email campaign with the following recipient list to trigger possible errors. Make sure that `bounce@simulator.amazonses.com` and `complaint@simulator.amazonses.com` are not in the `email_blacklist` table. 
```
recipient
bounce@simulator.amazonses.com
complaint@simulator.amazonses.com
suppressionlist@simulator.amazonses.com
invalid@example*sg
```
- Download the delivery report and check that the appropriate error messages are shown.

**SMS delivery errors**
- Send a SMS campaign using test credentials with the following recipient list to trigger possible errors.
```
recipient
+15005550001
+6571234567
```
- Download the delivery report and check that the appropriate error messages are shown.

**Telegram delivery errors**
- Send a Telegram campaign with a recipient list that includes phone numbers that are not subscribed to the bot.
- Download the delivery report and check that the appropriate error messages are shown.