### PR TITLE
chore: Update dependencies for database backup lambda

### DIFF
--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -81,9 +81,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.4.1.tgz",
-      "integrity": "sha512-e5z0CwsM0RXky+PnyPtQ3QK46ksqm+kE7kX8pm8X+ddBwZJipHchKeazMM5fLlGCS+AALalzXb+uYmH72TRnpQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
+      "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
       "requires": {
         "@google-cloud/projectify": "^2.0.0",
         "@google-cloud/promisify": "^2.0.0",
@@ -107,28 +107,40 @@
             "stream-shift": "^1.0.0"
           }
         },
+        "gaxios": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
         "google-auth-library": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.1.tgz",
-          "integrity": "sha512-0WfExOx3FrLYnY88RICQxvpaNzdwjz44OsHqHkIoAJfjY6Jck6CZRl1ASWadk+wbJ0LhkQ8rNY4zZebKml4Ghg==",
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+          "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "ecdsa-sig-formatter": "^1.0.11",
             "fast-text-encoding": "^1.0.0",
-            "gaxios": "^3.0.0",
-            "gcp-metadata": "^4.1.0",
+            "gaxios": "^4.0.0",
+            "gcp-metadata": "^4.2.0",
             "gtoken": "^5.0.4",
             "jws": "^4.0.0",
             "lru-cache": "^6.0.0"
           }
         },
         "gtoken": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.4.tgz",
-          "integrity": "sha512-U9wnSp4GZ7ov6zRdPuRHG4TuqEWqRRgT1gfXGNArhzBUn9byrPeH8uTmBWU/ZiWJJvTEmkjhDIC3mqHWdVi3xQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
+          "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
           "requires": {
-            "gaxios": "^3.0.0",
+            "gaxios": "^4.0.0",
             "google-p12-pem": "^3.0.3",
             "jws": "^4.0.0",
             "mime": "^2.2.0"
@@ -164,21 +176,21 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/storage": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.3.0.tgz",
-      "integrity": "sha512-3t5UF3SZ14Bw2kcBHubCai6EIugU2GnQOstYWVSFuoO8IJ94RAaIOPq/dtexvQbUTpBTAGpd5smVR9WPL1mJVw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.5.0.tgz",
+      "integrity": "sha512-Pat83kHNnKJpEHUirtQtCoAJ2K3OlEo2ZcSlPjierJnEKnhbIQPyJ6mAbs/ovm3K3QDQhouKJ9QSONkFPEwQuA==",
       "requires": {
         "@google-cloud/common": "^3.3.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
         "compressible": "^2.0.12",
-        "concat-stream": "^2.0.0",
         "date-and-time": "^0.14.0",
-        "duplexify": "^3.5.0",
+        "duplexify": "^4.0.0",
         "extend": "^3.0.2",
-        "gaxios": "^3.0.0",
+        "gaxios": "^4.0.0",
         "gcs-resumable-upload": "^3.1.0",
+        "get-stream": "^6.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
         "mime-types": "^2.0.8",
@@ -190,12 +202,35 @@
         "xdg-basedir": "^4.0.0"
       },
       "dependencies": {
-        "p-limit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+        "duplexify": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+          "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
           "requires": {
-            "p-try": "^2.0.0"
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "gaxios": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+          "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
           }
         }
       }
