### PR TITLE
chore: Parameterised database restore script

### DIFF
--- a/serverless/verify-backup/.gitignore
+++ b/serverless/verify-backup/.gitignore
@@ -1,0 +1,4 @@
+# Generated folders for pg_dump
+*.dump
+postman*.json
+dump-version.txt

--- a/serverless/verify-backup/package-lock.json
+++ b/serverless/verify-backup/package-lock.json
@@ -1128,6 +1128,24 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -1335,6 +1353,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
@@ -1515,6 +1539,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -2133,6 +2163,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/serverless/verify-backup/package.json
+++ b/serverless/verify-backup/package.json
@@ -39,6 +39,8 @@
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
     "eslint": "^7.9.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-prettier": "^3.1.4",
     "tsc-watch": "^4.2.9",
     "typescript": "^4.0.2"
   }

--- a/serverless/verify-backup/scripts/verify-backup.sh
+++ b/serverless/verify-backup/scripts/verify-backup.sh
@@ -30,11 +30,11 @@ DUMP_VERSION=$(cat dump-version.txt)
 # Restore dump; On error, print error message and exit script
 echo 'Restoring data dump'
 RESTORE_LOG="$DUMP_VERSION Data dump restoration failed!"
-pg_restore --no-owner --dbname $PGDATABASE postman.decrypted.dump || (notify "$RESTORE_LOG" && exit 1)
+pg_restore --no-owner --dbname $PGDATABASE postman.decrypted.dump || { notify "$RESTORE_LOG" && exit 1; }
 
 echo 'Making simple query on db'
 RESTORE_LOG="$DUMP_VERSION Verification query on restored db failed!"
-psql -c 'SELECT 1+1' || (notify "$RESTORE_LOG" && exit 1)
+psql -c 'SELECT 1+1' || { notify "$RESTORE_LOG" && exit 1; }
 
 # Get key metrics from restored db and set to env var
 DUMP_USERS=$(psql -qAt -c 'select count(*) from users;')

--- a/serverless/verify-backup/scripts/verify-backup.sh
+++ b/serverless/verify-backup/scripts/verify-backup.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # Whether to send notification to Sentry
-SEND_NOTIFICATION=${SEND_NOTIFICATION:-true}
+export SEND_NOTIFICATION=${SEND_NOTIFICATION:-true}
 
 # Set Postgres environment variables to define connection parameters.
 # See https://www.postgresql.org/docs/11/libpq-envars.html
