### PR TITLE
Standardise icon sizes

### DIFF
--- a/frontend/src/components/common/action-button/ActionButton.module.scss
+++ b/frontend/src/components/common/action-button/ActionButton.module.scss
@@ -44,7 +44,7 @@
   background-color: $primary;
 
   .icon {
-    @include icon;
+    @extend %icon;
     color: white;
     margin-left: 0;
   }
@@ -69,7 +69,7 @@
     }
 
     i {
-      @include icon;
+      @extend %icon;
       font-size: 1.2rem;
       margin-top: 0.1rem;
       margin-left: 0.5rem;

--- a/frontend/src/components/common/confirm-modal/ConfirmModal.module.scss
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.module.scss
@@ -12,7 +12,7 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
 }
 
 .greenButton {

--- a/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
@@ -26,7 +26,6 @@
 
   .icon {
     @include icon;
-    font-size: 20px;
     margin-right: 0.5rem;
   }
 

--- a/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.module.scss
@@ -25,7 +25,7 @@
   }
 
   .icon {
-    @include icon;
+    @extend %icon;
     margin-right: 0.5rem;
   }
 

--- a/frontend/src/components/common/nav-bar/NavBar.module.scss
+++ b/frontend/src/components/common/nav-bar/NavBar.module.scss
@@ -109,7 +109,7 @@ $navbar-link-margin: calc(1rem + 1vw);
       @include flex-horizontal;
 
       .icon {
-        font-size: 1.3rem;
+        @include icon-large;
         margin-left: 0.5rem;
       }
     }

--- a/frontend/src/components/common/nav-bar/NavBar.module.scss
+++ b/frontend/src/components/common/nav-bar/NavBar.module.scss
@@ -109,7 +109,7 @@ $navbar-link-margin: calc(1rem + 1vw);
       @include flex-horizontal;
 
       .icon {
-        @include icon-large;
+        @extend %icon-large;
         margin-left: 0.5rem;
       }
     }

