### PR TITLE
feat: add demo video modal for demo mode, and ui updates

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -65,7 +65,9 @@ frontend:
             default-src 'self' https://*.postman.gov.sg;
             object-src 'none';
             script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
-            img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg"
+            img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg;
+            media-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
+            child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/"
         - key: "Content-Security-Policy-Report-Only"
           value: report-uri https://b7b979b458ee470a86efff9ef1653b50@o399364.ingest.sentry.io/5261024;
     - pattern: "/static/**/*"

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -34,6 +34,34 @@ const isSmsCampaignOwnedByUser = async (
 }
 
 /**
+ * Disable a request made for a demo campaign
+ * @param req
+ * @param res
+ * @param next
+ */
+const disabledForDemoCampaign = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  try {
+    const userId = req.session?.user?.id
+    const campaign = await SmsService.findCampaign(
+      +req.params.campaignId,
+      userId
+    )
+    if (campaign.demoMessageLimit) {
+      return res.status(400).json({
+        message: `Action not allowed for demo campaign`,
+      })
+    }
+    return next()
+  } catch (err) {
+    return next(err)
+  }
+}
+
+/**
  * Parse twilio credentials from request body, setting it to res.locals.credentials to be passed downstream
  * @param req
  * @param res
@@ -43,7 +71,7 @@ const getCredentialsFromBody = async (
   req: Request,
   res: Response,
   next: NextFunction
-): Promise<void> => {
+): Promise<void | Response> => {
   const {
     twilio_account_sid: accountSid,
     twilio_api_key: apiKey,
@@ -60,6 +88,37 @@ const getCredentialsFromBody = async (
   return next()
 }
 
+const getDemoCredentialName = (label: string): string => {
+  // Demo campaigns can only use default credentials
+  if (label === DefaultCredentialName.SMS) {
+    return formatDefaultCredentialName(label)
+  } else {
+    throw new Error(
+      `Demo campaign must use demo credentials. ${label} is not allowed.`
+    )
+  }
+}
+const getCredentialName = async (
+  label: string,
+  userId: number
+): Promise<string> => {
+  // Non-demo campaigns cannot use default credentials
+  if (label === DefaultCredentialName.SMS) {
+    throw new Error(
+      `Campaign cannot use demo credentials. ${label} is not allowed.`
+    )
+  } else {
+    // if label provided, fetch from aws secrets
+    const userCred = await CredentialService.getUserCredential(userId, label)
+
+    if (!userCred) {
+      throw new Error('User credential cannot be found')
+    }
+
+    return userCred.credName
+  }
+}
+
 /**
  * Parse label from request body. Retrieve credentials associated with this label,
  * and set the credentials to res.locals.credentials, credName to res.locals.credentialName, to be passed downstream
@@ -72,46 +131,23 @@ const getCredentialsFromLabel = async (
   res: Response,
   next: NextFunction
 ): Promise<void | Response> => {
-  const { campaignId } = req.params
+  const { campaignId } = req.params // May be undefined if invoked from settings page
   const { label } = req.body
   const userId = req.session?.user?.id
-
+  const logMeta = {
+    campaignId,
+    label,
+    action: 'getCredentialsFromLabel',
+  }
   try {
-    const logMeta = {
-      label,
-      action: 'getCredentialsFromLabel',
-    }
     /* Determine if credential name can be used */
