### PR TITLE
fix(telegram): return 200 to skip Telegram API retries

### DIFF
--- a/backend/src/telegram/middlewares/telegram-callback.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-callback.middleware.ts
@@ -34,7 +34,7 @@ const verifyBotIdRegistered = async (
 const handleUpdate = async (
   req: Request,
   res: Response,
-  next: NextFunction
+  _next: NextFunction
 ): Promise<Response | void> => {
   const { botId, botToken } = res.locals
   try {
@@ -42,7 +42,12 @@ const handleUpdate = async (
     logger.info({ message: 'Update bot', botId, action: 'handleUpdate' })
     return res.sendStatus(200)
   } catch (err) {
-    return next(err)
+    logger.error({
+      error: err,
+      botId,
+      action: 'handleUpdate',
+    })
+    return res.sendStatus(200) // On errors, Do not trigger retries by Telegram API
   }
 }
 export const TelegramCallbackMiddleware = {

--- a/backend/src/telegram/utils/callback/handlers/contact.ts
+++ b/backend/src/telegram/utils/callback/handlers/contact.ts
@@ -88,7 +88,8 @@ export const contactMessageHandler = (botId: string) => async (
   ctx: TelegrafContext
 ): Promise<Message> => {
   logger.info({
-    message: ctx.from?.id.toString() as string,
+    from: ctx.from,
+    contact: ctx.message?.contact,
     botId,
     action: 'contactMessageHandler',
   })


### PR DESCRIPTION
## Problem

When an error occurs within `handleUpdate`, an error message is sent back to the user through Telegram to notify him/her. However, when this error occurs, our callback handler endpoint does not return a `200` response to the Telegram API. This causes the Telegram API to repeatedly retry the webhook. 

This results in the user being spammed with the same error message. 

## Solution

**Bug Fixes**:
- When an error occurs, log error and return 200 to the Telegram API to prevent retries
- Include `contact` and `from` in logs for debugging 

## Tests
- Setup and verify a bot on Postman
- Send a contact that is not your own contact
- Check in logs that `200` is returned by the callback endpoint
- Check that error message is only sent once

## TODO
- [x] Include additional information from the incoming message into the error log
