### PR TITLE
Deprecate new-credentials endpoint

### DIFF
--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { Router, Request, Response } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -38,16 +38,6 @@ const uploadCompleteValidator = {
 }
 
 const storeCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    twilio_account_sid: Joi.string().trim().required(),
-    twilio_api_secret: Joi.string().trim().required(),
-    twilio_api_key: Joi.string().trim().required(),
-    twilio_messaging_service_sid: Joi.string().trim().required(),
-    recipient: Joi.string().trim().required(),
-  }),
-}
-
-const storeCredentialsValidatorV2 = {
   [Segments.BODY]: Joi.object({
     twilio_account_sid: Joi.string().trim().required(),
     twilio_api_secret: Joi.string().trim().required(),
@@ -458,7 +448,7 @@ router.delete(
  *    post:
  *      tags:
  *        - SMS
- *      summary: Validate twilio credentials and assign to campaign
+ *      summary: Validate twilio credentials and assign to campaign, if label is provided - store credentials for user
  *      parameters:
  *        - name: campaignId
  *          in: path
@@ -476,6 +466,12 @@ router.delete(
  *                  properties:
  *                    recipient:
  *                      type: string
+ *                    label:
+ *                      type: string
+ *                      pattern: '/^[a-z0-9-]+$/'
+ *                      minLength: 1
+ *                      maxLength: 50
+ *                      description: should only consist of lowercase alphanumeric characters and dashes
  *
  *      responses:
  *        200:
@@ -500,6 +496,7 @@ router.post(
   SmsMiddleware.disabledForDemoCampaign,
   SmsMiddleware.getCredentialsFromBody,
   SmsMiddleware.validateAndStoreCredentials,
+  SettingsMiddleware.checkAndStoreLabelIfExists,
   SmsMiddleware.setCampaignCredential
 )
 
@@ -551,15 +548,8 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.post(
-  '/new-credentials/v2',
-  celebrate(storeCredentialsValidatorV2),
-  CampaignMiddleware.canEditCampaign,
-  SmsMiddleware.disabledForDemoCampaign,
-  SmsMiddleware.getCredentialsFromBody,
-  SmsMiddleware.validateAndStoreCredentials,
-  SettingsMiddleware.checkAndStoreLabelIfExists,
-  SmsMiddleware.setCampaignCredential
+router.post('/new-credentials/v2', (_req: Request, res: Response) =>
+  res.redirect('/new-credentials')
 )
 
 /**

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express'
+import { Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -548,9 +548,7 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.post('/new-credentials/v2', (_req: Request, res: Response) =>
-  res.redirect('/new-credentials')
-)
+router.post('/new-credentials/v2', redirectTo('/new-credentials'))
 
 /**
  * @swagger

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express'
+import { Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
   CampaignMiddleware,
@@ -605,9 +605,7 @@ router.post(
  *        "500":
  *           description: Internal Server Error
  */
-router.post('/new-credentials/v2', (_req: Request, res: Response) =>
-  res.redirect('/new-credentials')
-)
+router.post('/new-credentials/v2', redirectTo('/new-credentials'))
 
 /**
  * @swagger

--- a/frontend/src/services/sms.service.ts
+++ b/frontend/src/services/sms.service.ts
@@ -48,7 +48,7 @@ export async function validateNewCredentials({
   label?: string
 }): Promise<void> {
   try {
-    await axios.post(`/campaign/${campaignId}/sms/new-credentials/v2`, {
+    await axios.post(`/campaign/${campaignId}/sms/new-credentials`, {
       recipient,
       label,
       twilio_account_sid: accountSid,

--- a/frontend/src/services/telegram.service.ts
+++ b/frontend/src/services/telegram.service.ts
@@ -206,7 +206,7 @@ export async function validateNewCredentials({
   label?: string
 }): Promise<void> {
   try {
-    await axios.post(`/campaign/${campaignId}/telegram/new-credentials/v2`, {
+    await axios.post(`/campaign/${campaignId}/telegram/new-credentials`, {
       telegram_bot_token: telegramBotToken,
       label,
     })


### PR DESCRIPTION
## Problem

Part 1 of #805

## Solution

- Update `/new-credentials` endpoint to accept optional `label` body parameter
- Redirect `/new-credentials/v2` to `/new-credentials` for SMS and Telegram
- Update frontend to use the updated `/new-credentials` endpoint

## Tests

- [ ] Add new credentials with label in create campaign flow for SMS and Telegram and check that credential has been saved with corresponding label