### PR TITLE
fix: Preview component not rendering HTML for message body

### DIFF
--- a/frontend/src/components/common/preview-block/PreviewBlock.tsx
+++ b/frontend/src/components/common/preview-block/PreviewBlock.tsx
@@ -33,13 +33,17 @@ const PreviewBlock: React.FunctionComponent<PreviewBlockProps> = ({
   }
 
   function constructHtml() {
-    function h(name: string, value?: string | null) {
-      if (value) return `<h5>${name}</h5><p>${escapeHTML(value)}</p>`
+    function h(name: string, value?: string | null, escapeValue = true) {
+      if (value)
+        return `<h5>${name}</h5><p>${
+          escapeValue ? escapeHTML(value) : value
+        }</p>`
       return ''
     }
+
     const html = `${h('From', from)}
     ${h('Subject', subject)}
-    ${h('Body', body)}
+    ${h('Body', body, false)}
     ${h('Replies', replyTo)}`
     return html
   }


### PR DESCRIPTION
## Problem

Preview block was escaping the message body. This results in the raw HTML code being shown instead of rendering the HTML. Users will not be able to see how their rendered message body will look like until they send a test message.

## Solution

**Bug Fixes**:
- Remove escaping of message body for PreviewBlock. Escaping is still preserved for other fields (From, Subject, Reply To).

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/3666479/96678518-7b5a1e80-13a4-11eb-9088-bc58ea8aeedc.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/3666479/96678560-8ad96780-13a4-11eb-8abc-ed232004eea3.png)

## Tests
- Create a new email campaign with the following template and choose `Postman.gov.sg <donotreply@mail.postman.gov.sg>` as the From email
```
<b>bold</b>, bold
<i>italic</i>, italic
<u>underline</u>, underline
strikethrough, strikethrough, strikethrough
<b>bold <i>italic bold italic bold strikethrough <u>underline italic bold</u></i> bold</b>
<a href="https://www.google.com/">Google</a>
```
- Check that the preview block is rendering the HTML and the From is not being truncated