### PR TITLE
chore: Include time in backup folder name

### DIFF
--- a/serverless/database-backup/src/backup.ts
+++ b/serverless/database-backup/src/backup.ts
@@ -104,7 +104,12 @@ class Backup {
 
   async upload(): Promise<string> {
     const bucket = config.get('gcp.backupBucket')
-    const folder = new Date().toISOString().substring(0, 10)
+    // Backup folder follows the following format: YYYY-MM-DD_HH-mm-ss
+    const folder = new Date()
+      .toISOString()
+      .substring(0, 19)
+      .replace(/:/g, '-')
+      .replace('T', '_')
 
     const dumpParams = []
 


### PR DESCRIPTION
## Problem

Backup retries on the same day fail due to a conflict in backup folder name.

## Solution
- Add time to backup folder name. New folder name follows the following format `YYYY-MM-DD_HH-mm-ss`