@@ -986,17 +1021,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
-      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -1606,6 +1630,11 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg=="
     },
     "glob": {
       "version": "7.1.6",
@@ -2737,9 +2766,9 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "8.3.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -2817,11 +2846,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -3132,6 +3156,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -447,47 +447,47 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/core": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.22.3.tgz",
-      "integrity": "sha512-eGL5uUarw3o4i9QUb9JoFHnhriPpWCaqeaIBB06HUpdcvhrjoowcKZj1+WPec5lFg5XusE35vez7z/FPzmJUDw==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.27.6.tgz",
+      "integrity": "sha512-izCS5iyc6HAfpW1AsGXLAKetx82C1Sq1siAh97tOlSK58PVJAEH/WMiej9WuZJxCDTOtj94QtoLflssrZyAtFg==",
       "requires": {
-        "@sentry/hub": "5.22.3",
-        "@sentry/minimal": "5.22.3",
-        "@sentry/types": "5.22.3",
-        "@sentry/utils": "5.22.3",
+        "@sentry/hub": "5.27.6",
+        "@sentry/minimal": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.22.3.tgz",
-      "integrity": "sha512-INo47m6N5HFEs/7GMP9cqxOIt7rmRxdERunA3H2L37owjcr77MwHVeeJ9yawRS6FMtbWXplgWTyTIWIYOuqVbw==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.27.6.tgz",
+      "integrity": "sha512-bOMky3iu7zEghSaWmTayfme5tCpUok841qDCGxGKuyAtOhBDsgGNS/ApNEEDF2fyX0oo4G1cHYPWhX90ZFf/xA==",
       "requires": {
-        "@sentry/types": "5.22.3",
-        "@sentry/utils": "5.22.3",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.22.3.tgz",
-      "integrity": "sha512-HoINpYnVYCpNjn2XIPIlqH5o4BAITpTljXjtAftOx6Hzj+Opjg8tR8PWliyKDvkXPpc4kXK9D6TpEDw8MO0wZA==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.27.6.tgz",
+      "integrity": "sha512-pKhzVQX9nL4m1dcnb2i2Y47IWVNs+K3wiYLgCB9hl9+ApxppfOc+fquiFoCloST3IuaD4yly2TtbOJgAMWcMxQ==",
       "requires": {
-        "@sentry/hub": "5.22.3",
-        "@sentry/types": "5.22.3",
+        "@sentry/hub": "5.27.6",
+        "@sentry/types": "5.27.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.22.3.tgz",
-      "integrity": "sha512-TCCKO7hJKiQi1nGmJcQfvbbqv98P08LULh7pb/NaO5pV20t1FtICfGx8UMpORRDehbcAiYq/f7rPOF6X/Xl5iw==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.27.6.tgz",
+      "integrity": "sha512-ogKL4F3wSZuzNeHOGKPqQPbZ87Bd/dC8wk7Rwbui3SIMgtoUmO3rSOR4Edwar6mf330cA6CY9roylWdcaSqmZA==",
       "requires": {
-        "@sentry/core": "5.22.3",
-        "@sentry/hub": "5.22.3",
-        "@sentry/tracing": "5.22.3",
-        "@sentry/types": "5.22.3",
-        "@sentry/utils": "5.22.3",
+        "@sentry/core": "5.27.6",
+        "@sentry/hub": "5.27.6",
+        "@sentry/tracing": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
@@ -495,28 +495,28 @@
       }
     },
     "@sentry/tracing": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.22.3.tgz",
-      "integrity": "sha512-Zp59kMCk5v56ZAyErqjv/QvGOWOQ5fRltzeVQVp8unIDTk6gEFXfhwPsYHOokJe1mfkmrgPDV6xAkYgtL3KCDQ==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.27.6.tgz",
+      "integrity": "sha512-ms3vprEId+hi8hcqtf8weqsNGASaDXAZzIOT4g2gASGpwLb5hLuScpM8z6Yhu5FGjb8DektlW5OrXJSsStIozw==",
       "requires": {
-        "@sentry/hub": "5.22.3",
-        "@sentry/minimal": "5.22.3",
-        "@sentry/types": "5.22.3",
-        "@sentry/utils": "5.22.3",
+        "@sentry/hub": "5.27.6",
+        "@sentry/minimal": "5.27.6",
+        "@sentry/types": "5.27.6",
+        "@sentry/utils": "5.27.6",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.22.3.tgz",
-      "integrity": "sha512-cv+VWK0YFgCVDvD1/HrrBWOWYG3MLuCUJRBTkV/Opdy7nkdNjhCAJQrEyMM9zX0sac8FKWKOHT0sykNh8KgmYw=="
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.27.6.tgz",
+      "integrity": "sha512-XOW9W8DrMk++4Hk7gWi9o5VR0o/GrqGfTKyFsHSIjqt2hL6kiMPvKeb2Hhmp7Iq37N2bDmRdWpM5m+68S2Jk6w=="
     },
     "@sentry/utils": {
-      "version": "5.22.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.22.3.tgz",
-      "integrity": "sha512-AHNryXMBvIkIE+GQxTlmhBXD0Ksh+5w1SwM5qi6AttH+1qjWLvV6WB4+4pvVvEoS8t5F+WaVUZPQLmCCWp6zKw==",
+      "version": "5.27.6",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.27.6.tgz",
+      "integrity": "sha512-/QMVLv+zrTfiIj2PU+SodSbSzD5MmamMOaljkDsRIVsj6gpkm1/VG1g2+40TZ0FbQ4hCW2F+iR7cnqzZBNmchA==",
       "requires": {
-        "@sentry/types": "5.22.3",
+        "@sentry/types": "5.27.6",
         "tslib": "^1.9.3"
       }
     },

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -763,9 +763,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.749.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.749.0.tgz",
-      "integrity": "sha512-dG7jbOfSrZpdhCniQpe3hXmRNjmlKX7DyZuLDJ5tDl/4+jmXUEjXpM1IhMi0wWXriO/AnHBKlKGsePx8vBMqcw==",
+      "version": "2.798.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.798.0.tgz",
+      "integrity": "sha512-7BMCH90yFpMmCF5uxZiiKMMzIAFibZz8b6CLGw/92FgMd86ZedpNqDyaikcGv1yOVtOlNCCnXN6OglC8/vwm4Q==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -919,9 +919,9 @@
       }
     },
     "cliui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
-      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1213,9 +1213,9 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "escalade": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3005,11 +3005,10 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -3098,9 +3097,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.1.tgz",
-      "integrity": "sha512-/jJ831jEs4vGDbYPQp4yGKDYPSCCEQ45uZWJHE1AoYBzqdZi8+LDWas0z4HrmJXmKdpFsTiowSHXdxyFhpmdMg=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
     },
     "yallist": {
       "version": "4.0.0",
@@ -3108,17 +3107,17 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
-      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.1.1.tgz",
+      "integrity": "sha512-hAD1RcFP/wfgfxgMVswPE+z3tlPFtxG8/yWUrG2i17sTWGCGqWnxKcLTF4cUKDUK8fzokwsmO9H0TDkRbMHy8w==",
       "requires": {
-        "cliui": "^7.0.0",
-        "escalade": "^3.0.2",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
         "string-width": "^4.2.0",
-        "y18n": "^5.0.1",
-        "yargs-parser": "^20.0.0"
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       },
       "dependencies": {
         "emoji-regex": {
@@ -3142,9 +3141,9 @@
           }
         },
         "yargs-parser": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.0.0.tgz",
-          "integrity": "sha512-8eblPHTL7ZWRkyjIZJjnGf+TijiKJSwA24svzLRVvtgoi/RZiKa9fFQTrlx0OKLnyHSdt/enrdadji6WFfESVA=="
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
         }
       }
     },

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -763,9 +763,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.799.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.799.0.tgz",
-      "integrity": "sha512-NYAoiNU+bJXhlJsC0rFqrmD5t5ho7/VxldmziP6HLPYHfOCI9Uvk6UVjfPmhLWPm0mHnIxhsHqmsNGyjhHNYmw==",
+      "version": "2.801.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.801.0.tgz",
+      "integrity": "sha512-FfdlC1w3xwElI+DbrY6gqcz007g8C/9Yg84808fm5clrYiOd8fhCgyu1JYIUmbPCSy3/areW9dIbKeCz69pauw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -2240,24 +2240,23 @@
       }
     },
     "pg": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.3.3.tgz",
