### PR TITLE
UI fixes for demo campaign creation flow

### DIFF
--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -241,11 +241,13 @@ const Campaigns = () => {
           Create new campaign
         </PrimaryButton>
       </TitleBar>
-      <DemoBar
-        numDemosSms={numDemosSms}
-        numDemosTelegram={numDemosTelegram}
-        isDisplayed={isDemoDisplayed}
-      />
+      {campaignCount > 0 && (
+        <DemoBar
+          numDemosSms={numDemosSms}
+          numDemosTelegram={numDemosTelegram}
+          isDisplayed={isDemoDisplayed}
+        />
+      )}
       <div className={styles.content}>
         {isLoading ? (
           <i className={cx(styles.spinner, 'bx bx-loader-alt bx-spin')}></i>

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -124,18 +124,13 @@
 }
 
 .inputLabelHelpLink {
-  margin-left: 0.5rem;
-  font-weight: normal;
-  font-size: 0.75rem;
   font-style: italic;
-  color: $secondary;
-  text-decoration: underline;
   color: $primary;
-  &.botLink {
-    font-weight: bold;
-    &:active {
-      color: $red;
-    }
+  &:hover {
+    text-decoration: underline;
+  }
+  &:active {
+    color: $secondary;
   }
 }
 

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -130,8 +130,12 @@
   font-style: italic;
   color: $secondary;
   text-decoration: underline;
-  &.infoLink {
-    color: $primary;
+  color: $primary;
+  &.botLink {
+    font-weight: bold;
+    &:active {
+      color: $red;
+    }
   }
 }
 

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -189,7 +189,7 @@ const SMSCredentials = ({
                     you’d have to add your own credentials by setting up your
                     own Twilio account.{' '}
                     <OutboundLink
-                      className={cx(styles.inputLabelHelpLink, styles.infoLink)}
+                      className={styles.inputLabelHelpLink}
                       eventLabel={i18n._(LINKS.guideSmsUrl)}
                       to={i18n._(LINKS.guideSmsUrl)}
                       target="_blank"

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -265,7 +265,7 @@ const TelegramCredentials = ({
                     bot to try sending Telegram messages. In a normal campaign,
                     you’d have to set up your own Telegram bot.{' '}
                     <OutboundLink
-                      className={cx(styles.inputLabelHelpLink, styles.infoLink)}
+                      className={styles.inputLabelHelpLink}
                       eventLabel={i18n._(LINKS.guideTelegramUrl)}
                       to={i18n._(LINKS.guideTelegramUrl)}
                       target="_blank"
@@ -280,7 +280,7 @@ const TelegramCredentials = ({
                       <OutboundLink
                         className={cx(
                           styles.inputLabelHelpLink,
-                          styles.infoLink
+                          styles.botLink
                         )}
                         eventLabel={i18n._(LINKS.demoTelegramBotUrl)}
                         to={i18n._(LINKS.demoTelegramBotUrl)}

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -276,12 +276,9 @@ const TelegramCredentials = ({
                   <p>
                     Make sure that you and your recipients are{' '}
                     <b>
-                      subscribed to
+                      subscribed to{' '}
                       <OutboundLink
-                        className={cx(
-                          styles.inputLabelHelpLink,
-                          styles.botLink
-                        )}
+                        className={styles.inputLabelHelpLink}
                         eventLabel={i18n._(LINKS.demoTelegramBotUrl)}
                         to={i18n._(LINKS.demoTelegramBotUrl)}
                         target="_blank"

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -23,7 +23,7 @@
   display: flex;
   flex-direction: column;
   background-color: $backgroundColor;
-  border-left: 0.5rem solid lighten($color, 10%);
+  border-left: 0.5rem solid $color;
   margin: 2rem 0;
   color: $color;
 


### PR DESCRIPTION
## Problem

Fix a few UI issues highlighted for demo campaign creation.

Closes #821

## Solution

**Improvements**:

- Do not display demo bar in empty dashboard page
- Other minor css fixes

## Tests

- Check that demo bar is not displayed when dashboard is empty
- In Telegram demo campaign credentials screen. check that bot link is in bold and changes to red when pressed (mouse down state)