### PR TITLE
Remove uploaded file when Telegram template is updated

### DIFF
--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -3,7 +3,7 @@ import { difference, keys } from 'lodash'
 import config from '@core/config'
 import { isSuperSet } from '@core/utils'
 import { InvalidRecipientError, HydrationError } from '@core/errors'
-import { Campaign } from '@core/models'
+import { Campaign, Statistic } from '@core/models'
 import { PhoneNumberService } from '@core/services'
 import { TemplateClient, XSS_TELEGRAM_OPTION } from 'postman-templating'
 
@@ -89,9 +89,24 @@ const checkNewTemplateParams = async ({
     updatedTemplate.params
   )
   if (templateContainsExtraKeys) {
+    // warn if params from s3 file are not a superset of saved params, remind user to re-upload a new file
     const extraKeysInTemplate = difference(updatedTemplate.params, paramsFromS3)
 
-    await TelegramMessage.destroy({ where: { campaignId } })
+    // delete entries (message_logs) from the uploaded file and stored count since they are no longer valid,
+    await TelegramMessage.sequelize?.transaction(async (transaction) => {
+      await TelegramMessage.destroy({
+        where: {
+          campaignId,
+        },
+        transaction,
+      })
+      await Statistic.destroy({
+        where: {
+          campaignId,
+        },
+        transaction,
+      })
+    })
 
     return { reupload: true, extraKeys: extraKeysInTemplate }
   } else {


### PR DESCRIPTION
## Problem

When the telegram template is updated to include keywords that are not found in the previously uploaded file, the uploaded file should be removed.

Closes #818 

## Solution

If the telegram template contains extra keywords, remove all records in the `telegram_messages` table and remove the message status count in `statistic` table.

## Tests

1. Create telegram campaign
2. Create template
3. Upload a file
4. Update the template to include keywords which are absent in uploaded file
5. Check that the uploaded file is removed

