### PR TITLE
chore(robots): guide NLB crawler

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /static/js/

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,2 +1,6 @@
-User-agent: *
-Disallow: /static/js/
+User-agent: NLB_archive_bot
+
+Allow: /
+Allow: /static/
+Allow: /*.png
+Disallow: *


### PR DESCRIPTION
## Problem

Crawlers may be overly aggressive and parse bundle.js for possible links.
This results in the crawler trying to request paths from Postman that do not
actually exist

## Solution

None of the JavaScript source files will have links that crawlers can
follow, so prevent them from crawling them in the first place