### PR TITLE
Fix: campaign progress not updated when campaign properties were updated

### DIFF
--- a/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
@@ -14,14 +14,14 @@ import {
 import { useParams } from 'react-router-dom'
 
 import EmailValidationInput from './EmailValidationInput'
-import { EmailCampaign, EmailProgress } from 'classes'
+import { EmailProgress } from 'classes'
 
 const EmailCredentials = ({
   setActiveStep,
 }: {
   setActiveStep: Dispatch<SetStateAction<EmailProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { hasCredential: initialHasCredential, protect } = campaign
   const [hasCredential, setHasCredential] = useState(initialHasCredential)
   const [errorMsg, setErrorMsg] = useState(null)
@@ -39,9 +39,7 @@ const EmailCredentials = ({
       })
       setHasCredential(true)
       // Saves hasCredential property but do not advance to next step
-      setCampaign(
-        (campaign) => ({ ...campaign, hasCredential: true } as EmailCampaign)
-      )
+      updateCampaign({ hasCredential: true })
     } catch (err) {
       setErrorMsg(err.message)
     }

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -27,7 +27,7 @@ import {
   StepHeader,
   StepSection,
 } from 'components/common'
-import { EmailCampaign, EmailPreview, EmailProgress } from 'classes'
+import { EmailPreview, EmailProgress } from 'classes'
 import { sendTiming } from 'services/ga.service'
 
 import styles from '../Create.module.scss'
@@ -43,7 +43,7 @@ const EmailRecipients = ({
   template?: string
   forceReset?: boolean // this forces upload button to show without csv info and preview
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const {
     csvFilename: initialCsvFilename,
     isCsvProcessing: initialIsProcessing,
@@ -110,16 +110,8 @@ const EmailRecipients = ({
 
   // If campaign properties change, bubble up to root campaign object
   useEffect(() => {
-    setCampaign(
-      (campaign) =>
-        ({
-          ...campaign,
-          isCsvProcessing,
-          csvFilename,
-          numRecipients,
-        } as EmailCampaign)
-    )
-  }, [isCsvProcessing, csvFilename, numRecipients, setCampaign])
+    updateCampaign({ isCsvProcessing, csvFilename, numRecipients })
+  }, [isCsvProcessing, csvFilename, numRecipients, updateCampaign])
 
   // Handle file upload
   async function uploadFile(files: File[]) {

--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useParams } from 'react-router-dom'
 
 import { CampaignContext } from 'contexts/campaign.context'
-import { EmailCampaign, EmailProgress, Status } from 'classes'
+import { EmailProgress, Status } from 'classes'
 import { ModalContext } from 'contexts/modal.context'
 import {
   PreviewBlock,
@@ -29,7 +29,7 @@ const EmailSend = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<EmailProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { numRecipients } = campaign
   const modalContext = useContext(ModalContext)
   const [preview, setPreview] = useState(
@@ -63,9 +63,7 @@ const EmailSend = ({
 
   const onModalConfirm = async () => {
     await sendCampaign(+campaignId, 0)
-    setCampaign(
-      (campaign) => ({ ...campaign, status: Status.Sending } as EmailCampaign)
-    )
+    updateCampaign({ status: Status.Sending })
   }
 
   const openModal = () => {

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -31,7 +31,7 @@ const EmailTemplate = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<EmailProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const {
     body: initialBody,
     subject: initialSubject,
@@ -70,18 +70,14 @@ const EmailTemplate = ({
           from
         )
         if (updatedTemplate) {
-          setCampaign(
-            (campaign) =>
-              ({
-                ...campaign,
-                from: updatedTemplate.from,
-                subject: updatedTemplate.subject,
-                body: updatedTemplate.body,
-                replyTo: updatedTemplate.reply_to,
-                params: updatedTemplate.params,
-                numRecipients,
-              } as EmailCampaign)
-          )
+          updateCampaign({
+            from: updatedTemplate.from,
+            subject: updatedTemplate.subject,
+            body: updatedTemplate.body,
+            replyTo: updatedTemplate.reply_to,
+            params: updatedTemplate.params,
+            numRecipients,
+          })
           setActiveStep((s) => s + 1)
         }
       } catch (err) {
@@ -89,7 +85,7 @@ const EmailTemplate = ({
         if (propagateError) throw err
       }
     },
-    [body, campaignId, from, replyTo, setActiveStep, setCampaign, subject]
+    [body, campaignId, from, replyTo, setActiveStep, subject, updateCampaign]
   )
 
   async function populateFromAddresses() {

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -32,7 +32,7 @@ import TwilioCredentialsInput, {
   TwilioCredentials,
 } from './TwilioCredentialsInput'
 import styles from '../Create.module.scss'
-import { SMSCampaign, SMSProgress } from 'classes'
+import { SMSProgress } from 'classes'
 import { OutboundLink } from 'react-ga'
 import { i18n } from 'locales'
 import { LINKS } from 'config'
@@ -43,7 +43,7 @@ const SMSCredentials = ({
   setActiveStep: Dispatch<SetStateAction<SMSProgress>>
 }) => {
   const DEMO_CREDENTIAL = 'Postman_SMS_Demo'
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { hasCredential: initialHasCredential, demoMessageLimit } = campaign
   const isDemo = !!demoMessageLimit
 
@@ -115,9 +115,7 @@ const SMSCredentials = ({
       setHasCredential(true)
       setShowCredentialFields(false)
       // Saves hasCredential property but do not advance to next step
-      setCampaign(
-        (campaign) => ({ ...campaign, hasCredential: true } as SMSCampaign)
-      )
+      updateCampaign({ hasCredential: true })
     } catch (err) {
       setErrorMessage(err.message)
     }

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -37,7 +37,7 @@ const SMSRecipients = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<SMSProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const {
     isCsvProcessing: initialIsProcessing,
     numRecipients: initialNumRecipients,
@@ -93,16 +93,8 @@ const SMSRecipients = ({
 
   // If campaign properties change, bubble up to root campaign object
   useEffect(() => {
-    setCampaign(
-      (campaign) =>
-        ({
-          ...campaign,
-          isCsvProcessing,
-          csvFilename,
-          numRecipients,
-        } as SMSCampaign)
-    )
-  }, [isCsvProcessing, csvFilename, numRecipients, setCampaign])
+    updateCampaign({ isCsvProcessing, csvFilename, numRecipients })
+  }, [isCsvProcessing, csvFilename, numRecipients, updateCampaign])
 
   // Handle file upload
   async function uploadFile(files: File[]) {

--- a/frontend/src/components/dashboard/create/sms/SMSSend.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSSend.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useParams } from 'react-router-dom'
 
 import { CampaignContext } from 'contexts/campaign.context'
-import { Status, ChannelType, SMSCampaign, SMSProgress } from 'classes'
+import { Status, ChannelType, SMSProgress } from 'classes'
 import { ModalContext } from 'contexts/modal.context'
 import {
   PreviewBlock,
@@ -31,7 +31,7 @@ const SMSSend = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<SMSProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { numRecipients } = campaign
   const modalContext = useContext(ModalContext)
   const [preview, setPreview] = useState({} as { body: string })
@@ -62,9 +62,7 @@ const SMSSend = ({
     if (sendRate) {
       sendUserEvent(GA_USER_EVENTS.USE_SEND_RATE, ChannelType.SMS)
     }
-    setCampaign(
-      (campaign) => ({ ...campaign, status: Status.Sending } as SMSCampaign)
-    )
+    updateCampaign({ status: Status.Sending })
   }
 
   const openModal = () => {

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -19,7 +19,7 @@ import {
 } from 'components/common'
 import SaveDraftModal from 'components/dashboard/create/save-draft-modal'
 import { exceedsCharacterThreshold, saveTemplate } from 'services/sms.service'
-import { SMSCampaign, SMSProgress } from 'classes'
+import { SMSProgress } from 'classes'
 
 import styles from '../Create.module.scss'
 
@@ -28,7 +28,7 @@ const SMSTemplate = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<SMSProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { setFinishLaterContent } = useContext(FinishLaterModalContext)
   const [body, setBody] = useState(replaceNewLines(campaign.body))
   const [errorMsg, setErrorMsg] = useState(null)
@@ -63,15 +63,11 @@ const SMSTemplate = ({
           body
         )
         if (updatedTemplate) {
-          setCampaign(
-            (campaign) =>
-              ({
-                ...campaign,
-                body: updatedTemplate.body,
-                params: updatedTemplate.params,
-                numRecipients,
-              } as SMSCampaign)
-          )
+          updateCampaign({
+            body: updatedTemplate.body,
+            params: updatedTemplate.params,
+            numRecipients,
+          })
           setActiveStep((s) => s + 1)
         }
       } catch (err) {
@@ -79,7 +75,7 @@ const SMSTemplate = ({
         if (propagateError) throw err
       }
     },
-    [body, campaignId, setActiveStep, setCampaign]
+    [body, campaignId, setActiveStep, updateCampaign]
   )
 
   // Set callback for finish later button

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -35,7 +35,7 @@ import TelegramCredentialsInput from './TelegramCredentialsInput'
 import TelegramValidationInput from './TelegramValidationInput'
 import styles from '../Create.module.scss'
 import { i18n } from 'locales'
-import { TelegramCampaign, TelegramProgress } from 'classes'
+import { TelegramProgress } from 'classes'
 
 const TelegramCredentials = ({
   setActiveStep,
@@ -43,7 +43,7 @@ const TelegramCredentials = ({
   setActiveStep: Dispatch<SetStateAction<TelegramProgress>>
 }) => {
   const DEMO_CREDENTIAL = 'Postman_Telegram_Demo'
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { hasCredential: initialHasCredential, demoMessageLimit } = campaign
   const isDemo = !!demoMessageLimit
 
@@ -124,9 +124,7 @@ const TelegramCredentials = ({
       setHasCredential(true)
       setShowCredentialFields(false)
       // Saves hasCredential property but do not advance to next step
-      setCampaign(
-        (campaign) => ({ ...campaign, hasCredential: true } as TelegramCampaign)
-      )
+      updateCampaign({ hasCredential: true })
     } catch (e) {
       setErrorMessage(e.message)
     }

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -27,7 +27,7 @@ import {
   StepSection,
   InfoBlock,
 } from 'components/common'
-import { TelegramCampaign, TelegramPreview, TelegramProgress } from 'classes'
+import { TelegramPreview, TelegramProgress } from 'classes'
 import { sendTiming } from 'services/ga.service'
 
 import styles from '../Create.module.scss'
@@ -37,7 +37,7 @@ const TelegramRecipients = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<TelegramProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const {
     isCsvProcessing: initialIsProcessing,
     numRecipients: initialNumRecipients,
@@ -93,16 +93,8 @@ const TelegramRecipients = ({
 
   // If campaign properties change, bubble up to root campaign object
   useEffect(() => {
-    setCampaign(
-      (campaign) =>
-        ({
-          ...campaign,
-          isCsvProcessing,
-          csvFilename,
-          numRecipients,
-        } as TelegramCampaign)
-    )
-  }, [isCsvProcessing, csvFilename, numRecipients, setCampaign])
+    updateCampaign({ isCsvProcessing, csvFilename, numRecipients })
+  }, [isCsvProcessing, csvFilename, numRecipients, updateCampaign])
 
   async function uploadFile(files: File[]) {
     setIsUploading(true)

--- a/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useParams } from 'react-router-dom'
 
 import { CampaignContext } from 'contexts/campaign.context'
-import { Status, ChannelType, SMSCampaign, TelegramProgress } from 'classes'
+import { Status, ChannelType, TelegramProgress } from 'classes'
 import { ModalContext } from 'contexts/modal.context'
 import {
   PreviewBlock,
@@ -31,7 +31,7 @@ const TelegramSend = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<TelegramProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { numRecipients } = campaign
   const modalContext = useContext(ModalContext)
   const [preview, setPreview] = useState({} as { body: string })
@@ -62,9 +62,7 @@ const TelegramSend = ({
     if (sendRate) {
       sendUserEvent(GA_USER_EVENTS.USE_SEND_RATE, ChannelType.Telegram)
     }
-    setCampaign(
-      (campaign) => ({ ...campaign, status: Status.Sending } as SMSCampaign)
-    )
+    updateCampaign({ status: Status.Sending })
   }
 
   const openModal = () => {

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -26,7 +26,7 @@ const TelegramTemplate = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<TelegramProgress>>
 }) => {
-  const { campaign, setCampaign } = useContext(CampaignContext)
+  const { campaign, updateCampaign } = useContext(CampaignContext)
   const { body: initialBody } = campaign as TelegramCampaign
   const { setFinishLaterContent } = useContext(FinishLaterModalContext)
   const [body, setBody] = useState(replaceNewLines(initialBody))
@@ -45,22 +45,18 @@ const TelegramTemplate = ({
           body
         )
         if (!updatedTemplate) return
-        setCampaign(
-          (campaign) =>
-            ({
-              ...campaign,
-              body: updatedTemplate?.body,
-              params: updatedTemplate?.params,
-              numRecipients,
-            } as TelegramCampaign)
-        )
+        updateCampaign({
+          body: updatedTemplate?.body,
+          params: updatedTemplate?.params,
+          numRecipients,
+        })
         setActiveStep((s) => s + 1)
       } catch (err) {
         setErrorMsg(err.message)
         if (propagateError) throw err
       }
     },
-    [body, campaignId, setActiveStep, setCampaign]
+    [body, campaignId, setActiveStep, updateCampaign]
   )
 
   // Set callback for finish later button

--- a/frontend/src/contexts/campaign.context.tsx
+++ b/frontend/src/contexts/campaign.context.tsx
@@ -10,7 +10,9 @@ import { SMSCampaign, EmailCampaign, TelegramCampaign, Campaign } from 'classes'
 
 interface ContextProps {
   campaign: SMSCampaign | EmailCampaign | TelegramCampaign
-  updateCampaign: any
+  updateCampaign: (
+    changes: Partial<SMSCampaign | EmailCampaign | TelegramCampaign>
+  ) => void
   setCampaign: Dispatch<
     SetStateAction<SMSCampaign | EmailCampaign | TelegramCampaign>
   >

--- a/frontend/src/contexts/campaign.context.tsx
+++ b/frontend/src/contexts/campaign.context.tsx
@@ -46,6 +46,9 @@ const CampaignContextProvider = ({
     <CampaignContext.Provider
       value={{
         campaign,
+        // updateCampaign is re-created for every re-render of CampaignContextProvider
+        // Memoise updateCampaign to prevent unnecessary renders in subscribers when
+        // defined as dependencies in useEffect
         updateCampaign: useCallback(updateCampaign, []),
         setCampaign,
       }}

--- a/frontend/src/contexts/campaign.context.tsx
+++ b/frontend/src/contexts/campaign.context.tsx
@@ -1,8 +1,16 @@
-import React, { createContext, useState, SetStateAction, Dispatch } from 'react'
+import React, {
+  createContext,
+  useState,
+  useCallback,
+  Dispatch,
+  SetStateAction,
+} from 'react'
+import { cloneDeep } from 'lodash'
 import { SMSCampaign, EmailCampaign, TelegramCampaign, Campaign } from 'classes'
 
 interface ContextProps {
   campaign: SMSCampaign | EmailCampaign | TelegramCampaign
+  updateCampaign: any
   setCampaign: Dispatch<
     SetStateAction<SMSCampaign | EmailCampaign | TelegramCampaign>
   >
@@ -19,10 +27,24 @@ const CampaignContextProvider = ({
     new Campaign({}) as SMSCampaign | EmailCampaign | TelegramCampaign
   )
 
+  function updateCampaign(
+    changes: Partial<SMSCampaign | EmailCampaign | TelegramCampaign>
+  ) {
+    setCampaign((c) => {
+      const updatedCampaign = Object.assign(cloneDeep(c), changes) as
+        | SMSCampaign
+        | EmailCampaign
+        | TelegramCampaign
+      updatedCampaign.setProgress()
+      return updatedCampaign
+    })
+  }
+
   return (
     <CampaignContext.Provider
       value={{
         campaign,
+        updateCampaign: useCallback(updateCampaign, []),
         setCampaign,
       }}
     >


### PR DESCRIPTION
## Problem

Previously completed steps in progress pane were disabled. 

Closes #838

## Solution

Campaign progress was not being updated when campaign state was updated. The progress pane steps render enabled/disabled state based on the campaign progress property.

**Bug Fixes**:

- Create a function to handle updates to the campaign state in the campaign context provider
- Call the campaign `setProgress` function to update the progress value for the campaign state
- Implement `useCallback` for `updateCampaign` function to prevent re-render due to function being re-initialised for every render (**Looking into if this is the best way to do this**)

## Tests

1. Create a new sms campaign
2. Save a template, upload a file and click next
3. Now you should be at the insert credentials step
4. Previous step 'Upload recipients' is enabled
5. Insert credentials and proceed to 'Preview and send' step, then navigate to 'Create message' step via the progress pane
6. All the previously completed steps are enabled