-    let credentialName
-    if (label === DefaultCredentialName.SMS) {
-      const campaign = await SmsService.findCampaign(+campaignId, userId) // TODO: refactor this into res.locals
-      if (campaign.demoMessageLimit) {
-        credentialName = formatDefaultCredentialName(label)
-      } else {
-        logger.error({
-          message: `Campaign not allowed to use label`,
-          ...logMeta,
-        })
-        return res.status(400).json({
-          message: `Campaign ${campaignId} is not allowed to use default credentials`,
-        })
-      }
-    } else {
-      // if label provided, fetch from aws secrets
-      const userCred = await CredentialService.getUserCredential(+userId, label)
+    const campaign = campaignId
+      ? await SmsService.findCampaign(+campaignId, userId)
+      : null
+    const credentialName = campaign?.demoMessageLimit
+      ? getDemoCredentialName(label)
+      : await getCredentialName(label, +userId)
 
-      if (!userCred) {
-        logger.error({
-          message: 'User credentials not found',
-          ...logMeta,
-        })
-        return res
-          .status(400)
-          .json({ message: 'User credentials cannot be found' })
-      }
-
-      credentialName = userCred.credName
-    }
     /* Get credential from the name */
     const credentials = await CredentialService.getTwilioCredentials(
       credentialName
@@ -120,7 +156,11 @@ const getCredentialsFromLabel = async (
     res.locals.credentialName = credentialName
     return next()
   } catch (err) {
-    return next(err)
+    logger.error({
+      ...logMeta,
+      message: `${err.stack}`,
+    })
+    return res.status(400).json({ message: `${err.message}` })
   }
 }
 
