### PR TITLE
chore: Deprecate upload and complete endpoint

### DIFF
--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { Request, Response, Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -33,33 +33,18 @@ const storeTemplateValidator = {
 }
 
 const uploadStartValidator = {
-  v1: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-      md5: Joi.string().required(),
-    }),
-  },
+  [Segments.QUERY]: Joi.object({
+    mime_type: Joi.string().required(),
+    md5: Joi.string().required(),
+  }),
 }
 
 const uploadCompleteValidator = {
-  v1: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-      etag: Joi.string().required(),
-    }),
-  },
+  [Segments.BODY]: Joi.object({
+    transaction_id: Joi.string().required(),
+    filename: Joi.string().required(),
+    etag: Joi.string().required(),
+  }),
 }
 
 const storeCredentialsValidator = {
@@ -242,6 +227,11 @@ router.put(
  *           required: true
  *           schema:
  *             type: string
+ *         - name: md5
+ *           in: query
+ *           required: true
+ *           schema:
+ *             type: string
  *       responses:
  *         200:
  *           description: Success
@@ -265,7 +255,7 @@ router.put(
  */
 router.get(
   '/upload/start',
-  celebrate(uploadStartValidator.v1),
+  celebrate(uploadStartValidator),
   CampaignMiddleware.canEditCampaign,
   UploadMiddleware.uploadStartHandler
 )
@@ -315,11 +305,8 @@ router.get(
  *         "500":
  *           description: Internal Server Error
  */
-router.get(
-  '/upload/start-v2',
-  celebrate(uploadStartValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
+router.get('/upload/start-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/start')
 )
 
 /**
@@ -348,6 +335,8 @@ router.get(
  *                   type: string
  *                 filename:
  *                   type: string
+ *                 etag:
+ *                   type: string
  *       responses:
  *         "202" :
  *           description: Accepted. The uploaded file is being processed.
@@ -362,7 +351,7 @@ router.get(
  */
 router.post(
   '/upload/complete',
-  celebrate(uploadCompleteValidator.v1),
+  celebrate(uploadCompleteValidator),
   CampaignMiddleware.canEditCampaign,
   EmailTemplateMiddleware.uploadCompleteHandler
 )
@@ -407,11 +396,8 @@ router.post(
  *         "500":
  *           description: Internal Server Error
  */
-router.post(
-  '/upload/complete-v2',
-  celebrate(uploadCompleteValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  EmailTemplateMiddleware.uploadCompleteHandler
+router.post('/upload/complete-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/complete')
 )
 
 /**

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -213,7 +213,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/email/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Email
  *       parameters:
@@ -265,7 +265,7 @@ router.get(
  * path:
  *   /campaign/{campaignId}/email/upload/start-v2:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Email
  *       parameters:
@@ -314,7 +314,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/email/upload/complete:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - Email
  *       parameters:
@@ -361,7 +361,7 @@ router.post(
  * path:
  *   /campaign/{campaignId}/email/upload/complete-v2:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - Email
  *       parameters:
@@ -405,7 +405,7 @@ router.post('/upload/complete-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/email/upload/status:
  *     get:
- *       description: "Get csv processing status"
+ *       summary: "Get csv processing status"
  *       tags:
  *         - Email
  *       parameters:
@@ -813,7 +813,7 @@ router.get(
  * path:
  *   /campaign/{campaignId}/email/protect/upload/complete:
  *     post:
- *       description: Complete multipart upload
+ *       summary: Complete multipart upload
  *       tags:
  *         - Email
  *       parameters:

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -213,7 +213,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/email/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload"
+ *       description: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Email
  *       parameters:
@@ -314,7 +314,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/email/upload/complete:
  *     post:
- *       description: "Complete upload session"
+ *       description: "Complete upload session with ETag verification"
  *       tags:
  *         - Email
  *       parameters:

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -188,7 +188,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/sms/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - SMS
  *       parameters:
@@ -240,7 +240,7 @@ router.get(
  * path:
  *   /campaign/{campaignId}/sms/upload/start-v2:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - SMS
  *       parameters:
@@ -289,7 +289,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/sms/upload/complete:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - SMS
  *       parameters:
@@ -336,7 +336,7 @@ router.post(
  * path:
  *   /campaign/{campaignId}/sms/upload/complete-v2:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - SMS
  *       parameters:
@@ -380,7 +380,7 @@ router.post('/upload/complete-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/sms/upload/status:
  *     get:
- *       description: "Get csv processing status"
+ *       summary: "Get csv processing status"
  *       tags:
  *         - SMS
  *       parameters:

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -188,7 +188,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/sms/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload"
+ *       description: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - SMS
  *       parameters:
@@ -289,7 +289,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/sms/upload/complete:
  *     post:
- *       description: "Complete upload session"
+ *       description: "Complete upload session with ETag verification"
  *       tags:
  *         - SMS
  *       parameters:

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { Request, Response, Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -22,33 +22,18 @@ const storeTemplateValidator = {
 }
 
 const uploadStartValidator = {
-  v1: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-      md5: Joi.string().required(),
-    }),
-  },
+  [Segments.QUERY]: Joi.object({
+    mime_type: Joi.string().required(),
+    md5: Joi.string().required(),
+  }),
 }
 
 const uploadCompleteValidator = {
-  v1: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-      etag: Joi.string().required(),
-    }),
-  },
+  [Segments.BODY]: Joi.object({
+    transaction_id: Joi.string().required(),
+    filename: Joi.string().required(),
+    etag: Joi.string().required(),
+  }),
 }
 
 const storeCredentialsValidator = {
@@ -217,6 +202,11 @@ router.put(
  *           required: true
  *           schema:
  *             type: string
+ *         - name: md5
+ *           required: true
+ *           in: query
+ *           schema:
+ *             type: string
  *       responses:
  *         200:
  *           description: Success
@@ -240,7 +230,7 @@ router.put(
  */
 router.get(
   '/upload/start',
-  celebrate(uploadStartValidator.v1),
+  celebrate(uploadStartValidator),
   CampaignMiddleware.canEditCampaign,
   UploadMiddleware.uploadStartHandler
 )
@@ -290,11 +280,8 @@ router.get(
  *         "500":
  *           description: Internal Server Error
  */
-router.get(
-  '/upload/start-v2',
-  celebrate(uploadStartValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
+router.get('/upload/start-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/start')
 )
 
 /**
@@ -323,6 +310,8 @@ router.get(
  *                   type: string
  *                 filename:
  *                   type: string
+ *                 etag:
+ *                   type: string
  *       responses:
  *         "202" :
  *           description: Accepted. The uploaded file is being processed.
@@ -337,7 +326,7 @@ router.get(
  */
 router.post(
   '/upload/complete',
-  celebrate(uploadCompleteValidator.v1),
+  celebrate(uploadCompleteValidator),
   CampaignMiddleware.canEditCampaign,
   SmsTemplateMiddleware.uploadCompleteHandler
 )
@@ -382,11 +371,8 @@ router.post(
  *         "500":
  *           description: Internal Server Error
  */
-router.post(
-  '/upload/complete-v2',
-  celebrate(uploadCompleteValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  SmsTemplateMiddleware.uploadCompleteHandler
+router.post('/upload/complete-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/complete')
 )
 
 /**

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { Request, Response, Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -22,33 +22,18 @@ const storeTemplateValidator = {
 }
 
 const uploadStartValidator = {
-  v1: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.QUERY]: Joi.object({
-      mime_type: Joi.string().required(),
-      md5: Joi.string().required(),
-    }),
-  },
+  [Segments.QUERY]: Joi.object({
+    mime_type: Joi.string().required(),
+    md5: Joi.string().required(),
+  }),
 }
 
 const uploadCompleteValidator = {
-  v1: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-    }),
-  },
-  v2: {
-    [Segments.BODY]: Joi.object({
-      transaction_id: Joi.string().required(),
-      filename: Joi.string().required(),
-      etag: Joi.string().required(),
-    }),
-  },
+  [Segments.BODY]: Joi.object({
+    transaction_id: Joi.string().required(),
+    filename: Joi.string().required(),
+    etag: Joi.string().required(),
+  }),
 }
 
 const storeCredentialsValidator = {
@@ -218,6 +203,11 @@ router.put(
  *           required: true
  *           schema:
  *             type: string
+ *         - name: md5
+ *           required: true
+ *           in: query
+ *           schema:
+ *             type: string
  *       responses:
  *         200:
  *           description: Success
@@ -241,7 +231,7 @@ router.put(
  */
 router.get(
   '/upload/start',
-  celebrate(uploadStartValidator.v1),
+  celebrate(uploadStartValidator),
   CampaignMiddleware.canEditCampaign,
   UploadMiddleware.uploadStartHandler
 )
@@ -291,11 +281,8 @@ router.get(
  *         "500":
  *           description: Internal Server Error
  */
-router.get(
-  '/upload/start-v2',
-  celebrate(uploadStartValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
+router.get('/upload/start-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/start')
 )
 
 /**
@@ -324,6 +311,8 @@ router.get(
  *                   type: string
  *                 filename:
  *                   type: string
+ *                 etag:
+ *                   type: string
  *       responses:
  *         200:
  *           description: Success
@@ -350,7 +339,7 @@ router.get(
  */
 router.post(
   '/upload/complete',
-  celebrate(uploadCompleteValidator.v1),
+  celebrate(uploadCompleteValidator),
   CampaignMiddleware.canEditCampaign,
   TelegramTemplateMiddleware.uploadCompleteHandler
 )
@@ -407,11 +396,8 @@ router.post(
  *         "500":
  *           description: Internal Server Error
  */
-router.post(
-  '/upload/complete-v2',
-  celebrate(uploadCompleteValidator.v2),
-  CampaignMiddleware.canEditCampaign,
-  TelegramTemplateMiddleware.uploadCompleteHandler
+router.post('/upload/complete-v2', (_req: Request, res: Response) =>
+  res.redirect('/upload/complete')
 )
 
 /**

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -189,7 +189,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/telegram/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Telegram
  *       parameters:
@@ -241,7 +241,7 @@ router.get(
  * path:
  *   /campaign/{campaignId}/telegram/upload/start-v2:
  *     get:
- *       description: "Get a presigned URL for upload with Content-MD5 header"
+ *       summary: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Telegram
  *       parameters:
@@ -290,7 +290,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/telegram/upload/complete:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - Telegram
  *       parameters:
@@ -349,7 +349,7 @@ router.post(
  * path:
  *   /campaign/{campaignId}/telegram/upload/complete-v2:
  *     post:
- *       description: "Complete upload session with ETag verification"
+ *       summary: "Complete upload session with ETag verification"
  *       tags:
  *         - Telegram
  *       parameters:
@@ -405,7 +405,7 @@ router.post('/upload/complete-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/telegram/upload/status:
  *     get:
- *       description: "Get csv processing status"
+ *       summary: "Get csv processing status"
  *       tags:
  *         - Telegram
  *       parameters:

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -189,7 +189,7 @@ router.put(
  * path:
  *   /campaign/{campaignId}/telegram/upload/start:
  *     get:
- *       description: "Get a presigned URL for upload"
+ *       description: "Get a presigned URL for upload with Content-MD5 header"
  *       tags:
  *         - Telegram
  *       parameters:
@@ -290,7 +290,7 @@ router.get('/upload/start-v2', (_req: Request, res: Response) =>
  * path:
  *   /campaign/{campaignId}/telegram/upload/complete:
  *     post:
- *       description: "Complete upload session"
+ *       description: "Complete upload session with ETag verification"
  *       tags:
  *         - Telegram
  *       parameters:

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -37,8 +37,17 @@ curl --location --request PUT 'https://api.postman.gov.sg/v1/campaign/100/templa
 
 ### 3.1. Get a presigned url that will let you upload your file of recipients to S3
 
+You will need to include a base64 encoded MD5 checksum for the file that you are uploading when retrieving the presigned URL. This can be obtained from the command line by running the following:
+
 ```bash
-curl --location --request GET 'https://api.postman.gov.sg/v1/campaign/100/upload/start?mime_type=text/csv' \
+$ cat /Users/owner/postman-sample.csv | openssl dgst -md5 -binary | base64
+thisisanexamplemd5checksum
+```
+
+This MD5 checksum should then be included as part of parameters in the following GET request.
+
+```bash
+curl --location --request GET 'https://api.postman.gov.sg/v1/campaign/100/upload/start?mime_type=text/csv&md5=thisisanexamplemd5checksum' \
 --header 'Authorization: Bearer your_api_key'
 ```
 
@@ -47,19 +56,33 @@ curl --location --request GET 'https://api.postman.gov.sg/v1/campaign/100/upload
 ```
 {
     "presigned_url": "https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/some_other_parameters",
-    "transaction_id": some_transaction_id"
+    "transaction_id": "some_transaction_id"
 }
 ```
 
 ### 3.2. Upload the file to the presigned url that was returned in step 3.1
 
 ```bash
-curl --location --request PUT 'https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/some_other_parameters' \
+curl -i --location --request PUT 'https://s3.ap-southeast-1.amazonaws.com/file-staging.postman.gov.sg/some_other_parameters' \
 --header 'Content-Type: text/csv' \
+--header 'Content-MD5: thisisanexamplemd5checksum' \
 --data-binary '@/Users/owner/postman-sample.csv'
 ```
 
+**Sample response headers**
+
+Take note of the value of the `ETag` header in the response. You will need to use it in the next step.
+
+```
+HTTP/1.1 200 OK
+...
+ETag: "thisisanetagvalue"
+...
+```
+
 ### 3.3. After the file has been uploaded to S3, complete this process by requesting the backend to validate your file.
+
+The values for `transaction_id` and `etag` were obtained from Step 3.1 and Step 3.2 respectively.
 
 ```bash
 curl --location --request POST 'https://api.postman.gov.sg/v1/campaign/100/upload/complete' \
@@ -67,7 +90,8 @@ curl --location --request POST 'https://api.postman.gov.sg/v1/campaign/100/uploa
 --header 'Content-Type: application/json' \
 --data-raw '{
     "transaction_id": "some_transaction_id",
-    "filename": "postman-sample.csv"
+    "filename": "postman-sample.csv",
+    "etag": "thisisanetagvalue"
 }'
 ```
 
@@ -81,6 +105,9 @@ curl --location --request POST 'https://api.postman.gov.sg/v1/campaign/100/crede
 	"recipient": "youremail@gmail.com"
 }'
 ```
+
+If you are sending a SMS or Telegram campaign, you will need to provide an additional `label` parameter in the request body. This label refers
+to the label assigned to a credential when it was first added in the Settings page.
 
 ### 5. When you're ready to send the messages to everyone in the csv file you've uploaded, make a send request.
 

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -111,6 +111,7 @@ const TelegramCredentials = ({
         await validateNewCredentials({
           campaignId: +campaignId,
           ...creds,
+          ...(saveCredentialWithLabel && { label }),
         })
       } else if (!isManual && selectedCredential) {
         await validateStoredCredentials({

--- a/frontend/src/services/upload.service.ts
+++ b/frontend/src/services/upload.service.ts
@@ -88,15 +88,12 @@ export async function getPresignedUrl({
   try {
     const mimeType = await getMimeType(uploadedFile)
     const md5 = await getMd5(uploadedFile)
-    const response = await axios.get(
-      `/campaign/${campaignId}/upload/start-v2`,
-      {
-        params: {
-          mime_type: mimeType,
-          md5,
-        },
-      }
-    )
+    const response = await axios.get(`/campaign/${campaignId}/upload/start`, {
+      params: {
+        mime_type: mimeType,
+        md5,
+      },
+    })
     const {
       transaction_id: transactionId,
       presigned_url: presignedUrl,
@@ -119,7 +116,7 @@ export async function completeFileUpload({
   etag: string
 }): Promise<void> {
   try {
-    await axios.post(`/campaign/${campaignId}/upload/complete-v2`, {
+    await axios.post(`/campaign/${campaignId}/upload/complete`, {
       transaction_id: transactionId,
       filename,
       etag,


### PR DESCRIPTION
## Problem

Part 1 of #802 

## Solution
- Update `/upload` and `/complete` endpoint to enforce use of MD5 checksums and ETag
- Add redirects for `/upload-v2` and `/complete-v2`
- Update API Usage docs

## Tests

**Testing through UI** 
- Create and send campaigns for each channel type (SMS, Telegram, Email and Protected Email).
- Ensure that upload and processing of CSV does not introduce any regressions

**API testing**
- Follow the steps documented in `api-usage.md`
- Ensure that campaign can be created and sent as expected. 