--- a/frontend/src/components/common/pagination/Pagination.module.scss
+++ b/frontend/src/components/common/pagination/Pagination.module.scss
@@ -9,7 +9,7 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
   color: $secondary;
   vertical-align: middle;
   cursor: pointer;

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -9,7 +9,7 @@
       @include flex-horizontal;
 
       .icon {
-        @include icon;
+        @include icon-large;
       }
 
       td.status {

--- a/frontend/src/components/common/progress-details/ProgressDetails.module.scss
+++ b/frontend/src/components/common/progress-details/ProgressDetails.module.scss
@@ -9,7 +9,7 @@
       @include flex-horizontal;
 
       .icon {
-        @include icon-large;
+        @extend %icon-large;
       }
 
       td.status {
@@ -31,7 +31,7 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
   margin-right: 0.5rem;
 
   &.red {

--- a/frontend/src/components/common/send-rate/SendRate.module.scss
+++ b/frontend/src/components/common/send-rate/SendRate.module.scss
@@ -7,7 +7,7 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
   font-size: 0.8rem;
   margin-left: 0.5rem;
   transition: transform 0.3s ease-out;

--- a/frontend/src/components/common/side-nav/SideNav.module.scss
+++ b/frontend/src/components/common/side-nav/SideNav.module.scss
@@ -57,5 +57,5 @@ $nav-item-height: 88px;
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
 }

--- a/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
@@ -89,6 +89,9 @@
 
 .icon {
   @include icon;
+  &.mode {
+    @include icon-large;
+  }
 }
 
 .lockIcon {

--- a/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
@@ -88,9 +88,9 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
   &.mode {
-    @include icon-large;
+    @extend %icon-large;
   }
 }
 

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -83,7 +83,14 @@ const Campaigns = () => {
       name: 'Mode',
       render: (campaign: Campaign) => (
         <div className={styles.iconContainer}>
-          <i className={cx('bx', styles.icon, channelIcons[campaign.type])}></i>
+          <i
+            className={cx(
+              'bx',
+              styles.icon,
+              styles.mode,
+              channelIcons[campaign.type]
+            )}
+          ></i>
           {campaign.protect && (
             <i className={cx('bx bxs-lock-alt', styles.lockIcon)}></i>
           )}

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -42,6 +42,10 @@ $modal-width: $tablet;
       height: 4.5rem;
       border: 1px solid $primary;
 
+      .icon {
+        @include icon-large;
+      }
+
       &:not(.active) {
         color: $primary;
         background: $neutral-light;

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -43,7 +43,7 @@ $modal-width: $tablet;
       border: 1px solid $primary;
 
       .icon {
-        @include icon-large;
+        @extend %icon-large;
       }
 
       &:not(.active) {
@@ -81,7 +81,7 @@ $modal-width: $tablet;
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
 }
 
 .title {

--- a/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.module.scss
+++ b/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.module.scss
@@ -81,7 +81,7 @@ $modal-width: $tablet;
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
   font-size: 20px;
 }
 

--- a/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/completed-demo-modal/CompletedDemoModal.module.scss
@@ -13,7 +13,7 @@
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
 }
 
 .title {

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -66,7 +66,7 @@ $modal-width: $tablet;
 }
 
 .icon {
-  @include icon;
+  @extend %icon;
 }
 
 .title {

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.module.scss
@@ -20,7 +20,7 @@ table.credTable {
   }
 
   .icon {
-    @include icon;
+    @extend %icon;
     margin-right: 2rem;
 
     &:last-child {

--- a/frontend/src/components/dashboard/settings/custom-from-address/CustomFromAddress.module.scss
+++ b/frontend/src/components/dashboard/settings/custom-from-address/CustomFromAddress.module.scss
@@ -47,7 +47,7 @@
     }
 
     .icon {
-      @include icon;
+      @extend %icon;
       margin-right: 2rem;
 
       &:last-child {

--- a/frontend/src/styles/base/_buttons.scss
+++ b/frontend/src/styles/base/_buttons.scss
@@ -44,7 +44,7 @@ $border-radius: $button-height / 2;
   }
 
   i {
-    @include icon;
+    @extend %icon;
     margin-top: 0.15rem;
     margin-left: $spacing-2;
   }

--- a/frontend/src/styles/base/_buttons.scss
+++ b/frontend/src/styles/base/_buttons.scss
@@ -45,8 +45,6 @@ $border-radius: $button-height / 2;
 
   i {
     @include icon;
-    height: 20px;
-    width: 20px;
     margin-top: 0.15rem;
     margin-left: $spacing-2;
   }

--- a/frontend/src/styles/base/_icons.scss
+++ b/frontend/src/styles/base/_icons.scss
@@ -1,9 +1,23 @@
-@mixin icon {
+%icon {
   align-items: center;
   display: inline-flex;
   justify-content: center;
-  font-size: 1.5rem;
+}
+
+@mixin icon {
+  @extend %icon;
+  line-height: 1.25rem;
+  font-size: 1.25rem;
+  width: 20px;
+  height: 20px;
+}
+
+@mixin icon-large {
+  @extend %icon;
   line-height: 1.5rem;
+  font-size: 1.5rem;
+  width: 24px;
+  height: 24px;
 }
 
 @mixin spinner {

--- a/frontend/src/styles/base/_icons.scss
+++ b/frontend/src/styles/base/_icons.scss
@@ -1,19 +1,19 @@
-%icon {
+%icon-alignment {
   align-items: center;
   display: inline-flex;
   justify-content: center;
 }
 
-@mixin icon {
-  @extend %icon;
+%icon {
+  @extend %icon-alignment;
   line-height: 1.25rem;
   font-size: 1.25rem;
   width: 20px;
   height: 20px;
 }
 
-@mixin icon-large {
-  @extend %icon;
+%icon-large {
+  @extend %icon-alignment;
   line-height: 1.5rem;
   font-size: 1.5rem;
   width: 24px;


### PR DESCRIPTION
## Problem

Icon sizes were not standardised across the button icons and other isolated icons.
Closes #859 

## Solution

**Improvements**:

- Introduce css mixin for large icons (only two sizes of icons exist as of now - default and large)
- Standardise icon sizes by using relevant mixins