@@ -265,4 +305,5 @@ export const SmsMiddleware = {
   setCampaignCredential,
   getCampaignDetails,
   previewFirstMessage,
+  disabledForDemoCampaign,
 }

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -514,6 +514,7 @@ router.post(
   '/new-credentials',
   celebrate(storeCredentialsValidator),
   CampaignMiddleware.canEditCampaign,
+  SmsMiddleware.disabledForDemoCampaign,
   SmsMiddleware.getCredentialsFromBody,
   SmsMiddleware.validateAndStoreCredentials,
   SmsMiddleware.setCampaignCredential
@@ -571,6 +572,7 @@ router.post(
   '/new-credentials/v2',
   celebrate(storeCredentialsValidatorV2),
   CampaignMiddleware.canEditCampaign,
+  SmsMiddleware.disabledForDemoCampaign,
   SmsMiddleware.getCredentialsFromBody,
   SmsMiddleware.validateAndStoreCredentials,
   SettingsMiddleware.checkAndStoreLabelIfExists,

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -9,6 +9,34 @@ const logger = loggerWithLabel(module)
 
 const botId = (telegramBotToken: string): string =>
   telegramBotToken.split(':')[0]
+
+/**
+ * Disable a request made for a demo campaign
+ * @param req
+ * @param res
+ * @param next
+ */
+const disabledForDemoCampaign = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<Response | void> => {
+  try {
+    const userId = req.session?.user?.id
+    const campaign = await TelegramService.findCampaign(
+      +req.params.campaignId,
+      userId
+    )
+    if (campaign.demoMessageLimit) {
+      return res.status(400).json({
+        message: `Action disabled for demo campaign`,
+      })
+    }
+    return next()
+  } catch (err) {
+    return next(err)
+  }
+}
 /**
  * Parse telegram credentials from request body, setting it to res.locals.credentials to be passed downstream
  * @param req
@@ -19,12 +47,43 @@ const getCredentialsFromBody = async (
   req: Request,
   res: Response,
   next: NextFunction
-): Promise<void> => {
+): Promise<void | Response> => {
   const { telegram_bot_token: telegramBotToken } = req.body
 
   res.locals.credentials = { telegramBotToken }
   res.locals.credentialName = botId(telegramBotToken)
   return next()
+}
+
+const getDemoCredentialName = (label: string): string => {
+  // Demo campaigns can only use default credentials
+  if (label === DefaultCredentialName.Telegram) {
+    return formatDefaultCredentialName(label)
+  } else {
+    throw new Error(
+      `Demo campaign must use demo credentials. ${label} is not allowed.`
+    )
+  }
+}
+const getCredentialName = async (
+  label: string,
+  userId: number
+): Promise<string> => {
+  // Non-demo campaigns cannot use default credentials
+  if (label === DefaultCredentialName.Telegram) {
+    throw new Error(
+      `Campaign cannot use demo credentials. ${label} is not allowed.`
+    )
+  } else {
+    // if label provided, fetch from aws secrets
+    const userCred = await CredentialService.getUserCredential(userId, label)
+
+    if (!userCred) {
+      throw new Error('User credential cannot be found')
+    }
+
+    return userCred.credName
+  }
 }
 
 /**
@@ -39,45 +98,22 @@ const getCredentialsFromLabel = async (
   res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
-  const { campaignId } = req.params
+  const { campaignId } = req.params // May be undefined if invoked from settings page
   const { label } = req.body
   const userId = req.session?.user?.id
+  const logMeta = {
+    campaignId,
+    label,
+    action: 'getCredentialsFromLabel',
+  }
   try {
-    const logMeta = {
-      label,
-      action: 'getCredentialsFromLabel',
-    }
     /* Determine if credential name can be used */
-    let credentialName
-    if (label === DefaultCredentialName.Telegram) {
-      const campaign = await TelegramService.findCampaign(+campaignId, userId) // TODO: refactor this into res.locals
-      if (campaign.demoMessageLimit) {
-        credentialName = formatDefaultCredentialName(label)
-      } else {
-        logger.error({
-          message: `Campaign not allowed to use label`,
-          ...logMeta,
-        })
-        return res.status(400).json({
-          message: `Campaign ${campaignId} is not allowed to use default credentials`,
-        })
-      }
-    } else {
-      // if label provided, fetch from aws secrets
-      const userCred = await CredentialService.getUserCredential(+userId, label)
-
-      if (!userCred) {
-        logger.error({
-          message: 'User credentials not found',
-          ...logMeta,
-        })
-        return res
-          .status(400)
-          .json({ message: 'User credentials cannot be found' })
-      }
-
-      credentialName = userCred.credName
-    }
+    const campaign = campaignId
+      ? await TelegramService.findCampaign(+campaignId, userId)
+      : null
+    const credentialName = campaign?.demoMessageLimit
+      ? getDemoCredentialName(label)
+      : await getCredentialName(label, +userId)
 
     const telegramBotToken = await CredentialService.getTelegramCredential(
       credentialName
@@ -86,7 +122,11 @@ const getCredentialsFromLabel = async (
     res.locals.credentialName = botId(telegramBotToken)
     return next()
   } catch (err) {
-    return next(err)
+    logger.error({
+      ...logMeta,
+      message: `${err.stack}`,
+    })
+    return res.status(400).json({ message: `${err.message}` })
   }
 }
 
@@ -320,4 +360,5 @@ export const TelegramMiddleware = {
   validateAndStoreCredentials,
   setCampaignCredential,
   sendValidationMessage,
+  disabledForDemoCampaign,
 }

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -571,6 +571,7 @@ router.post(
   '/new-credentials',
   celebrate(storeCredentialsValidator),
   CampaignMiddleware.canEditCampaign,
+  TelegramMiddleware.disabledForDemoCampaign,
   TelegramMiddleware.getCredentialsFromBody,
   TelegramMiddleware.validateAndStoreCredentials,
   TelegramMiddleware.setCampaignCredential
@@ -625,6 +626,7 @@ router.post(
   '/new-credentials/v2',
   celebrate(storeCredentialsValidatorV2),
   CampaignMiddleware.canEditCampaign,
+  TelegramMiddleware.disabledForDemoCampaign,
   TelegramMiddleware.getCredentialsFromBody,
   TelegramMiddleware.validateAndStoreCredentials,
   SettingsMiddleware.checkAndStoreLabelIfExists,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5211,6 +5211,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -9306,6 +9311,11 @@
         }
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-fs-cache": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.3.tgz",
@@ -9686,6 +9696,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -12625,6 +12640,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
     "react-ga": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
@@ -12665,6 +12685,18 @@
       "integrity": "sha512-Ch++Njfv8UHpLtIMiQouAPeJQA5Ki86kIYfCer6c1B96Rvn3UF27se+goCilCP8oHNXNsA2R2kxvzanY1YIkyg==",
       "requires": {
         "prop-types": "^15.6.1"
+      }
+    },
+    "react-player": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.6.2.tgz",
+      "integrity": "sha512-Wi9DynNSVgddKxac5OzsH0Upk6VRYssvLLGgCRw6vsjzqMX6S5N26WDRNYnLaHykxFNtpPSDc53fXDe52hMaCg==",
+      "requires": {
+        "deepmerge": "^4.0.0",
+        "load-script": "^1.0.0",
+        "memoize-one": "^5.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.0.1"
       }
     },
     "react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "react-lottie": "^1.2.3",
     "react-moment": "^0.9.7",
     "react-paginate": "^6.3.2",
+    "react-player": "^2.6.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.3",
     "react-textarea-autosize": "^7.1.2",

--- a/frontend/src/components/common/dropdown/Dropdown.module.scss
+++ b/frontend/src/components/common/dropdown/Dropdown.module.scss
@@ -30,6 +30,13 @@
       font-size: 1.4rem;
       transition: transform 100ms ease-out;
     }
