### PR TITLE
chore: Add GA events for campaign duplication

### DIFF
--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -166,6 +166,7 @@ const Campaigns = () => {
             className={cx(styles.iconContainer, styles.duplicate)}
             onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
               event.stopPropagation()
+              sendUserEvent(GA_USER_EVENTS.OPEN_DUPLICATE_MODAL, campaign.type)
               modalContext.setModalContent(
                 <DuplicateCampaignModal campaign={campaign} />
               )

--- a/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
+++ b/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react'
 import { OutboundLink } from 'react-ga'
+import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 import { useHistory } from 'react-router-dom'
 import cx from 'classnames'
 
@@ -29,6 +30,7 @@ const DuplicateCampaignModal = ({ campaign }: { campaign: Campaign }) => {
         name: selectedName,
         campaignId: campaign.id,
       })
+      sendUserEvent(GA_USER_EVENTS.COMPLETE_DUPLICATE, campaign.type)
       // close modal and go to create view
       close()
       history.push(`/campaigns/${duplicate.id}`)

--- a/frontend/src/services/ga.service.ts
+++ b/frontend/src/services/ga.service.ts
@@ -15,6 +15,8 @@ export const GA_USER_EVENTS = {
   DOWNLOAD_DELIVERY_REPORT: 'Download delivery report',
   NEW_USER_TRY_EMAIL: 'New user try email',
   NEW_USER_TRY_SMS_TELEGRAM: 'New user try SMS or Telegram',
+  OPEN_DUPLICATE_MODAL: 'Open duplicate modal',
+  COMPLETE_DUPLICATE: 'Complete campaign duplication',
 }
 
 export function initializeGA() {


### PR DESCRIPTION
## Problem

Closes #881 

## Solution
**Improvements**:
- Added the following GA events:
   - `OPEN_DUPLICATE_MODAL` - Sent when user open duplication modal from the campaigns table
   - `COMPLETE_DUPLICATE`  - Sent when user complete a campaign duplication
- Include campaign type as label for events

## Tests
- [ ] Open duplication modal from campaigns table by clicking "Duplicate". Observe that event is sent through Chrome console.
- [ ] Complete duplication of a campaign through the duplication modal. Observe that event is sent through Chrome console.