-      "integrity": "sha512-wmUyoQM/Xzmo62wgOdQAn5tl7u+IA1ZYK7qbuppi+3E+Gj4hlUxVHjInulieWrd0SfHi/ADriTb5ILJ/lsJrSg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
+      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.3.0",
-        "pg-pool": "^3.2.1",
-        "pg-protocol": "^1.2.5",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.4.0",
         "pg-types": "^2.1.0",
-        "pgpass": "1.x",
-        "semver": "4.3.2"
+        "pgpass": "1.x"
       },
       "dependencies": {
-        "semver": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
-          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        "pg-connection-string": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+          "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
         }
       }
     },
@@ -2272,14 +2271,14 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-pool": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
-      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
     },
     "pg-protocol": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
-      "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
+      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -2294,21 +2293,11 @@
       }
     },
     "pgpass": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
-      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
       "requires": {
-        "split": "^1.0.0"
-      },
-      "dependencies": {
-        "split": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-          "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-          "requires": {
-            "through": "2"
-          }
-        }
+        "split2": "^3.1.1"
       }
     },
     "picomatch": {
@@ -2601,6 +2590,14 @@
         "through": "2"
       }
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2761,7 +2758,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/serverless/database-backup/package-lock.json
+++ b/serverless/database-backup/package-lock.json
@@ -763,9 +763,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.798.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.798.0.tgz",
-      "integrity": "sha512-7BMCH90yFpMmCF5uxZiiKMMzIAFibZz8b6CLGw/92FgMd86ZedpNqDyaikcGv1yOVtOlNCCnXN6OglC8/vwm4Q==",
+      "version": "2.799.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.799.0.tgz",
+      "integrity": "sha512-NYAoiNU+bJXhlJsC0rFqrmD5t5ho7/VxldmziP6HLPYHfOCI9Uvk6UVjfPmhLWPm0mHnIxhsHqmsNGyjhHNYmw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@google-cloud/kms": "^2.1.2",
     "@google-cloud/storage": "^5.5.0",
