### PR TITLE
Truncate log messages to prevent large logs causing memory issues

### DIFF
--- a/backend/src/core/logger.ts
+++ b/backend/src/core/logger.ts
@@ -44,12 +44,25 @@ const addTransport = (transport: any) => {
   logger.add(transport)
 }
 
+const truncate = (message: string, length: number, suffix = true): string => {
+  if (!message) {
+    return ''
+  }
+  return message.length > length
+    ? `${message.substring(0, length)}${suffix ? '...<TRUNCATED>' : ''}`
+    : message
+}
 const loggerWithLabel = (module: NodeModule): any => {
   const label = getModuleLabel(module)
   return {
     info: (logMeta: any): winston.Logger => logger.info({ label, ...logMeta }),
-    error: (logMeta: any): winston.Logger =>
-      logger.error({ label, ...logMeta }),
+    error: (logMeta: any): winston.Logger => {
+      if (logMeta.error && logMeta.error instanceof Error) {
+        logMeta.error = truncate(logMeta.error.stack, 400)
+      }
+      return logger.error({ label, ...logMeta })
+    },
+
     debug: (logMeta: any): winston.Logger =>
       logger.debug({ label, ...logMeta }),
     warn: (logMeta: any): winston.Logger => logger.warn({ label, ...logMeta }),

--- a/backend/src/core/services/parse-csv.service.ts
+++ b/backend/src/core/services/parse-csv.service.ts
@@ -133,10 +133,10 @@ const parseAndProcessCsv = async (
           } catch (err) {
             logger.error({
               message: 'Parsing failed',
-              error: err.message,
+              error: err,
               ...logMeta,
             })
-            reject(err.message)
+            reject(err)
           }
         } else {
           logger.info({ message: 'Parsing aborted', ...logMeta })

--- a/backend/src/core/services/parse-csv.service.ts
+++ b/backend/src/core/services/parse-csv.service.ts
@@ -131,8 +131,12 @@ const parseAndProcessCsv = async (
             await onComplete(numMessages)
             logger.info({ message: 'Parsing complete', ...logMeta })
           } catch (err) {
-            logger.error({ message: 'Parsing failed', error: err, ...logMeta })
-            reject(err)
+            logger.error({
+              message: 'Parsing failed',
+              error: err.message,
+              ...logMeta,
+            })
+            reject(err.message)
           }
         } else {
           logger.info({ message: 'Parsing aborted', ...logMeta })


### PR DESCRIPTION
## Problem

There are a few instances in the code where we write the whole error object in the `catch` block to logs. An error object that contains an abnormally large amount of data, e.g. very long stack traces or sequelize error trace, could cause the server to go out of memory when writing the logs to cloudwatch. This would cause the server to restart, causing a temporary loss in service. 

## Solution

After combing through the logs to identify such instances, my initial solution was to limit all functions with sequelize queries to output error logs with only `error.message`. However I realised this may not be a solid solution, as described below.

**Potential solutions**:

- Limit all functions with sequelize queries to output error logs with only `error.message`. This is not ideal as:
  1. The functions with sequelize queries may be also performing calls to other services for which a more verbose error message would be ideal i.e. would loose stack traces
  2. This issue may not be limited to sequelize error traces
  2. This is not foolproof as it may not be feasible to ensure that new code being written has to follow this convention
- Stringify and truncate all `error` object root properties to an arbitrary number of bytes
- Truncate the whole error object if larger than set threshold - destroys json structure

**Immediate fixes to resolve error source**:

- Only print out `error.message` in `parse-csv.service` to prevent regurgitating long bulk create queries on errors during file processing 

## Tests

- Upload a large recipient list with recipients that exceed 255 chars
- Observe logs

