### PR TITLE
chore(localstack): pin localstack version to 0.11.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "6379:6379"
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.11.6
     ports:
       - "4566-4599:4566-4599"
     environment:


### PR DESCRIPTION
## Problem

Closes #882 

## Solution

**Bug Fixes**:

- Pin localstack to `0.11.6`. This is a temporary fix first so that `npm run dev:localstack` works. Will be taking a deeper look into what is causing the incompatibility. However, given that some features (custom from email) cannot be replicated with localstack, we might eventually deprecate it entirely. 
