### PR TITLE
style: Fix section title typography styles

### DIFF
--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -90,7 +90,7 @@ const ProgressDetails = ({
     } else {
       progressMessage = 'Progress'
     }
-    return <h2>{progressMessage}</h2>
+    return <h3>{progressMessage}</h3>
   }
 
   function renderUpdateStats() {

--- a/frontend/src/components/common/step-header/StepHeader.module.scss
+++ b/frontend/src/components/common/step-header/StepHeader.module.scss
@@ -8,7 +8,7 @@
     margin-bottom: $spacing-1;
   }
 
-  h2 {
+  h3 {
     margin: 0;
     margin-bottom: $spacing-3;
   }

--- a/frontend/src/components/common/step-header/StepHeader.tsx
+++ b/frontend/src/components/common/step-header/StepHeader.tsx
@@ -14,7 +14,7 @@ const StepHeader = ({
   return (
     <div className={styles.stepHeader}>
       {subtitle && <sub>{subtitle}</sub>}
-      <h2>{title}</h2>
+      <h3>{title}</h3>
       {children && <div className={styles.description}>{children}</div>}
     </div>
   )

--- a/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
+++ b/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
@@ -5,6 +5,7 @@ import {
   TextInputWithButton,
   ConfirmModal,
   ErrorBlock,
+  StepHeader,
 } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'
 import { regenerateApiKey } from 'services/settings.service'
@@ -124,12 +125,13 @@ const ApiKey: React.FunctionComponent<ApiKeyProps> = ({
 
   return (
     <>
-      <h2>API Key</h2>
-      <p className={styles.helpText}>
-        After generating your API key, please make a copy of it immediately as
-        it will only be shown once. Upon leaving or refreshing this page, the
-        key will be hidden.
-      </p>
+      <StepHeader title="API Key">
+        <p className={styles.helpText}>
+          After generating your API key, please make a copy of it immediately as
+          it will only be shown once. Upon leaving or refreshing this page, the
+          key will be hidden.
+        </p>
+      </StepHeader>
       <TextInputWithButton
         value={apiKey}
         onChange={() => {

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
@@ -4,7 +4,7 @@
 .credHeader {
   @include flex-horizontal();
   justify-content: space-between;
-  margin-bottom: 3.5rem;
+  margin-bottom: $layout-4;
 }
 
 .blueButton {

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
@@ -96,7 +96,7 @@ const Credentials = ({
   return (
     <>
       <div className={styles.credHeader}>
-        <h2>{title}</h2>
+        <h3>{title}</h3>
         <PrimaryButton
           className={styles.blueButton}
           onClick={onAddCredentialClicked}


### PR DESCRIPTION
## Problem

Designers feedback that the previous UI fixes introduced wrong styles for `StepHeader` and the titles in the Settings page.

## Solution

**Bug Fixes**:

- Use `h3` for `StepHeader`
- Use `h3` for credentials pages

## Before & After Screenshots

**Before**
<img src='https://user-images.githubusercontent.com/3666479/98503424-71368c00-228f-11eb-9383-c650ace3edb2.png' width=500/>

**After**
<img src='https://user-images.githubusercontent.com/3666479/98503361-48ae9200-228f-11eb-9081-6ee8fdc3e9c9.png' width=500/>

