### PR TITLE
Fix: Check if sanitised template is empty before upserting template

### DIFF
--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -169,7 +169,9 @@ const storeTemplate = async ({
   const sanitizedSubject = client.replaceNewLinesAndSanitize(subject)
   const sanitizedBody = client.replaceNewLinesAndSanitize(body)
   if (!sanitizedSubject || !sanitizedBody) {
-    throw new TemplateError('Message template is empty!')
+    throw new TemplateError(
+      'Message template is invalid as it only contains invalid HTML tags!'
+    )
   }
   const updatedTemplate = await upsertEmailTemplate({
     subject: sanitizedSubject,

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -3,7 +3,11 @@ import { difference, keys } from 'lodash'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient, XSS_EMAIL_OPTION } from 'postman-templating'
+import {
+  TemplateClient,
+  XSS_EMAIL_OPTION,
+  TemplateError,
+} from 'postman-templating'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@email/interfaces'
@@ -162,9 +166,14 @@ const storeTemplate = async ({
   from,
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
   // extract params from template, save to db (this will be done with hook)
+  const sanitizedSubject = client.replaceNewLinesAndSanitize(subject)
+  const sanitizedBody = client.replaceNewLinesAndSanitize(body)
+  if (!sanitizedSubject || !sanitizedBody) {
+    throw new TemplateError('Message template is empty!')
+  }
   const updatedTemplate = await upsertEmailTemplate({
-    subject: client.replaceNewLinesAndSanitize(subject),
-    body: client.replaceNewLinesAndSanitize(body),
+    subject: sanitizedSubject,
+    body: sanitizedBody,
     replyTo,
     campaignId,
     from,

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -3,7 +3,11 @@ import { difference, keys } from 'lodash'
 import { isSuperSet } from '@core/utils'
 import { HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
-import { TemplateClient, XSS_SMS_OPTION } from 'postman-templating'
+import {
+  TemplateClient,
+  XSS_SMS_OPTION,
+  TemplateError,
+} from 'postman-templating'
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
@@ -149,8 +153,12 @@ const storeTemplate = async ({
   campaignId,
   body,
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
+  const sanitizedBody = client.replaceNewLinesAndSanitize(body)
+  if (!sanitizedBody) {
+    throw new TemplateError('Message template is empty!')
+  }
   const updatedTemplate = await upsertSmsTemplate({
-    body: client.replaceNewLinesAndSanitize(body),
+    body: sanitizedBody,
     campaignId,
   })
 

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -155,7 +155,9 @@ const storeTemplate = async ({
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
   const sanitizedBody = client.replaceNewLinesAndSanitize(body)
   if (!sanitizedBody) {
-    throw new TemplateError('Message template is empty!')
+    throw new TemplateError(
+      'Message template is invalid as it only contains invalid HTML tags!'
+    )
   }
   const updatedTemplate = await upsertSmsTemplate({
     body: sanitizedBody,

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -147,7 +147,9 @@ const storeTemplate = async ({
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
   const sanitizedBody = client.replaceNewLinesAndSanitize(body)
   if (!sanitizedBody) {
-    throw new TemplateError('Message template is empty!')
+    throw new TemplateError(
+      'Message template is invalid as it only contains invalid HTML tags!'
+    )
   }
   const updatedTemplate = await upsertTelegramTemplate({
     campaignId,

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -5,7 +5,11 @@ import { isSuperSet } from '@core/utils'
 import { InvalidRecipientError, HydrationError } from '@core/errors'
 import { Campaign, Statistic } from '@core/models'
 import { PhoneNumberService } from '@core/services'
-import { TemplateClient, XSS_TELEGRAM_OPTION } from 'postman-templating'
+import {
+  TemplateClient,
+  XSS_TELEGRAM_OPTION,
+  TemplateError,
+} from 'postman-templating'
 
 import { TelegramMessage, TelegramTemplate } from '@telegram/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
@@ -141,9 +145,13 @@ const storeTemplate = async ({
   campaignId,
   body,
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
+  const sanitizedBody = client.replaceNewLinesAndSanitize(body)
+  if (!sanitizedBody) {
+    throw new TemplateError('Message template is empty!')
+  }
   const updatedTemplate = await upsertTelegramTemplate({
     campaignId,
-    body: client.replaceNewLinesAndSanitize(body),
+    body: sanitizedBody,
   })
 
   const firstRecord = await TelegramMessage.findOne({


### PR DESCRIPTION
## Problem

Saving a message template with only invalid HTML tags results in an empty template being saved to the database.

Closes #792

## Solution

Check that for empty message templates and that message template is not empty after it has been sanitised.

**Improvements**:
- Frontend: Trim whitespaces to check for empty message template to disable next button
- postman-templating: Add new function in template client to strip all html tags from input

**Bug Fixes**:

- Strip all tags and leading whitespace from raw template and check that message is not empty
- Do same check on frontend for protected email template before processing csv
- If message template is empty, throw a `TemplateError` with the error message `Message template is empty!`
- Check that sanitised message template is not empty before upserting into template table in database
- If sanitised message template is empty, throw a `TemplateError` with the error message `Message template is invalid as it only contains invalid HTML tags!`

## Tests

- [x] Create a sms campaign, and save the template with an invalid tag e.g. `<foo></foo>`
- [x] Save the template with only whitespaces and/or `<br>` tags
- [x] Save the template with an valid tags but with empty content e.g. `<p>    </p>`
- [x] An error message should be displayed
- [x] Campaign will not be advanced to the next step
- [x] Repeat for telegram and email (check subject and body)