### PR TITLE
Prevent setting state after component is dismounted

### DIFF
--- a/frontend/src/components/common/primary-button/PrimaryButton.tsx
+++ b/frontend/src/components/common/primary-button/PrimaryButton.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import cx from 'classnames'
 
+import useIsMounted from 'components/custom-hooks/use-is-mounted'
 import styles from './PrimaryButton.module.scss'
 
 interface PrimaryButtonProps
@@ -20,13 +21,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
   ...otherProps
 }) => {
   const [asyncLoading, setAsyncLoading] = useState(false)
-  const isMounted = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
+  const isMounted = useIsMounted()
 
   const asyncOnClick = useMemo(
     () =>
@@ -43,7 +38,7 @@ const PrimaryButton: React.FunctionComponent<PrimaryButtonProps> = ({
             }
           }
         : undefined,
-    [onClick]
+    [isMounted, onClick]
   )
 
   return (

--- a/frontend/src/components/common/text-button/TextButton.module.scss
+++ b/frontend/src/components/common/text-button/TextButton.module.scss
@@ -22,4 +22,14 @@
       text-decoration: underline;
     }
   }
+
+  &:disabled {
+    background-color: unset;
+    color: $grey;
+    cursor: not-allowed;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }

--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useRef, useEffect, MutableRefObject } from 'react'
+import React, { useState, MutableRefObject } from 'react'
 import cx from 'classnames'
+
+import useIsMounted from 'components/custom-hooks/use-is-mounted'
+import { PrimaryButton, TextInput } from 'components/common'
 import styles from './TextInputWithButton.module.scss'
-import { PrimaryButton, TextInput } from '../'
 
 interface TextInputWithButtonProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