-PGHOST=${PGHOST:-localhost}
-PGPORT=${PGPORT:-5432}
-PGUSER=${PGUSER:-postgres}
-PGDATABASE=${PGDATABASE:-postmangovsg_dev}
+export PGHOST=${PGHOST:-localhost}
+export PGPORT=${PGPORT:-5432}
+export PGUSER=${PGUSER:-postgres}
+export PGDATABASE=${PGDATABASE:-postmangovsg_dev}
 
 notify() {
   echo $1

--- a/serverless/verify-backup/scripts/verify-backup.sh
+++ b/serverless/verify-backup/scripts/verify-backup.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
+# Whether to send notification to Sentry
+SEND_NOTIFICATION=${SEND_NOTIFICATION:-true}
+
+# Set Postgres environment variables to define connection parameters.
+# See https://www.postgresql.org/docs/11/libpq-envars.html
+PGHOST=${PGHOST:-localhost}
+PGPORT=${PGPORT:-5432}
+PGUSER=${PGUSER:-postgres}
+PGDATABASE=${PGDATABASE:-postmangovsg_dev}
+
+notify() {
+  echo $1
+  if [ "$SEND_NOTIFICATION" = true ]; then
+    npm run send-sentry-event -- --message "$1"
+  fi
+}
+
 # Downloads latest backup dump and decrypts it
 npm run decrypt-dump
 
 # Find for existing db; If exists, drop previously created db
 echo 'Preparing db'
-su - postgres -c "psql -lqt | cut -d \| -f 1 | grep -qw postmangovsg_dev && dropdb postmangovsg_dev"
-su - postgres -c "createdb postmangovsg_dev"
+dropdb --if-exists $PGDATABASE && createdb $PGDATABASE
 
 # Set env var with the dump version to be restored
 DUMP_VERSION=$(cat dump-version.txt)
@@ -14,28 +30,17 @@ DUMP_VERSION=$(cat dump-version.txt)
 # Restore dump; On error, print error message and exit script
 echo 'Restoring data dump'
 RESTORE_LOG="$DUMP_VERSION Data dump restoration failed!"
-pg_restore --no-owner -h localhost -p 5432 -U postgres -d postmangovsg_dev postman.decrypted.dump || \
-{ 
-  echo $RESTORE_LOG && \
-  npm run send-sentry-event -- --message "$RESTORE_LOG" && \
-  exit 1;
-}
+pg_restore --no-owner --dbname $PGDATABASE postman.decrypted.dump || (notify "$RESTORE_LOG" && exit 1)
 
 echo 'Making simple query on db'
 RESTORE_LOG="$DUMP_VERSION Verification query on restored db failed!"
-su - postgres -c "psql -d postmangovsg_dev -c 'SELECT 1+1'" || \
-{ 
-  echo $RESTORE_LOG && \
-  npm run send-sentry-event -- --message "$RESTORE_LOG" && \
-  exit 1;
-}
+psql -c 'SELECT 1+1' || (notify "$RESTORE_LOG" && exit 1)
 
 # Get key metrics from restored db and set to env var
-DUMP_USERS=$(su - postgres -c "psql -qAt -d postmangovsg_dev -c 'select count(*) from users;'")
-DUMP_CAMPAIGNS=$(su - postgres -c "psql -qAt -d postmangovsg_dev -c 'select count(*) from campaigns;'")
-DUMP_MESSAGES=$(su - postgres -c "psql -qAt -d postmangovsg_dev -c 'select sum(sent) from statistics;'")
+DUMP_USERS=$(psql -qAt -c 'select count(*) from users;')
+DUMP_CAMPAIGNS=$(psql -qAt -c 'select count(*) from campaigns;')
+DUMP_MESSAGES=$(psql -qAt -c 'select sum(sent) from statistics;')
 RESTORE_LOG="Successfully restored $DUMP_VERSION db dump! \
-The restored db has $DUMP_USERS users, $DUMP_CAMPAIGNS campaigns and $DUMP_MESSAGES sent messages."
+  The restored db has $DUMP_USERS users, $DUMP_CAMPAIGNS campaigns and $DUMP_MESSAGES sent messages."
 
-echo $RESTORE_LOG && \
-npm run send-sentry-event -- --message "$RESTORE_LOG"
+notify "$RESTORE_LOG"

--- a/serverless/verify-backup/src/config.ts
+++ b/serverless/verify-backup/src/config.ts
@@ -48,26 +48,28 @@ const config = convict({
     doc: 'Project id of the current Google Cloud Project',
     default: '',
     env: 'GCLOUD_PROJECT_ID',
-    format: 'required-string'
+    format: 'required-string',
   },
   gcloudLocationId: {
     doc: 'Location id of where the Google Cloud Bucket is hosted',
     default: '',
     env: 'GCLOUD_LOCATION_ID',
-    format: 'required-string'
+    format: 'required-string',
   },
   gcloudPrivateKeyResourceId: {
-    doc: 'Resource id of the private key from Google Cloud KMS used to decrypt db dumps',
+    doc:
+      'Resource id of the private key from Google Cloud KMS used to decrypt db dumps',
     default: '',
     env: 'GCLOUD_PRIVATE_KEY_RESOURCE_ID',
-    format: 'required-string'
+    format: 'required-string',
   },
   gcloudBackupKeyResourceId: {
-    doc: 'Resource id of the backup service account key in Google Cloud Secrets Manager',
+    doc:
+      'Resource id of the backup service account key in Google Cloud Secrets Manager',
     default: '',
     env: 'GCLOUD_BACKUP_KEY_RESOURCE_ID',
-    format: 'required-string'
-  }
+    format: 'required-string',
+  },
 })
 
 config.validate({ allowed: 'strict' })

--- a/serverless/verify-backup/src/decrypt-dump.ts
+++ b/serverless/verify-backup/src/decrypt-dump.ts
@@ -82,7 +82,6 @@ export async function decrypt() {
   )
   decipher.setAuthTag(Buffer.from(dumpParams.authTag, 'base64'))
 
