### PR TITLE
chore: Add Google Analytics to connect-src CSP headers

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -58,7 +58,8 @@ frontend:
             https://postmangovsg-prod-upload.s3.ap-northeast-1.amazonaws.com
             https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/
             https://s3.ap-southeast-1.amazonaws.com/file-production.postman.gov.sg/
-            https://o399364.ingest.sentry.io/;
+            https://o399364.ingest.sentry.io/
+            https://www.google-analytics.com;
             style-src 'self' https://*.postman.gov.sg https://fonts.googleapis.com;
             font-src 'self' https://*.postman.gov.sg https://fonts.gstatic.com;
             default-src 'self' https://*.postman.gov.sg;


### PR DESCRIPTION
## Problem

Existing CSP headers do not allow connection to Google Analytics. 

Closes #742 

## Solution

**Features**:
- Add `https://www.google-analytics.com` to `connect-src`

## Tests
- Deploy onto staging and verify that there is not longer an error for Google Analytics

## Others
**Why was GA still working previously?** 
Google analytics [supports three different transportation mechanism](https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms) (image, xhr and beacon). Since we allowed `https://www.google-analytics.com` in the `image-src` directive, data is still being sent back to GA. GA automatically picks the optimal transport to use. Adding GA to `connect-src` will allow GA to use `beacon` and `xhr` mode when it deems suitable. 

**Why is there still a CSP error to stats.g.doubleclick.net?**

DoubleClick is used for ad management and re-targeting (Google Signals). We can solve this CSP error (have not verified) by disabling Advertising Features. Read more [here](https://tonnygaric.com/blog/prevent-google-analytics-from-making-requests-to-stats-g-doubleclick-net).

![image](https://user-images.githubusercontent.com/3666479/96227734-1c249480-0fc7-11eb-860d-abeb5066ed7d.png)

## TODOs
- [ ] Try [disabling](https://support.google.com/analytics/answer/9050852?hl=en) Advertising Features for GA to prevent connections to `stats.g.doubleclick.net`. Might take some time to take effect.