### PR TITLE
Integrate cronitor for verify-backup

### DIFF
--- a/serverless/verify-backup/.env-example
+++ b/serverless/verify-backup/.env-example
@@ -9,6 +9,7 @@ GCLOUD_SERVICE_ACCOUNT='gcloud-service-account'
 GCLOUD_RUN_SERVICE_NAME='verify-backup'
 GCLOUD_RUN_SERVICE_URL='verify-back-url'
 SENTRY_DSN='https://123.ingest.sentry.io/456'
+CRONITOR_CODE='cronitor-code'
 
 # Required to run local instance
 # GOOGLE_APPLICATION_CREDENTIALS='path-to-key-file'

--- a/serverless/verify-backup/Dockerfile
+++ b/serverless/verify-backup/Dockerfile
@@ -2,6 +2,7 @@ FROM node:12-alpine
 
 RUN apk update && apk upgrade
 RUN apk add postgresql
+RUN apk add curl
 
 WORKDIR /usr/home/postmangovsg
 

--- a/serverless/verify-backup/scripts/run.sh
+++ b/serverless/verify-backup/scripts/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Started Cronitor job
+curl "https://cronitor.link/$CRONITOR_CODE/run"  -m 10 || true
+
 # Initialise and start postgres
 mkdir -p /run/postgresql/
 chown -R postgres:postgres /run/postgresql/


### PR DESCRIPTION
## Problem

A cloud scheduler job is scheduled to trigger the verify-backup service after database backups are completed every night. However the cloud scheduler job may fail to run, and the backup verification will fail silently. To prevent this, we need to setup a Cronitor job to monitor the verification job.

Closes #896 

## Solution

- Add cronitor calls in the docker entrypoint script `run.sh` and `verify-backup.sh`

## Tests

- Cronitor job `postmangovsg-staging-verify-backup` for staging at https://cronitor.io/dashboard?search=isPIpa
- Possible to test by modifying the alert trigger schedule, and cronitor should trigger a slack message when verify-backup job is not run 

## Deploy Notes

**New environment variables**:

- `CRONITOR_CODE ` : identifier string for cronitor integration