### PR TITLE
feat: Make reply-to address compulsory

### DIFF
--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -8,7 +8,12 @@ import {
   UserError,
 } from '@core/errors'
 import { TemplateError } from 'postman-templating'
-import { UploadService, StatsService, ParseCsvService } from '@core/services'
+import {
+  AuthService,
+  UploadService,
+  StatsService,
+  ParseCsvService,
+} from '@core/services'
 import { EmailTemplateService, EmailService } from '@email/services'
 import S3Client from '@core/services/s3-client.class'
 import { StoreTemplateOutput } from '@email/interfaces'
@@ -47,7 +52,8 @@ const storeTemplate = async (
       campaignId: +campaignId,
       subject,
       body,
-      replyTo,
+      replyTo:
+        replyTo || (await AuthService.findUser(req.session?.user?.id))?.email,
       from,
     })
 

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -27,6 +27,7 @@ const storeTemplateValidator = {
       .email()
       .options({ convert: true })
       .lowercase()
+      .allow(null)
       .required(),
     from: fromAddressValidator,
   }),

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -27,7 +27,6 @@ const storeTemplateValidator = {
       .email()
       .options({ convert: true })
       .lowercase()
-      .allow(null)
       .required(),
     from: fromAddressValidator,
   }),

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -18,6 +18,7 @@ import {
 } from 'components/common'
 import SaveDraftModal from 'components/dashboard/create/save-draft-modal'
 import { FinishLaterModalContext } from 'contexts/finish-later.modal.context'
+import { AuthContext } from 'contexts/auth.context'
 import { CampaignContext } from 'contexts/campaign.context'
 import { useParams } from 'react-router-dom'
 import { getCustomFromAddresses } from 'services/settings.service'
@@ -32,6 +33,7 @@ const EmailTemplate = ({
   setActiveStep: Dispatch<SetStateAction<EmailProgress>>
 }) => {
   const { campaign, updateCampaign } = useContext(CampaignContext)
+  const { email: userEmail } = useContext(AuthContext)
   const {
     body: initialBody,
     subject: initialSubject,
@@ -43,7 +45,7 @@ const EmailTemplate = ({
   const [body, setBody] = useState(replaceNewLines(initialBody))
   const [errorMsg, setErrorMsg] = useState(null)
   const [subject, setSubject] = useState(initialSubject)
-  const [replyTo, setReplyTo] = useState(initialReplyTo)
+  const [replyTo, setReplyTo] = useState(initialReplyTo || userEmail)
   const [from, setFrom] = useState(initialFrom)
   const [customFromAddresses, setCustomFromAddresses] = useState(
     [] as { label: string; value: string }[]
@@ -105,7 +107,7 @@ const EmailTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (subject && body && from) {
+          if (subject && body && from && replyTo) {
             await handleSaveTemplate(true)
           }
         }}
@@ -114,7 +116,7 @@ const EmailTemplate = ({
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, subject, from, handleSaveTemplate, setFinishLaterContent])
+  }, [body, subject, from, replyTo, handleSaveTemplate, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n') || ''
@@ -190,9 +192,7 @@ const EmailTemplate = ({
         </div>
 
         <div>
-          <h4 className={styles.replyToHeader}>
-            Replies <em>optional</em>
-          </h4>
+          <h4 className={styles.replyToHeader}>Replies</h4>
           <p>
             All replies will be directed to the email address indicated below
           </p>
@@ -204,7 +204,10 @@ const EmailTemplate = ({
         </div>
       </StepSection>
 
-      <NextButton disabled={!body || !subject} onClick={handleSaveTemplate} />
+      <NextButton
+        disabled={!body || !subject || !replyTo}
+        onClick={handleSaveTemplate}
+      />
       <ErrorBlock>{errorMsg}</ErrorBlock>
     </>
   )

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -45,7 +45,9 @@ const EmailTemplate = ({
   const [body, setBody] = useState(replaceNewLines(initialBody))
   const [errorMsg, setErrorMsg] = useState(null)
   const [subject, setSubject] = useState(initialSubject)
-  const [replyTo, setReplyTo] = useState(initialReplyTo || userEmail)
+  const [replyTo, setReplyTo] = useState(
+    initialReplyTo === userEmail ? null : initialReplyTo
+  )
   const [from, setFrom] = useState(initialFrom)
   const [customFromAddresses, setCustomFromAddresses] = useState(
     [] as { label: string; value: string }[]
@@ -107,7 +109,7 @@ const EmailTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (subject && body && from && replyTo) {
+          if (subject && body && from) {
             await handleSaveTemplate(true)
           }
         }}
@@ -116,7 +118,7 @@ const EmailTemplate = ({
     return () => {
       setFinishLaterContent(null)
     }
-  }, [body, subject, from, replyTo, handleSaveTemplate, setFinishLaterContent])
+  }, [body, subject, from, handleSaveTemplate, setFinishLaterContent])
 
   function replaceNewLines(body: string): string {
     return (body || '').replace(/<br\s*\/?>/g, '\n') || ''
@@ -193,9 +195,7 @@ const EmailTemplate = ({
 
         <div>
           <h4 className={styles.replyToHeader}>Replies</h4>
-          <p>
-            All replies will be directed to the email address indicated below
-          </p>
+          <p>If left blank, replies will be directed to {userEmail}</p>
           <TextInput
             placeholder="Enter reply-to email address"
             value={replyTo || ''}
@@ -204,10 +204,7 @@ const EmailTemplate = ({
         </div>
       </StepSection>
 
-      <NextButton
-        disabled={!body || !subject || !replyTo}
-        onClick={handleSaveTemplate}
-      />
+      <NextButton disabled={!body || !subject} onClick={handleSaveTemplate} />
       <ErrorBlock>{errorMsg}</ErrorBlock>
     </>
   )


### PR DESCRIPTION
## Problem

Closes #854 

## Solution

**Features**:
- Set logged in user email address as reply to if not provided

## Tests
- Create a new email campaign
- Leave reply to as empty and save template
- Check that the reply to field is set as the logged in user's email in the database