-
   await pipeline(inputFileStream, decipher, outputFileStream)
   console.log(`Success: ${encryptedDumpFile} decrypted to ${decryptedDumpFile}`)
 }

--- a/serverless/verify-backup/src/index.ts
+++ b/serverless/verify-backup/src/index.ts
@@ -10,27 +10,31 @@ let storage: Storage
 async function listFiles(): Promise<Array<File>> {
   console.log('Listing files...')
   // Lists files in the bucket
-  const [files] = await storage.bucket(bucket).getFiles();
+  const [files] = await storage.bucket(bucket).getFiles()
 
-  console.log('Files:');
+  console.log('Files:')
   files.forEach((file: File) => {
-    console.log(file.name);
-  });
+    console.log(file.name)
+  })
   return files
 }
 async function init() {
   // Creates a client
   const secretClient = new SecretManagerServiceClient()
   const secretResourceId = config.get('gcloudBackupKeyResourceId')
-  const [secret] = await secretClient.accessSecretVersion({ name: secretResourceId })
-  if(!secret.payload?.data) {
+  const [secret] = await secretClient.accessSecretVersion({
+    name: secretResourceId,
+  })
+  if (!secret.payload?.data) {
     throw new Error('Postman backup service account key secret not found!')
   }
   const serviceAccountKey = JSON.parse(secret.payload?.data?.toString())
-  storage = new Storage({credentials: {
-    client_email:serviceAccountKey.client_email,
-    private_key: serviceAccountKey.private_key
-  }});
+  storage = new Storage({
+    credentials: {
+      client_email: serviceAccountKey.client_email,
+      private_key: serviceAccountKey.private_key,
+    },
+  })
 }
 
 async function downloadFile(srcFilename: string): Promise<void> {
@@ -41,15 +45,13 @@ async function downloadFile(srcFilename: string): Promise<void> {
     // The path to which the file should be downloaded
     // remove date prefix
     destination: dumpFilename,
-  };
+  }
 
   console.log('Downloading file', srcFilename)
   // Downloads the file
-  await storage.bucket(bucket).file(srcFilename).download(options);
+  await storage.bucket(bucket).file(srcFilename).download(options)
 
-  console.log(
-    `gs://${bucket}/${srcFilename} downloaded.`
-  );
+  console.log(`gs://${bucket}/${srcFilename} downloaded.`)
 }
 
 async function getLatestBackup(files: Array<File>) {

--- a/serverless/verify-backup/src/server.ts
+++ b/serverless/verify-backup/src/server.ts
@@ -1,16 +1,16 @@
-import express, {Request, Response} from 'express'
+import express, { Request, Response } from 'express'
 import bodyParser from 'body-parser'
 
-const app = express();
-const PORT = process.env.PORT || 8080;
+const app = express()
+const PORT = process.env.PORT || 8080
 
-app.use(bodyParser.json());
+app.use(bodyParser.json())
 
-app.post('/', (req: Request, res:Response) => {
+app.post('/', (req: Request, res: Response) => {
   console.log('Incoming pubsub message', JSON.stringify(req.body))
   res.sendStatus(200)
 })
 
 app.listen(PORT, () =>
   console.log(`PubSub server is listening on port ${PORT}`)
-);
+)


### PR DESCRIPTION
## Problem

`verify-backup.sh` had hardcoded values for restore database name and database user. This made it hard to use this as a generic backup restore script without having to modify the script. 

## Solution

**Improvements**:
- Use [PostgreSQL environment variables](https://www.postgresql.org/docs/11/libpq-envars.html) instead of `su - postgres` to assume user to run commands.
- Made `verify-backup.sh` executable
- Add flag to toggle Sentry notification
- Prettier source files (eslint prettier were missing previously)

## Test
- Run `verify-backup.sh` script locally and specify values for `PGUSER` and `PGDATABASE`. Detailed instructions in `README.md`.
- Deploy to staging and check in logs that verification is working as expected. Use `deploy.sh` and credentials in 1Password.

## Deploy Notes

New scripts:
- Following the instructions in `README.md` and deploy to production

## TODOs
- [x] Update docs on how to run outside of GCP
- [x] Deploy and test script on staging