+
+    &.disabled {
+      opacity: 0.3;
+      background-color: $grey-500;
+      border-color: $light-grey;
+      cursor: not-allowed;
+    }
   }
 
   &.open {

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -7,10 +7,12 @@ const Dropdown = ({
   options,
   onSelect,
   defaultLabel,
+  disabled,
 }: {
   options: { label: string; value: string }[]
   onSelect: (value: string) => any
   defaultLabel?: string
+  disabled?: boolean
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isOpen, setIsOpen] = useState(false)
@@ -51,10 +53,15 @@ const Dropdown = ({
 
   return (
     <div
-      className={cx(styles.container, { [styles.open]: isOpen })}
+      className={cx(styles.container, {
+        [styles.open]: isOpen,
+      })}
       ref={containerRef}
     >
-      <div className={styles.select} onClick={() => setIsOpen(!isOpen)}>
+      <div
+        className={cx(styles.select, { [styles.disabled]: disabled })}
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+      >
         {selectedLabel}
         <i className={cx(styles.caret, 'bx bx-caret-down')}></i>
       </div>

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -167,8 +167,12 @@ const SMSCredentials = ({
                 onSelect={setSelectedCredential}
                 options={storedCredentials}
                 defaultLabel={storedCredentials[0]?.label}
+                disabled={isDemo}
               ></Dropdown>
-              <p className="clickable" onClick={() => setIsManual(true)}>
+              <p
+                className={cx('clickable', { disabled: isDemo })}
+                onClick={() => !isDemo && setIsManual(true)}
+              >
                 Input credentials manually
               </p>
               {isDemo && selectedCredential === DEMO_CREDENTIAL && (

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -250,10 +250,15 @@ const TelegramCredentials = ({
                 onSelect={setSelectedCredential}
                 options={storedCredentials}
                 defaultLabel={storedCredentials[0]?.label}
+                disabled={isDemo}
               ></Dropdown>
+
               <ErrorBlock>{errorMessage}</ErrorBlock>
 
-              <p className="clickable" onClick={() => setIsManual(true)}>
+              <p
+                className={cx('clickable', { disabled: isDemo })}
+                onClick={() => !isDemo && setIsManual(true)}
+              >
                 Add new credentials
               </p>
 

--- a/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.module.scss
@@ -31,7 +31,7 @@
 
 .options {
   @include flex-horizontal;
-  
+
   button {
     margin-top: $spacing-4;
     margin-right: $spacing-4;
@@ -51,5 +51,4 @@
       margin-right: 0;
     }
   }
-  
 }

--- a/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import styles from './CompletedDemoModal.module.scss'
 import CongratsImage from 'assets/img/demo/congrats.png'
 import EndDemoImage from 'assets/img/demo/end-demo.png'
@@ -8,12 +8,15 @@ import { OutboundLink } from 'react-ga'
 import { ChannelType } from 'classes'
 import { getUserSettings } from 'services/settings.service'
 import { PrimaryButton } from 'components/common'
+import DemoVideoModal from 'components/dashboard/demo/demo-video-modal'
+import { ModalContext } from 'contexts/modal.context'
 
 const CompletedDemoModal = ({
   selectedChannel,
 }: {
   selectedChannel: ChannelType
 }) => {
+  const { setModalContent } = useContext(ModalContext)
   const [demoInfo, setDemoInfo] = useState({
     numDemosSms: 0,
     numDemosTelegram: 0,
@@ -76,17 +79,23 @@ const CompletedDemoModal = ({
     )
   }
 
+  function showDemoVideoModal() {
+    setModalContent(
+      <DemoVideoModal
+        numDemosSms={demoInfo.numDemosSms}
+        numDemosTelegram={demoInfo.numDemosTelegram}
+      />
+    )
+  }
+
   return (
     <div className={styles.content}>
       {numDemosLeft() > 0 ? renderRemainingDemos() : renderNoDemos()}
       <div className={styles.options}>
-        <OutboundLink
-          eventLabel={i18n._(LINKS.guideDemoUrl)}
-          to={i18n._(LINKS.guideDemoUrl)}
-          target="_blank"
-        >
-          <PrimaryButton>Watch tutorial</PrimaryButton>
-        </OutboundLink>
+        <PrimaryButton onClick={showDemoVideoModal}>
+          Watch tutorial
+        </PrimaryButton>
+
         <OutboundLink
           eventLabel={i18n._(LINKS.contactUsUrl)}
           to={i18n._(LINKS.contactUsUrl)}

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
@@ -11,9 +11,7 @@ import {
 import { ModalContext } from 'contexts/modal.context'
 import { useHistory } from 'react-router-dom'
 import { createCampaign } from 'services/campaign.service'
-import { i18n } from 'locales'
-import { LINKS } from 'config'
-import { OutboundLink } from 'react-ga'
+import DemoVideoModal from 'components/dashboard/demo/demo-video-modal'
 const CreateDemoModal = ({
   numDemosSms,
   numDemosTelegram,
@@ -21,7 +19,7 @@ const CreateDemoModal = ({
   numDemosSms: number
   numDemosTelegram: number
 }) => {
-  const { close, setModalTitle } = useContext(ModalContext)
+  const { close, setModalTitle, setModalContent } = useContext(ModalContext)
   const history = useHistory()
   const [errorMessage, setErrorMessage] = useState('')
   const [selectedChannel, setSelectedChannel] = useState(ChannelType.SMS)
@@ -59,7 +57,6 @@ const CreateDemoModal = ({
         (numDemosChannel && 4 - numDemosChannel) || ''
       }`
     )
-    //setDemoCampaignMessage(message)
     setModalTitle(message)
     setIsCreateEnabled(!!numDemosChannel)
   }, [numDemosSms, numDemosTelegram, selectedChannel, setModalTitle])
@@ -79,6 +76,15 @@ const CreateDemoModal = ({
     }
   }
 
+  function showDemoVideoModal() {
+    setModalTitle(null)
+    setModalContent(
+      <DemoVideoModal
+        numDemosSms={numDemosSms}
+        numDemosTelegram={numDemosTelegram}
+      />
+    )
+  }
   return (
     <>
       <div className={styles.content}>
@@ -139,13 +145,10 @@ const CreateDemoModal = ({
         </div>
         <div className="separator"></div>
         <div className={styles.actions}>
-          <OutboundLink
-            eventLabel={i18n._(LINKS.guideDemoUrl)}
-            to={i18n._(LINKS.guideDemoUrl)}
-            target="_blank"
-          >
-            <TextButton minButtonWidth>Watch the video</TextButton>
-          </OutboundLink>
+          <TextButton minButtonWidth onClick={showDemoVideoModal}>
+            Watch the video
+          </TextButton>
+
           <PrimaryButton onClick={createDemo} disabled={!isCreateEnabled}>
             Create demo campaign
           </PrimaryButton>

--- a/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.module.scss
@@ -7,42 +7,32 @@
   text-align: center;
 }
 
-.modalImg {
-  width: 16rem;
-  margin-bottom: $spacing-5;
-}
-
-.icon {
-  @include icon;
-}
-
 .title {
   font-weight: 500;
   margin-top: 0;
   margin-bottom: $spacing-3;
 }
 
-.subtitle {
-  font-weight: normal;
-  margin-top: 0;
-  margin-bottom: $spacing-7;
-  text-align: center;
+.helpText {
+  @extend %body-1;
+  margin-top: $spacing-5;
+  a {
+    font-size: inherit;
+    font-weight: 500;
+    color: $primary;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
-
 .options {
   @include flex-horizontal;
-  
+
   button {
     margin-top: $spacing-4;
     margin-right: $spacing-4;
     &:last-child {
       margin-right: 0;
-    }
-  }
-  .outlineBtn {
-    @extend %outline-btn;
-    &:hover {
-      background-color: $neutral;
     }
   }
   @include mobile() {
@@ -51,5 +41,4 @@
       margin-right: 0;
     }
   }
-  
 }

--- a/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
@@ -1,0 +1,57 @@
+import React, { useContext } from 'react'
+import { ModalContext } from 'contexts/modal.context'
+import styles from './DemoVideoModal.module.scss'
+import { PrimaryButton, TextButton } from 'components/common'
+import CreateDemoModal from 'components/dashboard/demo/create-demo-modal'
+import { LINKS } from 'config'
+import { i18n } from 'locales'
+import { OutboundLink } from 'react-ga'
+
+const DemoVideoModal = ({
+  numDemosSms,
+  numDemosTelegram,
+}: {
+  numDemosSms: number
+  numDemosTelegram: number
+}) => {
+  const { close, setModalContent } = useContext(ModalContext)
+
+  function showCreateDemoModal() {
+    setModalContent(
+      <CreateDemoModal
+        numDemosSms={numDemosSms}
+        numDemosTelegram={numDemosTelegram}
+      />
+    )
+  }
+  return (
+    <div className={styles.content}>
+      <h2 className={styles.title}>Send Demo SMS or Telegram Campaigns</h2>
+      <p className={styles.helpText}>
+        Need more help?{' '}
+        <OutboundLink
+          eventLabel={i18n._(LINKS.guideDemoUrl)}
+          to={i18n._(LINKS.guideDemoUrl)}
+          target="_blank"
+        >
+          Read the guide
+        </OutboundLink>
+        .
+      </p>
+      <div className={styles.options}>
+        <TextButton minButtonWidth onClick={close}>
+          Dismiss
+        </TextButton>
+        {!!numDemosSms || !!numDemosTelegram ? (
+          <PrimaryButton onClick={showCreateDemoModal}>
+            Got it, I&apos;m ready to try
+          </PrimaryButton>
+        ) : (
+          <></>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default DemoVideoModal

--- a/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
@@ -6,6 +6,7 @@ import CreateDemoModal from 'components/dashboard/demo/create-demo-modal'
 import { LINKS } from 'config'
 import { i18n } from 'locales'
 import { OutboundLink } from 'react-ga'
+import ReactPlayer from 'react-player/lazy'
 
 const DemoVideoModal = ({
   numDemosSms,
@@ -27,17 +28,22 @@ const DemoVideoModal = ({
   return (
     <div className={styles.content}>
       <h2 className={styles.title}>Send Demo SMS or Telegram Campaigns</h2>
-      <p className={styles.helpText}>
+      <ReactPlayer
+        playing
+        controls
+        url={i18n._(LINKS.demoVideoUrl)}
+      ></ReactPlayer>
+      <div className={styles.helpText}>
         Need more help?{' '}
         <OutboundLink
           eventLabel={i18n._(LINKS.guideDemoUrl)}
           to={i18n._(LINKS.guideDemoUrl)}
           target="_blank"
         >
-          Read the guide
+          Read the walkthrough tutorial
         </OutboundLink>
         .
-      </p>
+      </div>
       <div className={styles.options}>
         <TextButton minButtonWidth onClick={close}>
           Dismiss

--- a/frontend/src/components/dashboard/demo/demo-video-modal/index.ts
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DemoVideoModal'

--- a/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
+++ b/frontend/src/components/dashboard/settings/add-credential-modal/AddCredentialModal.tsx
@@ -142,6 +142,7 @@ const AddCredentialModal = ({
         <div className={styles.actionButtons}>
           <PrimaryButton
             onClick={nextFunc}
+            disabled={!(credentials && label)}
             loadingPlaceholder={
               <>
                 Validating<i className="bx bx-loader-alt bx-spin"></i>

--- a/frontend/src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx
+++ b/frontend/src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx
@@ -111,13 +111,13 @@ const CustomFromAddress = ({
             The process requires correspondence with your agency&apos;s IT team,
             and is manual at the moment, so please follow the steps below.
           </p>
-          <p>
+          <div>
             <b>How to proceed</b>:
             <ol>
               <li>Fill in request form on FormSG</li>
               <li>Wait for us to contact you within 5 working days</li>
             </ol>
-          </p>
+          </div>
         </StepHeader>
 
         <div className={styles.actionButtons}>

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -40,6 +40,12 @@ const Landing = () => {
   const history = useHistory()
 
   useEffect(() => {
+    async function getSentMessages() {
+      const stats = await getLandingStats()
+      if (stats) {
+        setSentMessages(stats.toLocaleString())
+      }
+    }
     getSentMessages()
   }, [])
 
@@ -137,13 +143,6 @@ const Landing = () => {
       ),
     },
   ]
-
-  async function getSentMessages() {
-    const stats = await getLandingStats()
-    if (stats) {
-      setSentMessages(stats.toLocaleString())
-    }
-  }
 
   return (
     <div className={styles.landing}>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -40,6 +40,7 @@ export const LINKS = {
   reportBugUrl: t('link.reportBugUrl')``,
   customFromAddressRequestUrl: t('link.customFromAddressRequestUrl')``,
   demoTelegramBotUrl: t('link.demoTelegramBotUrl')``,
+  demoVideoUrl: t('link.demoVideoUrl')``,
 }
 export const DEFAULT_MAIL_FROM = t('defaultMailFrom')``
 // Semi-colon separated list of allowed image source hostnames

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -57,12 +57,12 @@ msgstr "Unsubscribe me"
 msgid "Verifying OTP..."
 msgstr "Verifying OTP..."
 
-#: src/config.ts:46
+#: src/config.ts:47
 msgid "allowedImageSources"
 msgstr "file.go.gov.sg"
 
 #: src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
-#: src/config.ts:44
+#: src/config.ts:45
 msgid "defaultMailFrom"
 msgstr "donotreply@mail.postman.gov.sg"
 
@@ -129,6 +129,10 @@ msgstr "https://go.gov.sg/postman-custom-from"
 #: src/config.ts:42
 msgid "link.demoTelegramBotUrl"
 msgstr "https://go.gov.sg/postmangovsgbot"
+
+#: src/config.ts:43
+msgid "link.demoVideoUrl"
+msgstr "https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/Demo+Campaign+Mode.mp4"
 
 #: src/config.ts:35
 msgid "link.guideDemoUrl"

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -78,6 +78,13 @@ p {
   &:hover {
     text-decoration: underline;
   }
+
+  &.disabled {
+    color: $grey-500;
+    opacity: 0.7;
+    text-decoration: none;
+    cursor: not-allowed;
+  }
 }
 
 img {


### PR DESCRIPTION
## Problem
Updates needed for demo mode
Closes #820

## Solution
- Add a demo video modal, accessible when users click on "Watch video"
- Prevent use of non-demo credentials in demo campaigns

### Other fixes:
- Move getting of stats on landing page inside useEffect to get rid of memory leak complaint

## Screenshots
<img width="790" alt="Screenshot 2020-11-11 at 2 50 47 AM" src="https://user-images.githubusercontent.com/33819199/98718128-f96c7c80-23c8-11eb-9bf9-3320892fd284.png">
<img width="578" alt="Screenshot 2020-11-11 at 2 51 05 AM" src="https://user-images.githubusercontent.com/33819199/98718136-fd000380-23c8-11eb-9844-f21b4a0ef53a.png">
<img width="629" alt="Screenshot 2020-11-11 at 2 51 55 AM" src="https://user-images.githubusercontent.com/33819199/98718138-fd989a00-23c8-11eb-9190-26f79abd88b9.png">

## Tests
- Posting to /new-credentials is not allowed for demo campaigns
- Demo campaigns can use only demo credentials
- Non demo campaigns cannot use demo credentials

## Notes
- Created a new **public** bucket for the video
- Added csp headers to allow videos originating from that bucket

**New dependencies**
- `react-player` : component for playing video