@@ -30,13 +32,7 @@ const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = (
   errorMessage,
 }) => {
   const [asyncLoading, setAsyncLoading] = useState(false)
-  const isMounted = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
+  const isMounted = useIsMounted()
 
   const asyncSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/frontend/src/components/custom-hooks/use-is-mounted.tsx
+++ b/frontend/src/components/custom-hooks/use-is-mounted.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react'
+
+const useIsMounted = () => {
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+  return isMounted
+}
+
+export default useIsMounted

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -1,7 +1,6 @@
 import React, {
   useState,
   useEffect,
-  useRef,
   useContext,
   Dispatch,
   SetStateAction,
@@ -29,6 +28,7 @@ import {
 } from 'components/common'
 import { EmailPreview, EmailProgress } from 'classes'
 import { sendTiming } from 'services/ga.service'
+import useIsMounted from 'components/custom-hooks/use-is-mounted'
 
 import styles from '../Create.module.scss'
 
@@ -63,13 +63,7 @@ const EmailRecipients = ({
   const [preview, setPreview] = useState({} as EmailPreview)
   const { id: campaignId } = useParams()
   const { csvFilename, numRecipients = 0 } = csvInfo
-  const isMounted = useRef(true)
-
-  useEffect(() => {
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
+  const isMounted = useIsMounted()
 
   // Poll csv status
   useEffect(() => {
@@ -93,6 +87,7 @@ const EmailRecipients = ({
         if (preview) {
           setPreview(preview as EmailPreview)
         }
+
         if (isCsvProcessing) {
           timeoutId = setTimeout(pollStatus, 2000)
         }
@@ -106,7 +101,7 @@ const EmailRecipients = ({
     pollStatus()
 
     return () => clearTimeout(timeoutId)
-  }, [campaignId, csvFilename, forceReset, isCsvProcessing])
+  }, [campaignId, csvFilename, forceReset, isCsvProcessing, isMounted])
 
   // If campaign properties change, bubble up to root campaign object
   useEffect(() => {
@@ -225,7 +220,10 @@ const EmailRecipients = ({
             disabled={!numRecipients || isCsvProcessing}
             onClick={() => setActiveStep((s) => s + 1)}
           />
-          <TextButton onClick={() => setActiveStep((s) => s - 1)}>
+          <TextButton
+            disabled={isCsvProcessing}
+            onClick={() => setActiveStep((s) => s - 1)}
+          >
             Previous
           </TextButton>
         </ButtonGroup>

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -105,7 +105,7 @@ const EmailTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (subject && body && from) {
+          if (campaignId && subject && body && from) {
             await saveTemplate(+campaignId, subject, body, replyTo, from)
           }
         }}

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -55,38 +55,34 @@ const EmailTemplate = ({
   const bodyPlaceholder =
     'Dear {{ name }}, your next appointment at {{ clinic }} is on {{ date }} at {{ time }}'
 
-  const handleSaveTemplate = useCallback(
-    async (propagateError = false): Promise<void> => {
-      setErrorMsg(null)
-      try {
-        if (!campaignId) {
-          throw new Error('Invalid campaign id')
-        }
-        const { updatedTemplate, numRecipients } = await saveTemplate(
-          +campaignId,
-          subject,
-          body,
-          replyTo,
-          from
-        )
-        if (updatedTemplate) {
-          updateCampaign({
-            from: updatedTemplate.from,
-            subject: updatedTemplate.subject,
-            body: updatedTemplate.body,
-            replyTo: updatedTemplate.reply_to,
-            params: updatedTemplate.params,
-            numRecipients,
-          })
-          setActiveStep((s) => s + 1)
-        }
-      } catch (err) {
-        setErrorMsg(err.message)
-        if (propagateError) throw err
+  const handleSaveTemplate = useCallback(async (): Promise<void> => {
+    setErrorMsg(null)
+    try {
+      if (!campaignId) {
+        throw new Error('Invalid campaign id')
       }
-    },
-    [body, campaignId, from, replyTo, setActiveStep, subject, updateCampaign]
-  )
+      const { updatedTemplate, numRecipients } = await saveTemplate(
+        +campaignId,
+        subject,
+        body,
+        replyTo,
+        from
+      )
+      if (updatedTemplate) {
+        updateCampaign({
+          from: updatedTemplate.from,
+          subject: updatedTemplate.subject,
+          body: updatedTemplate.body,
+          replyTo: updatedTemplate.reply_to,
+          params: updatedTemplate.params,
+          numRecipients,
+        })
+        setActiveStep((s) => s + 1)
+      }
+    } catch (err) {
+      setErrorMsg(err.message)
+    }
+  }, [body, campaignId, from, replyTo, setActiveStep, subject, updateCampaign])
 
   async function populateFromAddresses() {
     const fromAddresses = await getCustomFromAddresses()
@@ -106,7 +102,12 @@ const EmailTemplate = ({
         saveable
         onSave={async () => {
           if (campaignId && subject && body && from) {
-            await saveTemplate(+campaignId, subject, body, replyTo, from)
+            try {
+              await saveTemplate(+campaignId, subject, body, replyTo, from)
+            } catch (err) {
+              setErrorMsg(err.message)
+              throw err
+            }
           }
         }}
       />
@@ -114,15 +115,7 @@ const EmailTemplate = ({
     return () => {
       setFinishLaterContent(null)
     }
-  }, [
-    body,
-    subject,
-    from,
-    handleSaveTemplate,
-    setFinishLaterContent,
-    campaignId,
-    replyTo,
-  ])
+  }, [body, subject, from, setFinishLaterContent, campaignId, replyTo])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n') || ''

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -106,7 +106,7 @@ const EmailTemplate = ({
         saveable
         onSave={async () => {
           if (subject && body && from) {
-            await handleSaveTemplate(true)
+            await saveTemplate(+campaignId, subject, body, replyTo, from)
           }
         }}
       />
@@ -114,7 +114,15 @@ const EmailTemplate = ({
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, subject, from, handleSaveTemplate, setFinishLaterContent])
+  }, [
+    body,
+    subject,
+    from,
+    handleSaveTemplate,
+    setFinishLaterContent,
+    campaignId,
+    replyTo,
+  ])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n') || ''

--- a/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
@@ -15,8 +15,8 @@ const EmailValidationInput = ({
   }
 
   async function onClickHandler() {
-    await onClick(recipient)
     setRecipient('')
+    await onClick(recipient)
   }
 
   return (

--- a/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
@@ -15,7 +15,6 @@ const EmailValidationInput = ({
   }
 
   async function onClickHandler() {
-    setRecipient('')
     await onClick(recipient)
   }
 

--- a/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCreate.tsx
@@ -24,10 +24,6 @@ const CreateSMS = () => {
   const { progress, isCsvProcessing, status } = campaign as SMSCampaign
   const [activeStep, setActiveStep] = useState(progress)
 
-  useEffect(() => {
-    setActiveStep(progress)
-  }, [progress])
-
   // If isCsvProcessing, user can only access UploadRecipients tab
   useEffect(() => {
     if (isCsvProcessing) {

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -29,6 +29,7 @@ import {
 import { SMSCampaign, SMSPreview, SMSProgress } from 'classes'
 import { sendTiming } from 'services/ga.service'
 import { CampaignContext } from 'contexts/campaign.context'
+import useIsMounted from 'components/custom-hooks/use-is-mounted'
 
 import styles from '../Create.module.scss'
 
@@ -60,6 +61,7 @@ const SMSRecipients = ({
   const { id: campaignId } = useParams()
 
   const { csvFilename, numRecipients = 0 } = csvInfo
+  const isMounted = useIsMounted()
 
   // Poll csv status
   useEffect(() => {
@@ -71,6 +73,9 @@ const SMSRecipients = ({
         const { isCsvProcessing, preview, ...newCsvInfo } = await getCsvStatus(
           +campaignId
         )
+        // Prevent setting state if unmounted
+        if (!isMounted.current) return
+
         setIsCsvProcessing(isCsvProcessing)
         setCsvInfo(newCsvInfo)
         if (preview) {
@@ -89,7 +94,7 @@ const SMSRecipients = ({
     pollStatus()
 
     return () => clearTimeout(timeoutId)
-  }, [campaignId, isCsvProcessing])
+  }, [campaignId, isCsvProcessing, isMounted])
 
   // If campaign properties change, bubble up to root campaign object
   useEffect(() => {
@@ -112,6 +117,11 @@ const SMSRecipients = ({
 
       const uploadTimeEnd = performance.now()
       sendTiming('Contacts file', 'upload', uploadTimeEnd - uploadTimeStart)
+
+      // Prevent setting state if unmounted
+      if (!isMounted.current) {
+        return
+      }
 
       setIsCsvProcessing(true)
       setCsvInfo((info) => ({ ...info, tempCsvFilename }))

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -184,7 +184,7 @@ const SMSRecipients = ({
           onClick={() => setActiveStep((s) => s + 1)}
         />
         <TextButton
-          disabled={!csvFilename}
+          disabled={isCsvProcessing}
           onClick={() => setActiveStep((s) => s - 1)}
         >
           Previous

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -183,7 +183,10 @@ const SMSRecipients = ({
           disabled={!numRecipients || !csvFilename}
           onClick={() => setActiveStep((s) => s + 1)}
         />
-        <TextButton onClick={() => setActiveStep((s) => s - 1)}>
+        <TextButton
+          disabled={!csvFilename}
+          onClick={() => setActiveStep((s) => s - 1)}
+        >
           Previous
         </TextButton>
       </ButtonGroup>

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -84,7 +84,7 @@ const SMSTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (body) await saveTemplate(+campaignId, body)
+          if (campaignId && body) await saveTemplate(+campaignId, body)
         }}
       />
     )

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -84,14 +84,14 @@ const SMSTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (body) await handleSaveTemplate(true)
+          if (body && campaignId) await saveTemplate(+campaignId, body)
         }}
       />
     )
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, handleSaveTemplate, setFinishLaterContent])
+  }, [body, campaignId, handleSaveTemplate, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n')

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -51,32 +51,28 @@ const SMSTemplate = ({
     }
   }, [body])
 
-  const handleSaveTemplate = useCallback(
-    async (propagateError = false): Promise<void> => {
-      setErrorMsg(null)
-      try {
-        if (!campaignId) {
-          throw new Error('Invalid campaign id')
-        }
-        const { updatedTemplate, numRecipients } = await saveTemplate(
-          +campaignId,
-          body
-        )
-        if (updatedTemplate) {
-          updateCampaign({
-            body: updatedTemplate.body,
-            params: updatedTemplate.params,
-            numRecipients,
-          })
-          setActiveStep((s) => s + 1)
-        }
-      } catch (err) {
-        setErrorMsg(err.message)
-        if (propagateError) throw err
+  const handleSaveTemplate = useCallback(async (): Promise<void> => {
+    setErrorMsg(null)
+    try {
+      if (!campaignId) {
+        throw new Error('Invalid campaign id')
       }
-    },
-    [body, campaignId, setActiveStep, updateCampaign]
-  )
+      const { updatedTemplate, numRecipients } = await saveTemplate(
+        +campaignId,
+        body
+      )
+      if (updatedTemplate) {
+        updateCampaign({
+          body: updatedTemplate.body,
+          params: updatedTemplate.params,
+          numRecipients,
+        })
+        setActiveStep((s) => s + 1)
+      }
+    } catch (err) {
+      setErrorMsg(err.message)
+    }
+  }, [body, campaignId, setActiveStep, updateCampaign])
 
   // Set callback for finish later button
   useEffect(() => {
@@ -84,14 +80,21 @@ const SMSTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (campaignId && body) await saveTemplate(+campaignId, body)
+          if (campaignId && body) {
+            try {
+              await saveTemplate(+campaignId, body)
+            } catch (err) {
+              setErrorMsg(err.message)
+              throw err
+            }
+          }
         }}
       />
     )
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, campaignId, handleSaveTemplate, setFinishLaterContent])
+  }, [body, campaignId, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n')

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -84,7 +84,7 @@ const SMSTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (body && campaignId) await saveTemplate(+campaignId, body)
+          if (body) await saveTemplate(+campaignId, body)
         }}
       />
     )

--- a/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
@@ -16,8 +16,8 @@ const SMSValidationInput = ({
   }
 
   async function onClickHandler() {
-    await onClick(recipient)
     setRecipient('')
+    await onClick(recipient)
   }
 
   return (

--- a/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
@@ -16,7 +16,6 @@ const SMSValidationInput = ({
   }
 
   async function onClickHandler() {
-    setRecipient('')
     await onClick(recipient)
   }
 

--- a/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 
 import { TextInputWithButton } from 'components/common'
 
-const EmailValidationInput = ({
+const SMSValidationInput = ({
   onClick,
   buttonDisabled,
 }: {
@@ -39,4 +39,4 @@ const EmailValidationInput = ({
   )
 }
 
-export default EmailValidationInput
+export default SMSValidationInput

--- a/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
@@ -59,6 +59,7 @@ const CreateTelegram = () => {
             activeStep={activeStep}
             setActiveStep={setActiveStep}
             progress={progress}
+            disabled={isCsvProcessing}
           />
           <div className={styles.stepContainer}>{renderStep()}</div>
         </>

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -184,10 +184,13 @@ const TelegramRecipients = ({
 
       <ButtonGroup>
         <NextButton
-          disabled={!numRecipients || !csvFilename}
+          disabled={!numRecipients || !isCsvProcessing}
           onClick={() => setActiveStep((s) => s + 1)}
         />
-        <TextButton onClick={() => setActiveStep((s) => s - 1)}>
+        <TextButton
+          disabled={isCsvProcessing}
+          onClick={() => setActiveStep((s) => s - 1)}
+        >
           Previous
         </TextButton>
       </ButtonGroup>

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -65,14 +65,14 @@ const TelegramTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (body) await handleSaveTemplate(true)
+          if (body) await saveTemplate(+campaignId, body)
         }}
       />
     )
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, handleSaveTemplate, setFinishLaterContent])
+  }, [body, campaignId, handleSaveTemplate, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n')

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -65,7 +65,7 @@ const TelegramTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (body) await saveTemplate(+campaignId, body)
+          if (campaignId && body) await saveTemplate(+campaignId, body)
         }}
       />
     )

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -33,31 +33,27 @@ const TelegramTemplate = ({
   const [errorMsg, setErrorMsg] = useState(null)
   const { id: campaignId } = useParams()
 
-  const handleSaveTemplate = useCallback(
-    async (propagateError = false): Promise<void> => {
-      setErrorMsg(null)
-      try {
-        if (!campaignId) {
-          throw new Error('Invalid campaign id')
-        }
-        const { updatedTemplate, numRecipients } = await saveTemplate(
-          +campaignId,
-          body
-        )
-        if (!updatedTemplate) return
-        updateCampaign({
-          body: updatedTemplate?.body,
-          params: updatedTemplate?.params,
-          numRecipients,
-        })
-        setActiveStep((s) => s + 1)
-      } catch (err) {
-        setErrorMsg(err.message)
-        if (propagateError) throw err
+  const handleSaveTemplate = useCallback(async (): Promise<void> => {
+    setErrorMsg(null)
+    try {
+      if (!campaignId) {
+        throw new Error('Invalid campaign id')
       }
-    },
-    [body, campaignId, setActiveStep, updateCampaign]
-  )
+      const { updatedTemplate, numRecipients } = await saveTemplate(
+        +campaignId,
+        body
+      )
+      if (!updatedTemplate) return
+      updateCampaign({
+        body: updatedTemplate?.body,
+        params: updatedTemplate?.params,
+        numRecipients,
+      })
+      setActiveStep((s) => s + 1)
+    } catch (err) {
+      setErrorMsg(err.message)
+    }
+  }, [body, campaignId, setActiveStep, updateCampaign])
 
   // Set callback for finish later button
   useEffect(() => {
@@ -65,14 +61,21 @@ const TelegramTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (campaignId && body) await saveTemplate(+campaignId, body)
+          if (campaignId && body) {
+            try {
+              await saveTemplate(+campaignId, body)
+            } catch (err) {
+              setErrorMsg(err.message)
+              throw err
+            }
+          }
         }}
       />
     )
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, campaignId, handleSaveTemplate, setFinishLaterContent])
+  }, [body, campaignId, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n')

--- a/frontend/src/components/dashboard/create/telegram/TelegramValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramValidationInput.tsx
@@ -17,7 +17,6 @@ const TelegramValidationInput = ({
 
   async function onClickHandler() {
     await onClick(recipient)
-    setRecipient('')
   }
 
   return (

--- a/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
+++ b/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
@@ -46,12 +46,14 @@ const ApiKey: React.FunctionComponent<ApiKeyProps> = ({
   useEffect(() => {
     if (apiKeyState !== ApiKeyState.COPIED) return
 
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       setApiKeyState(ApiKeyState.COPY)
 
       if (!apiKeyRef.current) return
       apiKeyRef.current.blur()
     }, RESET_COPY_TIMEOUT)
+
+    return () => clearTimeout(timeoutId)
   }, [apiKeyState])
 
   async function onButtonClick() {

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -35,11 +35,12 @@ import { i18n } from 'locales'
 const isIE11 = !!window.MSInputMethodContext && !!(document as any).documentMode
 
 const Landing = () => {
-  const authContext = useContext(AuthContext)
+  const { isAuthenticated } = useContext(AuthContext)
   const [sentMessages, setSentMessages] = useState('0')
   const history = useHistory()
 
   useEffect(() => {
+    if (isAuthenticated) return
     async function getSentMessages() {
       const stats = await getLandingStats()
       if (stats) {
@@ -47,9 +48,9 @@ const Landing = () => {
       }
     }
     getSentMessages()
-  }, [])
+  }, [isAuthenticated])
 
-  if (authContext.isAuthenticated) {
+  if (isAuthenticated) {
     return <Redirect to="/campaigns"></Redirect>
   }
 

--- a/frontend/src/components/login/login-input/LoginInput.tsx
+++ b/frontend/src/components/login/login-input/LoginInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import cx from 'classnames'
 import { noop } from 'lodash'
 import { TextInputWithButton, TextButton } from 'components/common'
@@ -33,6 +33,11 @@ const Login = () => {
   const [errorMsg, setErrorMsg] = useState(null)
   const [canResend, setCanResend] = useState(false)
   const [isResending, setIsResending] = useState(false)
+  let timeoutId: NodeJS.Timeout
+
+  useEffect(() => {
+    return () => timeoutId && clearTimeout(timeoutId)
+  })
 
   async function sendOtp() {
     resetButton()
@@ -40,7 +45,7 @@ const Login = () => {
       await getOtpWithEmail(email)
       setOtpSent(true)
       // Show resend button after wait time
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         setCanResend(true)
       }, RESEND_WAIT_TIME)
     } catch (err) {


### PR DESCRIPTION
## Problem

**Prevent setting state after component is dismounted**
There are many instances where `useEffect` sets components state after running asynchronous queries. When the component is dismounted before these execute finish, they result in react trying to update the state of an unmounted component. This throws a warning that this may indicate a potential memory leak in the app.

Closes #846 
Closes #858 

## Solution

Ran through different user flows to check for warnings, let me know if there are some which have not been addressed!

**Bug Fixes**:

- When handling finish later - save draft callbacks, remove use of `handleSaveTemplate()` which has redundant setState calls and instead use `saveTemplate` to directly call endpoint
- clear timers set in `useEffect` hooks for `ApiKey` and `LoginInput` component
- In `SMSValidationInput` and `EmailValidationInput`, switch order of setState calls to set internal state before calling handler from parent component
- In `Landing` component, check `isAuthenticated` is false before retrieving stats, as page gets redirected when it is true
- Create custom hook tp encapsulate `isMounted` state - used to check if component is mounted/dismounted
- Disable previous button when csv upload is in progress for all channels
- Remove `activeStep`'s incorrect dependency on progress in `SMSCreate`
- Disable progress pane for Telegram when csv upload is in progress

## Tests

- [x] Check for react warnings regarding setting state after component has been dismounted
- [x] In SMS channel, after file upload, preview should be displayed and page should not progress to next step immediately
- [x] Check that progress pane and previous, next buttons are disabled when csv upload is in progress for all channels
