### PR TITLE
Fix saving telegram credential from create campaign page

### DIFF
--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -111,6 +111,7 @@ const TelegramCredentials = ({
         await validateNewCredentials({
           campaignId: +campaignId,
           ...creds,
+          ...(saveCredentialWithLabel && { label }),
         })
       } else if (!isManual && selectedCredential) {
         await validateStoredCredentials({


### PR DESCRIPTION
## Problem

Unable to save credential from insert credentials step for Telegram channel.

Closes #837

## Solution

Include label in args for `validateNewCredentials` function call in `TelegramCredentials` component.