-    "@sentry/node": "^5.22.3",
+    "@sentry/node": "^5.27.6",
     "aws-sdk": "^2.798.0",
     "axios": "^0.21.0",
     "convict": "^6.0.0",

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -43,7 +43,7 @@
     "dotenv": "^8.2.0",
     "fast-crc32c": "^2.0.0",
     "pg-connection-string": "^2.3.0",
-    "pg": "^8.3.3",
+    "pg": "^8.5.1",
     "source-map-support": "^0.5.19",
     "yargs": "^16.0.3"
   }

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -45,6 +45,6 @@
     "pg-connection-string": "^2.3.0",
     "pg": "^8.5.1",
     "source-map-support": "^0.5.19",
-    "yargs": "^16.0.3"
+    "yargs": "^16.1.1"
   }
 }

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -37,7 +37,7 @@
     "@google-cloud/kms": "^2.1.2",
     "@google-cloud/storage": "^5.5.0",
     "@sentry/node": "^5.27.6",
-    "aws-sdk": "^2.799.0",
+    "aws-sdk": "^2.801.0",
     "axios": "^0.21.0",
     "convict": "^6.0.0",
     "dotenv": "^8.2.0",

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -37,7 +37,7 @@
     "@google-cloud/kms": "^2.1.2",
     "@google-cloud/storage": "^5.5.0",
     "@sentry/node": "^5.22.3",
-    "aws-sdk": "^2.749.0",
+    "aws-sdk": "^2.798.0",
     "axios": "^0.21.0",
     "convict": "^6.0.0",
     "dotenv": "^8.2.0",

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@google-cloud/kms": "^2.1.2",
-    "@google-cloud/storage": "^5.3.0",
+    "@google-cloud/storage": "^5.5.0",
     "@sentry/node": "^5.22.3",
     "aws-sdk": "^2.749.0",
     "axios": "^0.21.0",

--- a/serverless/database-backup/package.json
+++ b/serverless/database-backup/package.json
@@ -37,7 +37,7 @@
     "@google-cloud/kms": "^2.1.2",
     "@google-cloud/storage": "^5.5.0",
     "@sentry/node": "^5.27.6",
-    "aws-sdk": "^2.798.0",
+    "aws-sdk": "^2.799.0",
     "axios": "^0.21.0",
     "convict": "^6.0.0",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
## Problem

Updating dependencies suggested by Snyk for backup lambda.

## Deploy Notes

**Upgraded dependencies**:
| Library | From | To |
| :------ | :---: | :---: |
| `pg` | 8.3.3 | 8.5.1 |
| `@google-cloud/storage` | 5.3.0 | 5.5.0 |
| `yargs` | 16.0.3 | 16.1.1 |
| `aws-sdk` | 2.749.0 | 2.801.0 |
| `@sentry/node` | 5.22.3 | 5.27.6 |

## Tests
- Deploy and trigger backup lambda on staging