### PR TITLE
Fix: edit draft returns user to main dashboard instead of template page

### DIFF
--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -38,7 +38,7 @@ const Create = () => {
   async function handleFinishLater() {
     if (campaign.status === Status.Draft) {
       sendUserEvent(GA_USER_EVENTS.FINISH_CAMPAIGN_LATER, campaign.type)
-      if (finishLaterContent) finishLaterContextHandler()
+      if (finishLaterContent) return finishLaterContextHandler()
     }
     history.push('/campaigns')
   }

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -105,13 +105,14 @@ const EmailTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (campaignId && subject && body && from) {
-            try {
-              await saveTemplate(+campaignId, subject, body, replyTo, from)
-            } catch (err) {
-              setErrorMsg(err.message)
-              throw err
-            }
+          if (!campaignId) return
+          try {
+            if (!subject || !body)
+              throw new Error('Message subject or template cannot be empty!')
+            await saveTemplate(+campaignId, subject, body, replyTo, from)
+          } catch (err) {
+            setErrorMsg(err.message)
+            throw err
           }
         }}
       />

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -80,13 +80,13 @@ const SMSTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (campaignId && body) {
-            try {
-              await saveTemplate(+campaignId, body)
-            } catch (err) {
-              setErrorMsg(err.message)
-              throw err
-            }
+          if (!campaignId) return
+          try {
+            if (!body) throw new Error('Message template cannot be empty!')
+            await saveTemplate(+campaignId, body)
+          } catch (err) {
+            setErrorMsg(err.message)
+            throw err
           }
         }}
       />

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -61,13 +61,13 @@ const TelegramTemplate = ({
       <SaveDraftModal
         saveable
         onSave={async () => {
-          if (campaignId && body) {
-            try {
-              await saveTemplate(+campaignId, body)
-            } catch (err) {
-              setErrorMsg(err.message)
-              throw err
-            }
+          if (!campaignId) return
+          try {
+            if (!body) throw new Error('Message template cannot be empty!')
+            await saveTemplate(+campaignId, body)
+          } catch (err) {
+            setErrorMsg(err.message)
+            throw err
           }
         }}
       />


### PR DESCRIPTION
## Problem

After a user enters an invalid template and clicks 'Finish Later' button on Create template screen, the 'Finish Later' modal will open. When clicking 'Save draft', this will then display an error together with the 'Edit Draft' button. When clicking on the 'Edit Draft' button, the page routes to the dashboard view. This is an incorrect behaviour.

Closes #871 

## Solution

**Bug Fixes**:

https://github.com/opengovsg/postmangovsg/blob/347ebfa58894a162b79dfbb380d92c57f7138546/frontend/src/components/dashboard/create/Create.tsx#L38-L44

Previously, we did not `return finishLaterContextHandler() `, hence the page was routed to the dashboard regardless of the outcome of the SaveDraft modal. By returning the handler, when `finishLaterContent` is defined, i.e. it will open SaveDraft modal when clicked, any page routing will be handled within that component.

## Tests

- [x] Edit draft functionality
- Enter an Invalid template `{{test`
- Click on `Finish Later` button followed by `Save draft`
- Modal displays error, click on `Edit draft`, modal should close and current screen should be still at create template 

- [x] Click on 'Skip saving draft' in previous scenario, check that page is routed to the dashboard view
- [x] In password protected campaign, click on 'Finish later' for Message B followed by 'Back to campaigns', check that page is routed to the dashboard view