### PR TITLE
build(ci): use lockfile-lint to inspect lockfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ jobs:
         - npm ci
       script:
         - npm run lint-no-fix
-        - npx lockfile-lint --type npm --path frontend/package-lock.json --validate-https --allowed-hosts npm
-        - npx lockfile-lint --type npm --path backend/package-lock.json --validate-https --allowed-hosts npm        
+        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm        
         - npm run test
       before_deploy:
         - cd $TRAVIS_BUILD_DIR/backend && ./before-deploy.sh
@@ -74,6 +73,7 @@ jobs:
         - npm install
       script:
         - npm run compile
+        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
         - npm run lint-no-fix
         - CI=false npm run build
     - name: serverless-unsubscribe-digest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ jobs:
     - name: backend
       before_install:
         - cd $TRAVIS_BUILD_DIR/backend
+        - npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       install:
         - npm ci
       script:
         - npm run lint-no-fix
-        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm        
         - npm run test
       before_deploy:
         - cd $TRAVIS_BUILD_DIR/backend && ./before-deploy.sh
@@ -47,6 +47,7 @@ jobs:
     - name: worker
       before_install:
         - cd $TRAVIS_BUILD_DIR/worker
+        - npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       install:
         - npm ci
       script:
@@ -72,14 +73,19 @@ jobs:
       install:
         - npm install
       script:
+        - npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
         - npm run compile
-        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
         - npm run lint-no-fix
         - CI=false npm run build
     - name: serverless-unsubscribe-digest
-      before_deploy:
+      before_install:
         - cd $TRAVIS_BUILD_DIR/serverless/unsubscribe-digest
-        - npm install && npm run build
+      install:
+        - npm install
+      before_deploy:
+        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
+        - npm run build
+        - npm prune --production
         - zip -qr code.zip build src package.json node_modules/
       deploy:
         - provider: lambda
@@ -134,8 +140,11 @@ jobs:
             - SES_PORT=$STAGING_UNSUBSCRIBE_DIGEST_SES_PORT
             - UNSUBSCRIBE_GUIDE_URL=$UNSUBSCRIBE_GUIDE_URL
     - name: serverless-database-backup
-      before_deploy:
+      before_install:
         - cd $TRAVIS_BUILD_DIR/serverless/database-backup
+      script:
+        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
+      before_deploy:
         - npm run build:docker
       deploy:
         - provider: lambda
@@ -185,4 +194,5 @@ jobs:
       install:
         - npm install --ignore-scripts
       script:
+        - npx lockfile-lint --type npm --path package-lock.json --validate-https --allowed-hosts npm
         - npm run lint-no-fix

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
         - npm ci
       script:
         - npm run lint-no-fix
+        - npx lockfile-lint --type npm --path frontend/package-lock.json --validate-https --allowed-hosts npm
+        - npx lockfile-lint --type npm --path backend/package-lock.json --validate-https --allowed-hosts npm        
         - npm run test
       before_deploy:
         - cd $TRAVIS_BUILD_DIR/backend && ./before-deploy.sh


### PR DESCRIPTION
## Problem

Lockfiles do not get properly inspected at PRs, so it might be trivial to sneak something
past the PR that we may not want

## Solution

 use lockfile-lint to inspect lockfiles