### PR TITLE
feat: Verify SES notification settings

### DIFF
--- a/backend/.env-example
+++ b/backend/.env-example
@@ -28,6 +28,7 @@ TELEGRAM_BOT_GUIDE_URL="https://go.gov.sg/postman-recipient-guide"
 # SES_PASS=""
 # SES_USER=""
 # SES_PORT=""
+# SES_NOTIFICATION_TOPIC="arn:aws:sns:..."
 
 # Use either AWS credentials or localstack endpoint
 # AWS_ACCESS_KEY_ID="YOURAWSACCESSKEYID"

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -292,6 +292,12 @@ const config = convict({
     env: 'EMAIL_DEFAULT_RATE',
     format: 'int',
   },
+  sesNotificationTopic: {
+    doc: 'The SNS topic to send SES notifications to',
+    default: '',
+    env: 'SES_NOTIFICATION_TOPIC',
+    format: 'required-string',
+  },
   defaultCountry: {
     doc: 'Two-letter ISO country code to use in libphonenumber-js',
     default: 'SG',

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -161,8 +161,10 @@ const existsFromAddress = async (
 ): Promise<Response | void> => {
   const { from } = req.body
   const defaultEmail = config.get('mailFrom')
-  if (from === defaultEmail) return next()
-  const { fromName, from: fromAddress } = res.locals
+  const { fromName, from: fromAddress, templateFrom } = res.locals
+  // Skip check if either the provided from address or the template's from address is the same
+  // as the configured default mail from.
+  if (from === defaultEmail || templateFrom === defaultEmail) return next()
 
   try {
     const exists = await CustomDomainService.existsFromAddress(
@@ -195,8 +197,10 @@ const verifyFromAddress = async (
 ): Promise<Response | void> => {
   const { from } = req.body
   const defaultEmail = config.get('mailFrom')
-  if (from === defaultEmail) return next()
-  const { from: fromAddress } = res.locals
+  const { from: fromAddress, templateFrom } = res.locals
+  // Skip check if either the provided from address or the template's from address is the same
+  // as the configured default mail from.
+  if (from === defaultEmail || templateFrom === defaultEmail) return next()
 
   try {
     await CustomDomainService.verifyFromAddress(fromAddress)
@@ -287,6 +291,7 @@ const getCampaignFromAddress = async (
 
     /* eslint-disable @typescript-eslint/no-non-null-assertion*/
     const { name, fromAddress } = parseFromAddress(template?.from!)
+    res.locals.templateFrom = template?.from
     res.locals.fromName = name
     res.locals.from = fromAddress
 

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -521,6 +521,9 @@ router.post(
   '/credentials',
   celebrate(storeCredentialsValidator),
   CampaignMiddleware.canEditCampaign,
+  EmailMiddleware.getCampaignFromAddress,
+  EmailMiddleware.existsFromAddress,
+  EmailMiddleware.verifyFromAddress,
   EmailMiddleware.validateAndStoreCredentials
 )
 
@@ -608,6 +611,9 @@ router.post(
   '/send',
   celebrate(sendCampaignValidator),
   CampaignMiddleware.canEditCampaign,
+  EmailMiddleware.getCampaignFromAddress,
+  EmailMiddleware.existsFromAddress,
+  EmailMiddleware.verifyFromAddress,
   JobMiddleware.sendCampaign
 )
 

--- a/backend/src/email/services/custom-domain.service.ts
+++ b/backend/src/email/services/custom-domain.service.ts
@@ -135,7 +135,7 @@ const verifyNotificationSettings = async (email: string): Promise<void> => {
     logger.error({
       message: 'Invalid SES notification settings',
       email,
-      error: err,
+      error: err.message,
       action: 'verifyNotificationSettings',
     })
     throw new Error(

--- a/backend/src/email/services/custom-domain.service.ts
+++ b/backend/src/email/services/custom-domain.service.ts
@@ -111,17 +111,6 @@ const verifyNotificationSettings = async (email: string): Promise<void> => {
       )
     }
 
-    if (
-      !HeadersInBounceNotificationsEnabled ||
-      !HeadersInComplaintNotificationsEnabled ||
-      !HeadersInDeliveryNotificationsEnabled
-    ) {
-      throw new Error(
-        'Original email headers are not included in notifications. Please include them by ' +
-          'enabling it in SES.'
-      )
-    }
-
     const sesNotificationTopic = config.get('sesNotificationTopic')
     const allTopicsValid = [BounceTopic, ComplaintTopic, DeliveryTopic].every(
       (topic) => topic === sesNotificationTopic
@@ -132,6 +121,16 @@ const verifyNotificationSettings = async (email: string): Promise<void> => {
           'bounce, complaint and delivery notifications'
       )
     }
+    if (
+      !HeadersInBounceNotificationsEnabled ||
+      !HeadersInComplaintNotificationsEnabled ||
+      !HeadersInDeliveryNotificationsEnabled
+    ) {
+      throw new Error(
+        'Original email headers are not included in notifications. Please include them by ' +
+          'enabling it in SES.'
+      )
+    }
   } catch (err) {
     logger.error({
       message: 'Invalid SES notification settings',
@@ -139,7 +138,9 @@ const verifyNotificationSettings = async (email: string): Promise<void> => {
       error: err,
       action: 'verifyNotificationSettings',
     })
-    throw err
+    throw new Error(
+      `This From Address cannot be used to send emails. Select another email address to send from, or contact us to investigate.`
+    )
   }
 }
 

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -164,7 +164,7 @@ export async function sendCampaign(
   } catch (err) {
     errorHandler(
       err,
-      'An error occured while sending the campaign. Please try again.'
+      'An error occurred while sending the campaign. Please try again.'
     )
   }
 }

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import {
   Campaign,
   CampaignStats,
@@ -158,8 +158,15 @@ export async function sendCampaign(
   campaignId: number,
   sendRate: number
 ): Promise<void> {
-  const body = sendRate ? { rate: sendRate } : null
-  await axios.post(`/campaign/${campaignId}/send`, body)
+  try {
+    const body = sendRate ? { rate: sendRate } : null
+    await axios.post(`/campaign/${campaignId}/send`, body)
+  } catch (err) {
+    errorHandler(
+      err,
+      'An error occured while sending the campaign. Please try again.'
+    )
+  }
 }
 
 export async function stopCampaign(campaignId: number): Promise<void> {
@@ -190,4 +197,12 @@ export async function exportCampaignStats(
 
     return campaignRecipients
   })
+}
+
+function errorHandler(e: AxiosError, defaultMsg: string): never {
+  console.error(e)
+  if (e.response && e.response.data && e.response.data.message) {
+    throw new Error(e.response.data.message)
+  }
+  throw new Error(defaultMsg)
 }


### PR DESCRIPTION
## Problem

Closes #777 

## Solution

**Features**:

- Retrieve and verify that the notification settings are configured correctly:
   - All notifications should be directed to configured SNS topic
   - Inclusion of original headers should be enabled for all notification types
   - Disable forwarding of notification to email

## Tests
_I've setup Jean's domain for test in eu-central-1_

**Verify custom domain**
- Given the following: 
   - Email is verified
   - DKIM records are set
   - Notification settings are wrong
- Custom domain verification should fail

**Previously valid settings**
- If previously valid settings are now invalid, the following scenarios should result in an error:
   - Template cannot not be saved
   - If template is saved, send test email should raise an error
   - If template is saved and test email was already sent, triggering campaign send should raise an error

**Send with default mail from**
- Create campaign with default mail from instead of custom mail from
- Verify that campaign can still be sent out

## Deploy Notes

**New environment variables**:

- `SES_NOTIFICATION_TOPIC` : SNS topic to direct all notifications to

**IAM Permissions**
- Ensure that `getIdentityNotificationAttributes` is granted for beanstalk instance role

## TODOs
- [x] Test with a custom domain