### PR TITLE
Update the announcement modal

### DIFF
--- a/backend/src/core/routes/settings.routes.ts
+++ b/backend/src/core/routes/settings.routes.ts
@@ -27,31 +27,10 @@ const demoDisplayedValidator = {
   }),
 }
 
-// Only allow updating with versions less than or equal to the current package version
-const compareSemverMethod = (value: string, helpers: any) => {
-  const currentPackageVersion = process.env.npm_package_version
-  const updatingVersion = value
-
-  const currentSplit = currentPackageVersion
-    ?.split('.')
-    .map((num) => parseInt(num, 10))
-  const updatingSplit = updatingVersion
-    .split('.')
-    .map((num) => parseInt(num, 10))
-  for (let i = 0; i < 3; i++) {
-    if ((!currentSplit || currentSplit[i]) < updatingSplit[i]) {
-      return helpers.error('any.invalid')
-    }
-  }
-  return value
-}
-
+// The version has to be a SHA-256 hash written in base64.
 const updateAnnouncementVersionValidator = {
   [Segments.BODY]: Joi.object({
-    announcement_version: Joi.string()
-      .pattern(new RegExp('[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}'))
-      .custom(compareSemverMethod)
-      .required(),
+    announcement_version: Joi.string().base64().length(44).required(),
   }),
 }
 

--- a/docs/creating-announcements.md
+++ b/docs/creating-announcements.md
@@ -1,0 +1,84 @@
+# Creating announcements
+
+## Announcement design
+
+For an idea of how an announcement looks, see [this](https://www.figma.com/file/29FkTqWnA4yLKzstnvyY6X/%F0%9F%91%91Design-Master?node-id=5761%3A0).
+
+## Available parameters
+
+An announcement comprises of the following parameters:
+
+- **title**: the title of the announcement
+- **subtext**: the main text content of the announcement (optional)
+- **mediaUrl**: the link to the image or video (optional)
+- **primaryButtonUrl**: the link the user is directed to upon clicking the primary button
+- **primaryButtonText**: the text displayed in the primary button
+- **secondaryButtonUrl**: the link the user is directed to upon clicking the secondary button (optional)
+- **secondaryButtonText**: the text displayed in the secondary button (optional)
+
+There are 2 types of announcements:
+
+- Graphic/text announcement
+- Video announcement
+
+## Graphic/text announcement parameters
+
+A graphic/text announcement typically comprises the following parameters:
+
+- title
+- subtext
+- primaryButtonUrl
+- primaryButtonText
+- secondaryButtonUrl (optional)
+- secondaryButtonText (optional)
+
+Furthermore, a graphic announcement also contains the following parameter:
+
+- mediaUrl (link to an image)
+
+## Video announcement parameters
+
+A video announcement typically comprises the following parameters:
+
+- title
+- mediaUrl (link to a video)
+- primaryButtonUrl
+- primaryButtonText
+- secondaryButtonUrl (optional)
+- secondaryButtonText (optional)
+
+## Creating an announcement
+
+Announcement parameters are stored in the [frontend/src/locales/en/messages.po](../frontend/src/locales/en/messages.po) file.
+
+### Editing a parameters
+
+Steps to edit a parameter:
+
+1. Navigate to the aforementioned file.
+2. Locate the line that starts with `msgid` and contains the name of the parameter.
+3. Replace the string in the line below it with your desired text.
+
+For example, if you want to edit the **title** parameter,
+
+1. Navigate to [frontend/src/locales/en/messages.po](../frontend/src/locales/en/messages.po).
+2. Locate the line that states `msgid "announcement.title"`.
+3. Replace the line right below it with `msgid "Insert new title here"`.
+
+### Unused optional parameters
+
+For any unused optional parameters, make sure to replace the text with `null`.
+
+These parameters include:
+
+- subtext
+- mediaUrl
+- secondaryButtonUrl
+- secondaryButtonText
+
+For example, if the **secondaryButtonUrl** parameter is unused, the lines should look like:
+
+```
+msgid "announcement.secondaryButtonUrl"
+msgstr "null"
+```

--- a/frontend/src/components/common/text-button/TextButton.module.scss
+++ b/frontend/src/components/common/text-button/TextButton.module.scss
@@ -3,14 +3,10 @@
 
 .textButton {
   @include button(transparent, transparent, transparent);
-  color: $primary;
+  color: $secondary;
   display: inline-block;
   padding: 0;
   border-radius: 0;
-
-  &:hover {
-    color: $secondary;
-  }
 
   &.noMinWidth {
     min-width: unset;

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -26,7 +26,7 @@ import CreateDemoModal from 'components/dashboard/demo/create-demo-modal'
 import { getUserSettings } from 'services/settings.service'
 import DuplicateCampaignModal from '../create/duplicate-campaign-modal'
 import AnnouncementModal from './announcement-modal'
-import { ANNOUNCEMENT } from 'config'
+import { ANNOUNCEMENT, getAnnouncementVersion } from 'config'
 
 const ITEMS_PER_PAGE = 10
 
@@ -89,7 +89,7 @@ const Campaigns = () => {
     // TODO: refactor out num demos processing
     async function getNumDemosAndAnnouncementVersion() {
       const { demo, announcementVersion } = await getUserSettings()
-      const latestAnnouncementVersion = await ANNOUNCEMENT.version
+      const latestAnnouncementVersion = await getAnnouncementVersion()
       setIsDemoDisplayed(demo?.isDisplayed)
       setNumDemosSms(demo?.numDemosSms)
       setNumDemosTelegram(demo?.numDemosTelegram)

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -66,18 +66,13 @@ const Campaigns = () => {
     setLoading(false)
   }
 
-  // Returns true if the current version is different from the last seen version
-  function compareVersions(lastSeenVersion: string, currentVersion: string) {
-    return lastSeenVersion !== currentVersion
-  }
-
   // Only call the modalContext if content is currently null - prevents infinite re-rendering
   // Note that this triggers unnecessary network calls because useCallback evaluates the function being passed in
   const displayNewAnnouncement = useCallback(
-    (userAnnouncementVersion: string, latestAnnouncementVersion: string) => {
+    (lastSeenVersion: string, currentVersion: string) => {
       if (
         ANNOUNCEMENT.isActive &&
-        compareVersions(userAnnouncementVersion, latestAnnouncementVersion) &&
+        lastSeenVersion !== currentVersion &&
         modalContext.modalContent === null
       ) {
         modalContext.setModalContent(<AnnouncementModal />)

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -26,7 +26,6 @@ import CreateDemoModal from 'components/dashboard/demo/create-demo-modal'
 import { getUserSettings } from 'services/settings.service'
 import DuplicateCampaignModal from '../create/duplicate-campaign-modal'
 import AnnouncementModal from './announcement-modal'
-import { i18n } from 'locales'
 import { ANNOUNCEMENT } from 'config'
 
 const ITEMS_PER_PAGE = 10
@@ -67,38 +66,18 @@ const Campaigns = () => {
     setLoading(false)
   }
 
-  // Returns true if lastSeenVersion < currentPackageVersion, else false
-  function compareSemver(
-    lastSeenVersion: string,
-    currentPackageVersion: string
-  ) {
-    if (!lastSeenVersion) {
-      return true
-    }
-    const lastSeenSplit = lastSeenVersion
-      .split('.')
-      .map((num) => parseInt(num, 10))
-    const currentSplit = currentPackageVersion
-      .split('.')
-      .map((num) => parseInt(num, 10))
-    for (let i = 0; i < 3; i++) {
-      if (lastSeenSplit[i] < currentSplit[i]) {
-        return true
-      }
-      if (lastSeenSplit[i] > currentSplit[i]) {
-        return false
-      }
-    }
-    return false
+  // Returns true if the current version is different from the last seen version
+  function compareVersions(lastSeenVersion: string, currentVersion: string) {
+    return lastSeenVersion !== currentVersion
   }
 
   // Only call the modalContext if content is currently null - prevents infinite re-rendering
   // Note that this triggers unnecessary network calls because useCallback evaluates the function being passed in
   const displayNewAnnouncement = useCallback(
-    (userAnnouncementVersion: string) => {
+    (userAnnouncementVersion: string, latestAnnouncementVersion: string) => {
       if (
         ANNOUNCEMENT.isActive &&
-        compareSemver(userAnnouncementVersion, i18n._(ANNOUNCEMENT.version)) &&
+        compareVersions(userAnnouncementVersion, latestAnnouncementVersion) &&
         modalContext.modalContent === null
       ) {
         modalContext.setModalContent(<AnnouncementModal />)
@@ -115,10 +94,11 @@ const Campaigns = () => {
     // TODO: refactor out num demos processing
     async function getNumDemosAndAnnouncementVersion() {
       const { demo, announcementVersion } = await getUserSettings()
+      const latestAnnouncementVersion = await ANNOUNCEMENT.version
       setIsDemoDisplayed(demo?.isDisplayed)
       setNumDemosSms(demo?.numDemosSms)
       setNumDemosTelegram(demo?.numDemosTelegram)
-      displayNewAnnouncement(announcementVersion)
+      displayNewAnnouncement(announcementVersion, latestAnnouncementVersion)
     }
     getNumDemosAndAnnouncementVersion()
   }, [displayNewAnnouncement])

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
@@ -1,18 +1,4 @@
 @import 'styles/_variables';
-@import 'styles/_mixins';
-
-$modal-width: $tablet;
-$title-height: $height-4;
-.modalBg {
-  @include flex-center();
-  background: adjust-color($secondary, $alpha: -0.05);
-  position: fixed;
-  width: 100vw;
-  height: 100vh;
-  z-index: 120;
-  top: 0;
-  left: 0;
-}
 
 .modal {
   max-width: 100vw;
@@ -28,59 +14,5 @@ $title-height: $height-4;
     border-radius: 0;
     min-height: 100vh;
     padding: 0px;
-  }
-}
-
-.title {
-  margin-bottom: 0px;
-}
-
-.titleTop {
-  margin-top: 0px;
-}
-
-.titleCentered {
-  margin-top: 24px;
-  text-align: center;
-}
-
-.modalMedia {
-  margin-top: 24px;
-  max-width: 100%;
-}
-
-.modalImg {
-  max-height: 250px;
-
-  @include mobile() {
-    max-height: 20vh;
-  }
-}
-
-.content {
-  max-width: 100vw;
-  margin-top: 24px;
-  text-align: center;
-}
-
-.close {
-  position: absolute;
-  top: 2rem;
-  right: 2rem;
-  &.modalTitleClose {
-    color: $green-900;
-    top: calc(#{$title-height} / 2 - 1.5rem); // close button has height of 3rem
-  }
-}
-
-.options {
-  margin-top: 24px;
-
-  @include mobile {
-    padding-bottom: 24px;
-  }
-
-  & > *:not(:first-child) {
-    margin-left: $spacing-7;
   }
 }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
@@ -39,8 +39,9 @@ $title-height: $height-4;
   margin-top: 25px;
 }
 
-.modalImg {
+.modalMedia {
   max-height: 250px;
+  max-width: 100%;
 
   @include mobile() {
     max-height: 20vh;

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
@@ -40,12 +40,12 @@ $title-height: $height-4;
 }
 
 .titleCentered {
-  margin-top: 25px;
+  margin-top: 24px;
   text-align: center;
 }
 
 .modalMedia {
-  margin-top: 25px;
+  margin-top: 24px;
   max-width: 100%;
 }
 
@@ -59,7 +59,7 @@ $title-height: $height-4;
 
 .content {
   max-width: 100vw;
-  margin-top: 25px;
+  margin-top: 24px;
   text-align: center;
 }
 
@@ -74,10 +74,10 @@ $title-height: $height-4;
 }
 
 .options {
-  margin-top: 25px;
+  margin-top: 24px;
 
   @include mobile {
-    padding-bottom: 25px;
+    padding-bottom: 24px;
   }
 
   & > *:not(:first-child) {

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
@@ -13,6 +13,6 @@
   @include mobile {
     border-radius: 0;
     min-height: 100vh;
-    padding: 0px;
+    padding: 0;
   }
 }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.module.scss
@@ -19,9 +19,7 @@ $title-height: $height-4;
   border-radius: 0.6rem;
   background-color: $neutral-light;
   height: auto;
-  max-height: calc(70vh);
   position: relative;
-  padding: 2rem;
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -34,14 +32,25 @@ $title-height: $height-4;
 }
 
 .title {
-  text-align: center;
   margin-bottom: 0px;
+}
+
+.titleTop {
+  margin-top: 0px;
+}
+
+.titleCentered {
   margin-top: 25px;
+  text-align: center;
 }
 
 .modalMedia {
-  max-height: 250px;
+  margin-top: 25px;
   max-width: 100%;
+}
+
+.modalImg {
+  max-height: 250px;
 
   @include mobile() {
     max-height: 20vh;
@@ -50,7 +59,7 @@ $title-height: $height-4;
 
 .content {
   max-width: 100vw;
-  margin: 25px 0px;
+  margin-top: 25px;
   text-align: center;
 }
 
@@ -65,7 +74,13 @@ $title-height: $height-4;
 }
 
 .options {
+  margin-top: 25px;
+
   @include mobile {
     padding-bottom: 25px;
+  }
+
+  & > *:not(:first-child) {
+    margin-left: $spacing-7;
   }
 }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -17,7 +17,7 @@ const AnnouncementModal = () => {
   useEffect(() => {
     setBeforeClose(() => async () => {
       try {
-        await updateAnnouncementVersion(i18n._(ANNOUNCEMENT.version))
+        await updateAnnouncementVersion(await ANNOUNCEMENT.version)
       } catch (err) {
         setErrorMessage(err.message)
       }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -9,6 +9,13 @@ import styles from './AnnouncementModal.module.scss'
 import { i18n } from 'locales'
 import { ANNOUNCEMENT } from 'config'
 import { OutboundLink } from 'react-ga'
+import ReactPlayer from 'react-player/lazy'
+
+function isVideoUrl(url: string) {
+  url = url.toLowerCase()
+  const VIDEO_EXTENSIONS = ['mp4']
+  return VIDEO_EXTENSIONS.some((extension) => url.endsWith(`.${extension}`))
+}
 
 const AnnouncementModal = () => {
   const { close, setBeforeClose } = useContext(ModalContext)
@@ -33,13 +40,30 @@ const AnnouncementModal = () => {
     }
   }
 
-  return (
-    <div className={styles.modal}>
+  const mediaUrl = i18n._(ANNOUNCEMENT.mediaUrl)
+  let mediaContent = null
+  if (isVideoUrl(mediaUrl)) {
+    mediaContent = (
+      <ReactPlayer
+        url={mediaUrl}
+        className={styles.modalMedia}
+        controls
+        playing
+      />
+    )
+  } else {
+    mediaContent = (
       <img
-        className={styles.modalImg}
-        src={i18n._(ANNOUNCEMENT.imageUrl)}
+        className={styles.modalMedia}
+        src={mediaUrl}
         alt="Modal graphic"
       ></img>
+    )
+  }
+
+  return (
+    <div className={styles.modal}>
+      {mediaContent}
       <h4 className={styles.title}>{i18n._(ANNOUNCEMENT.title)}</h4>
       <div className={styles.content}>{i18n._(ANNOUNCEMENT.subtext)}</div>
       <div className={styles.options}>

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect } from 'react'
 import cx from 'classnames'
 import { updateAnnouncementVersion } from 'services/settings.service'
 
-import { PrimaryButton, ErrorBlock } from 'components/common'
+import { PrimaryButton, ErrorBlock, TextButton } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'
 
 import styles from './AnnouncementModal.module.scss'
@@ -41,39 +41,83 @@ const AnnouncementModal = () => {
   }
 
   const mediaUrl = i18n._(ANNOUNCEMENT.mediaUrl)
-  let mediaContent = null
+  let mediaAndTitle = null
   if (isVideoUrl(mediaUrl)) {
-    mediaContent = (
-      <ReactPlayer
-        url={mediaUrl}
-        className={styles.modalMedia}
-        controls
-        playing
-      />
+    mediaAndTitle = (
+      <>
+        <h4 className={`${styles.title} ${styles.titleTop}`}>
+          {i18n._(ANNOUNCEMENT.title)}
+        </h4>
+        <ReactPlayer
+          url={mediaUrl}
+          className={styles.modalMedia}
+          controls
+          playing
+          width="100%"
+          height="100%"
+        />
+      </>
     )
   } else {
-    mediaContent = (
-      <img
-        className={styles.modalMedia}
-        src={mediaUrl}
-        alt="Modal graphic"
-      ></img>
+    mediaAndTitle = (
+      <>
+        <img
+          className={`${styles.modalMedia} ${styles.modalImg}`}
+          src={mediaUrl}
+          alt="Modal graphic"
+        ></img>
+        <h4 className={`${styles.title} ${styles.titleCentered}`}>
+          {i18n._(ANNOUNCEMENT.title)}
+        </h4>
+      </>
     )
+  }
+
+  // In lingui, we can't simply leave a translation empty as a default will be used during compilation.
+  // Instead, mark it as "null" to indicate that it is empty.
+  const EMPTY_TRANSLATION = 'null'
+  const subtextText = i18n._(ANNOUNCEMENT.subtext)
+  let subtext = null
+  if (subtextText !== EMPTY_TRANSLATION) {
+    subtext = <div className={styles.content}>{subtextText}</div>
+  }
+
+  const secondaryButtonText = i18n._(ANNOUNCEMENT.secondaryButtonText)
+  let secondaryLink = null
+  if (secondaryButtonText !== EMPTY_TRANSLATION) {
+    // If the URL is non-empty, the secondary button is an external link.
+    // Otherwise, it is just a button to close the modal.
+    secondaryLink = (
+      <TextButton onClick={onReadMoreClicked}>{secondaryButtonText}</TextButton>
+    )
+
+    const secondaryButtonUrl = i18n._(ANNOUNCEMENT.secondaryButtonUrl)
+    if (secondaryButtonUrl !== EMPTY_TRANSLATION) {
+      secondaryLink = (
+        <OutboundLink
+          eventLabel={secondaryButtonUrl}
+          to={secondaryButtonUrl}
+          target="_blank"
+        >
+          {secondaryLink}
+        </OutboundLink>
+      )
+    }
   }
 
   return (
     <div className={styles.modal}>
-      {mediaContent}
-      <h4 className={styles.title}>{i18n._(ANNOUNCEMENT.title)}</h4>
-      <div className={styles.content}>{i18n._(ANNOUNCEMENT.subtext)}</div>
+      {mediaAndTitle}
+      {subtext}
       <div className={styles.options}>
+        {secondaryLink}
         <OutboundLink
-          eventLabel={i18n._(ANNOUNCEMENT.buttonUrl)}
-          to={i18n._(ANNOUNCEMENT.buttonUrl)}
+          eventLabel={i18n._(ANNOUNCEMENT.primaryButtonUrl)}
+          to={i18n._(ANNOUNCEMENT.primaryButtonUrl)}
           target="_blank"
         >
           <PrimaryButton onClick={onReadMoreClicked}>
-            <span>{i18n._(ANNOUNCEMENT.buttonText)}</span>
+            <span>{i18n._(ANNOUNCEMENT.primaryButtonText)}</span>
             <i className={cx('bx', styles.icon, 'bx-right-arrow-alt')}></i>
           </PrimaryButton>
         </OutboundLink>{' '}

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -1,15 +1,53 @@
 import React, { useContext, useState, useEffect } from 'react'
-import cx from 'classnames'
 import { updateAnnouncementVersion } from 'services/settings.service'
 
-import { PrimaryButton, ErrorBlock, TextButton } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'
 
-import styles from './AnnouncementModal.module.scss'
 import { i18n } from 'locales'
 import { ANNOUNCEMENT, getAnnouncementVersion } from 'config'
-import { OutboundLink } from 'react-ga'
-import ReactPlayer from 'react-player/lazy'
+import { ErrorBlock } from 'components/common'
+import GraphicAnnouncementModal from './GraphicAnnouncementModal'
+import VideoAnnouncementModal from './VideoAnnouncementModal'
+import styles from './AnnouncementModal.module.scss'
+
+export type Translation = string | undefined
+
+export type AnnouncementModalProps = {
+  title: Translation
+  mediaUrl: Translation
+  subtext: Translation
+  primaryButtonUrl: Translation
+  primaryButtonText: Translation
+  secondaryButtonUrl: Translation
+  secondaryButtonText: Translation
+  handleReadMoreClicked: () => Promise<void>
+}
+
+type Translations = Omit<AnnouncementModalProps, 'handleReadMoreClicked'>
+
+function getTranslations(): Translations {
+  // In lingui, we can't simply leave a translation empty as a default will be used during compilation.
+  // Instead, mark it as "null" to indicate that it is empty.
+  const EMPTY_TRANSLATION = 'null'
+  const KEYS = [
+    'title',
+    'subtext',
+    'mediaUrl',
+    'primaryButtonUrl',
+    'primaryButtonText',
+    'secondaryButtonUrl',
+    'secondaryButtonText',
+  ]
+  return KEYS.reduce((acc: Record<string, Translation>, cur) => {
+    let translation: Translation = i18n._(ANNOUNCEMENT[cur])
+    // Convert any "null" translations to undefined to make it simpler to parse
+    if (translation === EMPTY_TRANSLATION) {
+      translation = undefined
+    }
+    acc[cur] = translation
+    return acc
+  }, {}) as Translations
+}
 
 function isVideoUrl(url: string) {
   url = url.toLowerCase()
@@ -40,88 +78,28 @@ const AnnouncementModal = () => {
     }
   }
 
-  const mediaUrl = i18n._(ANNOUNCEMENT.mediaUrl)
-  let mediaAndTitle = null
-  if (isVideoUrl(mediaUrl)) {
-    mediaAndTitle = (
-      <>
-        <h4 className={`${styles.title} ${styles.titleTop}`}>
-          {i18n._(ANNOUNCEMENT.title)}
-        </h4>
-        <ReactPlayer
-          url={mediaUrl}
-          className={styles.modalMedia}
-          controls
-          playing
-          width="100%"
-          height="100%"
-        />
-      </>
+  // Render the appropriate modal based on the type of content
+  const translations = getTranslations()
+  let specificAnnouncementModal = null
+  if (isVideoUrl(translations.mediaUrl!)) {
+    specificAnnouncementModal = (
+      <VideoAnnouncementModal
+        {...translations}
+        handleReadMoreClicked={onReadMoreClicked}
+      />
     )
   } else {
-    mediaAndTitle = (
-      <>
-        <img
-          className={`${styles.modalMedia} ${styles.modalImg}`}
-          src={mediaUrl}
-          alt="Modal graphic"
-        ></img>
-        <h4 className={`${styles.title} ${styles.titleCentered}`}>
-          {i18n._(ANNOUNCEMENT.title)}
-        </h4>
-      </>
+    specificAnnouncementModal = (
+      <GraphicAnnouncementModal
+        {...translations}
+        handleReadMoreClicked={onReadMoreClicked}
+      />
     )
-  }
-
-  // In lingui, we can't simply leave a translation empty as a default will be used during compilation.
-  // Instead, mark it as "null" to indicate that it is empty.
-  const EMPTY_TRANSLATION = 'null'
-  const subtextText = i18n._(ANNOUNCEMENT.subtext)
-  let subtext = null
-  if (subtextText !== EMPTY_TRANSLATION) {
-    subtext = <div className={styles.content}>{subtextText}</div>
-  }
-
-  const secondaryButtonText = i18n._(ANNOUNCEMENT.secondaryButtonText)
-  let secondaryLink = null
-  if (secondaryButtonText !== EMPTY_TRANSLATION) {
-    // If the URL is non-empty, the secondary button is an external link.
-    // Otherwise, it is just a button to close the modal.
-    secondaryLink = (
-      <TextButton onClick={onReadMoreClicked}>{secondaryButtonText}</TextButton>
-    )
-
-    const secondaryButtonUrl = i18n._(ANNOUNCEMENT.secondaryButtonUrl)
-    if (secondaryButtonUrl !== EMPTY_TRANSLATION) {
-      secondaryLink = (
-        <OutboundLink
-          eventLabel={secondaryButtonUrl}
-          to={secondaryButtonUrl}
-          target="_blank"
-        >
-          {secondaryLink}
-        </OutboundLink>
-      )
-    }
   }
 
   return (
     <div className={styles.modal}>
-      {mediaAndTitle}
-      {subtext}
-      <div className={styles.options}>
-        {secondaryLink}
-        <OutboundLink
-          eventLabel={i18n._(ANNOUNCEMENT.primaryButtonUrl)}
-          to={i18n._(ANNOUNCEMENT.primaryButtonUrl)}
-          target="_blank"
-        >
-          <PrimaryButton onClick={onReadMoreClicked}>
-            <span>{i18n._(ANNOUNCEMENT.primaryButtonText)}</span>
-            <i className={cx('bx', styles.icon, 'bx-right-arrow-alt')}></i>
-          </PrimaryButton>
-        </OutboundLink>{' '}
-      </div>
+      {specificAnnouncementModal}
       <ErrorBlock>{errorMessage}</ErrorBlock>
     </div>
   )

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -10,26 +10,27 @@ import GraphicAnnouncementModal from './GraphicAnnouncementModal'
 import VideoAnnouncementModal from './VideoAnnouncementModal'
 import styles from './AnnouncementModal.module.scss'
 
-export type Translation = string | undefined
-
 export type AnnouncementModalProps = {
-  title: Translation
-  mediaUrl: Translation
-  subtext: Translation
-  primaryButtonUrl: Translation
-  primaryButtonText: Translation
-  secondaryButtonUrl: Translation
-  secondaryButtonText: Translation
+  title: string
+  primaryButtonUrl: string
+  primaryButtonText: string
   handleReadMoreClicked: () => Promise<void>
+
+  // Optional parameters
+  mediaUrl?: string
+  subtext?: string
+  secondaryButtonUrl?: string
+  secondaryButtonText?: string
 }
 
-type Translations = Omit<AnnouncementModalProps, 'handleReadMoreClicked'>
+type AnnouncementContent = Omit<AnnouncementModalProps, 'handleReadMoreClicked'>
 
-function getTranslations(): Translations {
-  // In lingui, we can't simply leave a translation empty as a default will be used during compilation.
+function getAnnouncementContent(): AnnouncementContent {
+  // In lingui, we can't simply leave a translation empty as it will be replaced
+  // by a default value during compilation.
   // Instead, mark it as "null" to indicate that it is empty.
   const EMPTY_TRANSLATION = 'null'
-  const KEYS = [
+  const KEYS: Array<keyof AnnouncementContent> = [
     'title',
     'subtext',
     'mediaUrl',
@@ -38,15 +39,15 @@ function getTranslations(): Translations {
     'secondaryButtonUrl',
     'secondaryButtonText',
   ]
-  return KEYS.reduce((acc: Record<string, Translation>, cur) => {
-    let translation: Translation = i18n._(ANNOUNCEMENT[cur])
-    // Convert any "null" translations to undefined to make it simpler to parse
-    if (translation === EMPTY_TRANSLATION) {
-      translation = undefined
+  const content: Partial<AnnouncementContent> = {}
+  for (const key of KEYS) {
+    const translation = i18n._(ANNOUNCEMENT[key])
+    // Omit "null"/empty translations
+    if (translation !== EMPTY_TRANSLATION) {
+      content[key] = translation
     }
-    acc[cur] = translation
-    return acc
-  }, {}) as Translations
+  }
+  return content as AnnouncementContent
 }
 
 function isVideoUrl(url: string) {
@@ -79,19 +80,19 @@ const AnnouncementModal = () => {
   }
 
   // Render the appropriate modal based on the type of content
-  const translations = getTranslations()
+  const content = getAnnouncementContent()
   let specificAnnouncementModal = null
-  if (isVideoUrl(translations.mediaUrl!)) {
+  if (content.mediaUrl && isVideoUrl(content.mediaUrl)) {
     specificAnnouncementModal = (
       <VideoAnnouncementModal
-        {...translations}
+        {...content}
         handleReadMoreClicked={onReadMoreClicked}
       />
     )
   } else {
     specificAnnouncementModal = (
       <GraphicAnnouncementModal
-        {...translations}
+        {...content}
         handleReadMoreClicked={onReadMoreClicked}
       />
     )

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModal.tsx
@@ -7,7 +7,7 @@ import { ModalContext } from 'contexts/modal.context'
 
 import styles from './AnnouncementModal.module.scss'
 import { i18n } from 'locales'
-import { ANNOUNCEMENT } from 'config'
+import { ANNOUNCEMENT, getAnnouncementVersion } from 'config'
 import { OutboundLink } from 'react-ga'
 import ReactPlayer from 'react-player/lazy'
 
@@ -24,7 +24,7 @@ const AnnouncementModal = () => {
   useEffect(() => {
     setBeforeClose(() => async () => {
       try {
-        await updateAnnouncementVersion(await ANNOUNCEMENT.version)
+        await updateAnnouncementVersion(await getAnnouncementVersion())
       } catch (err) {
         setErrorMessage(err.message)
       }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.module.scss
@@ -1,0 +1,7 @@
+@import 'styles/_variables';
+
+.container {
+  & > .option:not(:first-child) {
+    margin-left: $spacing-7;
+  }
+}

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { TextButton, PrimaryButton } from 'components/common'
+import { OutboundLink } from 'react-ga'
+import cx from 'classnames'
+
+import { Translation } from './AnnouncementModal'
+import styles from './AnnouncementModalOptions.module.scss'
+
+interface AnnouncementModalOptionsProps {
+  primaryButtonUrl: Translation
+  primaryButtonText: Translation
+  secondaryButtonUrl: Translation
+  secondaryButtonText: Translation
+  handleReadMoreClicked: () => Promise<void>
+}
+
+const AnnouncementModalOptions = ({
+  primaryButtonUrl,
+  primaryButtonText,
+  secondaryButtonUrl,
+  secondaryButtonText,
+  handleReadMoreClicked,
+}: AnnouncementModalOptionsProps) => {
+  let secondaryLink = null
+  if (secondaryButtonText !== undefined) {
+    // If the URL is non-empty, the secondary button is an external link.
+    // Otherwise, it is just a button to close the modal.
+    secondaryLink = (
+      <TextButton className={styles.option} onClick={handleReadMoreClicked}>
+        {secondaryButtonText}
+      </TextButton>
+    )
+
+    if (secondaryButtonUrl !== undefined) {
+      secondaryLink = (
+        <OutboundLink
+          className={styles.option}
+          eventLabel={secondaryButtonUrl}
+          to={secondaryButtonUrl}
+          target="_blank"
+        >
+          {secondaryLink}
+        </OutboundLink>
+      )
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      {secondaryLink}
+      <OutboundLink
+        className={styles.option}
+        eventLabel={primaryButtonUrl!}
+        to={primaryButtonUrl!}
+        target="_blank"
+      >
+        <PrimaryButton onClick={handleReadMoreClicked}>
+          <span>{primaryButtonText!}</span>
+          <i className={cx('bx', styles.icon, 'bx-right-arrow-alt')}></i>
+        </PrimaryButton>
+      </OutboundLink>{' '}
+    </div>
+  )
+}
+
+export default AnnouncementModalOptions

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/AnnouncementModalOptions.tsx
@@ -3,15 +3,16 @@ import { TextButton, PrimaryButton } from 'components/common'
 import { OutboundLink } from 'react-ga'
 import cx from 'classnames'
 
-import { Translation } from './AnnouncementModal'
 import styles from './AnnouncementModalOptions.module.scss'
 
 interface AnnouncementModalOptionsProps {
-  primaryButtonUrl: Translation
-  primaryButtonText: Translation
-  secondaryButtonUrl: Translation
-  secondaryButtonText: Translation
+  primaryButtonUrl: string
+  primaryButtonText: string
   handleReadMoreClicked: () => Promise<void>
+
+  // Optional parameters
+  secondaryButtonUrl?: string
+  secondaryButtonText?: string
 }
 
 const AnnouncementModalOptions = ({
@@ -21,17 +22,17 @@ const AnnouncementModalOptions = ({
   secondaryButtonText,
   handleReadMoreClicked,
 }: AnnouncementModalOptionsProps) => {
+  // The secondary button closes the modal.
+  // If the secondary URL is defined, the button also navigates to the specified URL.
   let secondaryLink = null
-  if (secondaryButtonText !== undefined) {
-    // If the URL is non-empty, the secondary button is an external link.
-    // Otherwise, it is just a button to close the modal.
+  if (secondaryButtonText) {
     secondaryLink = (
       <TextButton className={styles.option} onClick={handleReadMoreClicked}>
         {secondaryButtonText}
       </TextButton>
     )
 
-    if (secondaryButtonUrl !== undefined) {
+    if (secondaryButtonUrl) {
       secondaryLink = (
         <OutboundLink
           className={styles.option}
@@ -50,12 +51,12 @@ const AnnouncementModalOptions = ({
       {secondaryLink}
       <OutboundLink
         className={styles.option}
-        eventLabel={primaryButtonUrl!}
-        to={primaryButtonUrl!}
+        eventLabel={primaryButtonUrl}
+        to={primaryButtonUrl}
         target="_blank"
       >
         <PrimaryButton onClick={handleReadMoreClicked}>
-          <span>{primaryButtonText!}</span>
+          <span>{primaryButtonText}</span>
           <i className={cx('bx', styles.icon, 'bx-right-arrow-alt')}></i>
         </PrimaryButton>
       </OutboundLink>{' '}

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.module.scss
@@ -1,3 +1,4 @@
+@import 'styles/_variables';
 @import 'styles/_mixins';
 
 .graphic {
@@ -10,15 +11,15 @@
 
 .title {
   text-align: center;
-  margin-top: 32px;
+  margin-top: $spacing-5;
   margin-bottom: 0px;
 }
 
 .subtext {
-  margin-top: 32px;
+  margin-top: $spacing-5;
   text-align: center;
 }
 
 .options {
-  margin-top: 48px;
+  margin-top: $spacing-7;
 }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.module.scss
@@ -1,0 +1,24 @@
+@import 'styles/_mixins';
+
+.graphic {
+  max-height: 250px;
+
+  @include mobile() {
+    max-height: 20vh;
+  }
+}
+
+.title {
+  text-align: center;
+  margin-top: 32px;
+  margin-bottom: 0px;
+}
+
+.subtext {
+  margin-top: 32px;
+  text-align: center;
+}
+
+.options {
+  margin-top: 48px;
+}

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import styles from './GraphicAnnouncementModal.module.scss'
+import AnnouncementModalOptions from './AnnouncementModalOptions'
+import { AnnouncementModalProps } from './AnnouncementModal'
+
+const GraphicAnnouncementModal = ({
+  title,
+  mediaUrl,
+  subtext,
+  primaryButtonUrl,
+  primaryButtonText,
+  secondaryButtonUrl,
+  secondaryButtonText,
+  handleReadMoreClicked,
+}: AnnouncementModalProps) => {
+  return (
+    <>
+      <img className={styles.graphic} src={mediaUrl} alt="Modal graphic"></img>
+      <h4 className={styles.title}>{title}</h4>
+      <div className={styles.subtext}>{subtext}</div>
+      <div className={styles.options}>
+        <AnnouncementModalOptions
+          primaryButtonText={primaryButtonText}
+          primaryButtonUrl={primaryButtonUrl}
+          secondaryButtonText={secondaryButtonText}
+          secondaryButtonUrl={secondaryButtonUrl}
+          handleReadMoreClicked={handleReadMoreClicked}
+        />
+      </div>
+    </>
+  )
+}
+
+export default GraphicAnnouncementModal

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/GraphicAnnouncementModal.tsx
@@ -16,7 +16,13 @@ const GraphicAnnouncementModal = ({
 }: AnnouncementModalProps) => {
   return (
     <>
-      <img className={styles.graphic} src={mediaUrl} alt="Modal graphic"></img>
+      {mediaUrl && (
+        <img
+          className={styles.graphic}
+          src={mediaUrl}
+          alt="Modal graphic"
+        ></img>
+      )}
       <h4 className={styles.title}>{title}</h4>
       <div className={styles.subtext}>{subtext}</div>
       <div className={styles.options}>

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.module.scss
@@ -1,0 +1,12 @@
+.title {
+  margin-bottom: 0px;
+}
+
+.video {
+  margin-top: 48px;
+  max-width: 100%;
+}
+
+.options {
+  margin-top: 48px;
+}

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.module.scss
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.module.scss
@@ -1,12 +1,14 @@
+@import 'styles/_variables';
+
 .title {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .video {
-  margin-top: 48px;
+  margin-top: $spacing-7;
   max-width: 100%;
 }
 
 .options {
-  margin-top: 48px;
+  margin-top: $spacing-7;
 }

--- a/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.tsx
+++ b/frontend/src/components/dashboard/campaigns/announcement-modal/VideoAnnouncementModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import ReactPlayer from 'react-player/lazy'
+
+import styles from './VideoAnnouncementModal.module.scss'
+import { AnnouncementModalProps } from './AnnouncementModal'
+import AnnouncementModalOptions from './AnnouncementModalOptions'
+
+const VideoAnnouncementModal = ({
+  title,
+  mediaUrl,
+  primaryButtonUrl,
+  primaryButtonText,
+  secondaryButtonUrl,
+  secondaryButtonText,
+  handleReadMoreClicked,
+}: AnnouncementModalProps) => {
+  return (
+    <>
+      <h4 className={styles.title}>{title}</h4>
+      <ReactPlayer
+        url={mediaUrl}
+        className={styles.video}
+        controls
+        playing
+        width="100%"
+        height="100%"
+      />
+      <div className={styles.options}>
+        <AnnouncementModalOptions
+          primaryButtonUrl={primaryButtonUrl}
+          primaryButtonText={primaryButtonText}
+          secondaryButtonUrl={secondaryButtonUrl}
+          secondaryButtonText={secondaryButtonText}
+          handleReadMoreClicked={handleReadMoreClicked}
+        />
+      </div>
+    </>
+  )
+}
+
+export default VideoAnnouncementModal

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -72,8 +72,10 @@ export const ANNOUNCEMENT: any = {
   title: t('announcement.title')``,
   subtext: t('announcement.subtext')``,
   mediaUrl: t('announcement.mediaUrl')``,
-  buttonUrl: t('announcement.buttonUrl')``,
-  buttonText: t('announcement.buttonText')``,
+  primaryButtonUrl: t('announcement.primaryButtonUrl')``,
+  primaryButtonText: t('announcement.primaryButtonText')``,
+  secondaryButtonUrl: t('announcement.secondaryButtonUrl')``,
+  secondaryButtonText: t('announcement.secondaryButtonText')``,
 }
 
 // Lazily compute the announcement version and memoize it for future use.
@@ -86,8 +88,10 @@ export async function getAnnouncementVersion(): Promise<string> {
     'title',
     'subtext',
     'mediaUrl',
-    'buttonUrl',
-    'buttonText',
+    'primaryButtonUrl',
+    'primaryButtonText',
+    'secondaryButtonUrl',
+    'secondaryButtonText',
   ]
   const translations = HASHABLE_KEYS.map((key) => i18n._(ANNOUNCEMENT[key]))
   const concatenatedStr = translations.join(';')

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,5 +1,9 @@
 import axios from 'axios'
 import { t } from '@lingui/macro'
+import { i18n } from 'locales'
+
+import { sha256 } from './services/crypto.service'
+
 /**
  * React env vars are used for injecting variables at build time
  * https://create-react-app.dev/docs/adding-custom-environment-variables/#referencing-environment-variables-in-the-html
@@ -63,12 +67,32 @@ function getAnnouncementActive() {
 
 // Feature Launch Announcements
 // If `isActive` is false, the modal will not proc for ANY user
-export const ANNOUNCEMENT = {
+export const ANNOUNCEMENT: any = {
   isActive: getAnnouncementActive(),
-  version: t('announcement.version')``,
   title: t('announcement.title')``,
   subtext: t('announcement.subtext')``,
   imageUrl: t('announcement.imageUrl')``,
   buttonUrl: t('announcement.buttonUrl')``,
   buttonText: t('announcement.buttonText')``,
 }
+
+// Lazily compute the announcement version and memoize it for future use.
+let memoizedVersion: string | null = null
+export async function getAnnouncementVersion(): Promise<string> {
+  if (memoizedVersion !== null) {
+    return memoizedVersion
+  }
+  const HASHABLE_KEYS = [
+    'title',
+    'subtext',
+    'imageUrl',
+    'buttonUrl',
+    'buttonText',
+  ]
+  const translations = HASHABLE_KEYS.map((key) => i18n._(ANNOUNCEMENT[key]))
+  const concatenatedStr = translations.join(';')
+  memoizedVersion = await sha256(concatenatedStr)
+  return memoizedVersion
+}
+// Users of ANNOUNCEMENT.version have to await it.
+ANNOUNCEMENT.version = getAnnouncementVersion()

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -78,6 +78,7 @@ export const ANNOUNCEMENT: any = {
   secondaryButtonText: t('announcement.secondaryButtonText')``,
 }
 
+// Users of getAnnouncementVersion have to await it.
 // Lazily compute the announcement version and memoize it for future use.
 let memoizedVersion: string | null = null
 export async function getAnnouncementVersion(): Promise<string> {
@@ -98,5 +99,3 @@ export async function getAnnouncementVersion(): Promise<string> {
   memoizedVersion = await sha256(concatenatedStr)
   return memoizedVersion
 }
-// Users of ANNOUNCEMENT.version have to await it.
-ANNOUNCEMENT.version = getAnnouncementVersion()

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -67,7 +67,7 @@ function getAnnouncementActive() {
 
 // Feature Launch Announcements
 // If `isActive` is false, the modal will not proc for ANY user
-export const ANNOUNCEMENT: any = {
+export const ANNOUNCEMENT: Record<string, any> = {
   isActive: getAnnouncementActive(),
   title: t('announcement.title')``,
   subtext: t('announcement.subtext')``,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -71,7 +71,7 @@ export const ANNOUNCEMENT: any = {
   isActive: getAnnouncementActive(),
   title: t('announcement.title')``,
   subtext: t('announcement.subtext')``,
-  imageUrl: t('announcement.imageUrl')``,
+  mediaUrl: t('announcement.mediaUrl')``,
   buttonUrl: t('announcement.buttonUrl')``,
   buttonText: t('announcement.buttonText')``,
 }
@@ -85,7 +85,7 @@ export async function getAnnouncementVersion(): Promise<string> {
   const HASHABLE_KEYS = [
     'title',
     'subtext',
-    'imageUrl',
+    'mediaUrl',
     'buttonUrl',
     'buttonText',
   ]

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/common/progress-details/ProgressDetails.tsx:92
+#: src/components/common/progress-details/ProgressDetails.tsx:95
 msgid "Delivery report has expired and is no longer available for download."
 msgstr "Delivery report has expired and is no longer available for download."
 
@@ -21,11 +21,11 @@ msgstr "Delivery report has expired and is no longer available for download."
 msgid "Delivery report will expire 14 days after sending is completed."
 msgstr "Delivery report will expire 14 days after sending is completed."
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "Enter OTP"
 msgstr "Enter OTP"
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "Get OTP"
 msgstr "Get OTP"
 
@@ -33,31 +33,31 @@ msgstr "Get OTP"
 msgid "I'd rather stay"
 msgstr "I'd rather stay"
 
-#: src/components/login/login-input/LoginInput.tsx:79
+#: src/components/login/login-input/LoginInput.tsx:83
 msgid "One-Time Password"
 msgstr "One-Time Password"
 
-#: src/components/dashboard/campaigns/Campaigns.tsx:118
+#: src/components/dashboard/campaigns/Campaigns.tsx:138
 msgid "Report expired"
 msgstr "Report expired"
 
-#: src/components/login/login-input/LoginInput.tsx:82
+#: src/components/login/login-input/LoginInput.tsx:86
 msgid "Resend?"
 msgstr "Resend?"
 
-#: src/components/login/login-input/LoginInput.tsx:82
+#: src/components/login/login-input/LoginInput.tsx:86
 msgid "Resending OTP..."
 msgstr "Resending OTP..."
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "Sending OTP..."
 msgstr "Sending OTP..."
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "Sign In"
 msgstr "Sign In"
 
-#: src/components/login/login-input/LoginInput.tsx:79
+#: src/components/login/login-input/LoginInput.tsx:83
 msgid "Sign in with your gov.sg email"
 msgstr "Sign in with your gov.sg email"
 
@@ -65,40 +65,36 @@ msgstr "Sign in with your gov.sg email"
 msgid "Unsubscribe me"
 msgstr "Unsubscribe me"
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "Verifying OTP..."
 msgstr "Verifying OTP..."
 
-#: src/config.ts:48
+#: src/config.ts:59
 msgid "allowedImageSources"
 msgstr "file.go.gov.sg"
 
-#: src/config.ts:63
+#: src/config.ts:79
 msgid "announcement.buttonText"
 msgstr "Read guide"
 
-#: src/config.ts:62
+#: src/config.ts:78
 msgid "announcement.buttonUrl"
 msgstr "https://guide.postman.gov.sg/release-notes"
 
-#: src/config.ts:61
+#: src/config.ts:77
 msgid "announcement.imageUrl"
 msgstr "https://file.go.gov.sg/dz52q4.png"
 
-#: src/config.ts:60
+#: src/config.ts:76
 msgid "announcement.subtext"
 msgstr "Thanks for using Postman and joining us every step of the way while we mature as a product. We'll be releasing exciting new features this year. For instance, this is an announcement modal that will keep you up-to-date about our new features! Watch this space for things that are brewing. Learn more about Postman's releases by reading our guide."
 
-#: src/config.ts:59
+#: src/config.ts:75
 msgid "announcement.title"
 msgstr "Happy New Year! Congrats on making it through 2020."
 
-#: src/config.ts:58
-msgid "announcement.version"
-msgstr "1.17.2"
-
 #: src/components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
-#: src/config.ts:46
+#: src/config.ts:57
 msgid "defaultMailFrom"
 msgstr "donotreply@mail.postman.gov.sg"
 
@@ -110,7 +106,7 @@ msgstr "This demo campaign will be sent to a maximum of 20 recipients."
 msgid "demoMessageLabel"
 msgstr "DEMO"
 
-#: src/components/login/login-input/LoginInput.tsx:86
+#: src/components/login/login-input/LoginInput.tsx:90
 msgid "e.g. postman@agency.gov.sg"
 msgstr "e.g. postman@agency.gov.sg"
 
@@ -150,74 +146,74 @@ msgstr "Bot has been blocked by the recipient. Please contact the recipient via 
 msgid "errors.telegram.notSubscribed"
 msgstr "Recipient has not subscribed to your agency's bot - please ask them to subscribe before sending a message."
 
-#: src/config.ts:37
+#: src/config.ts:48
 msgid "link.contactUsUrl"
 msgstr "https://go.gov.sg/postman-contact-us"
 
-#: src/config.ts:38
+#: src/config.ts:49
 msgid "link.contributeUrl"
 msgstr "https://github.com/opengovsg/postmangovsg"
 
-#: src/config.ts:42
+#: src/config.ts:53
 msgid "link.customFromAddressRequestUrl"
 msgstr "https://go.gov.sg/postman-custom-from"
 
-#: src/config.ts:43
+#: src/config.ts:54
 msgid "link.demoTelegramBotUrl"
 msgstr "https://go.gov.sg/postmangovsgbot"
 
-#: src/config.ts:44
+#: src/config.ts:55
 msgid "link.demoVideoUrl"
 msgstr "https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/Demo+Campaign+Mode.mp4"
 
-#: src/config.ts:35
+#: src/config.ts:46
 msgid "link.guideDemoUrl"
 msgstr "https://guide.postman.gov.sg/before-you-start/demo-mode"
 
-#: src/config.ts:28
+#: src/config.ts:39
 msgid "link.guideEmailPasswordProtectedUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/password-protected-email"
 
-#: src/config.ts:34
+#: src/config.ts:45
 msgid "link.guidePowerUserUrl"
 msgstr "https://guide.postman.gov.sg/guide/power-users"
 
-#: src/config.ts:36
+#: src/config.ts:47
 msgid "link.guideRemoveDuplicatesUrl"
 msgstr "https://guide.postman.gov.sg/quick-start#remove-duplicates-in-excel"
 
-#: src/config.ts:30
+#: src/config.ts:41
 msgid "link.guideSmsAccountSidUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-1-account-sid-and-auth-token"
 
-#: src/config.ts:31
+#: src/config.ts:42
 msgid "link.guideSmsApiKeyUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-2-set-up-a-standard-api-key"
 
-#: src/config.ts:32
+#: src/config.ts:43
 msgid "link.guideSmsMessagingServiceUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-3-set-up-your-messaging-service"
 
-#: src/config.ts:29
+#: src/config.ts:40
 msgid "link.guideSmsUrl"
 msgstr "https://guide.postman.gov.sg/guide/getting-started/sms#find-twilio-credentials-on-twilio-console"
 
-#: src/config.ts:33
+#: src/config.ts:44
 msgid "link.guideTelegramUrl"
 msgstr "https://guide.postman.gov.sg/guide/getting-started/telegram-bot"
 
-#: src/config.ts:27
+#: src/config.ts:38
 msgid "link.guideUrl"
 msgstr "https://guide.postman.gov.sg"
 
-#: src/config.ts:40
+#: src/config.ts:51
 msgid "link.privacyUrl"
 msgstr "https://guide.postman.gov.sg/legal/privacy"
 
-#: src/config.ts:41
+#: src/config.ts:52
 msgid "link.reportBugUrl"
 msgstr "https://guide.postman.gov.sg/contact-us"
 
-#: src/config.ts:39
+#: src/config.ts:50
 msgid "link.tncUrl"
 msgstr "https://guide.postman.gov.sg/legal/t-and-c"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -73,17 +73,25 @@ msgstr "Verifying OTP..."
 msgid "allowedImageSources"
 msgstr "file.go.gov.sg"
 
-#: src/config.ts:79
-msgid "announcement.buttonText"
-msgstr "Read guide"
-
-#: src/config.ts:78
-msgid "announcement.buttonUrl"
-msgstr "https://guide.postman.gov.sg/release-notes"
-
 #: src/config.ts:77
 msgid "announcement.mediaUrl"
 msgstr "https://file.go.gov.sg/dz52q4.png"
+
+#: src/config.ts:79
+msgid "announcement.primaryButtonText"
+msgstr "Read guide"
+
+#: src/config.ts:78
+msgid "announcement.primaryButtonUrl"
+msgstr "https://guide.postman.gov.sg/release-notes"
+
+#: src/config.ts:81
+msgid "announcement.secondaryButtonText"
+msgstr "null"
+
+#: src/config.ts:80
+msgid "announcement.secondaryButtonUrl"
+msgstr "null"
 
 #: src/config.ts:76
 msgid "announcement.subtext"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -37,7 +37,7 @@ msgstr "I'd rather stay"
 msgid "One-Time Password"
 msgstr "One-Time Password"
 
-#: src/components/dashboard/campaigns/Campaigns.tsx:138
+#: src/components/dashboard/campaigns/Campaigns.tsx:137
 msgid "Report expired"
 msgstr "Report expired"
 
@@ -82,7 +82,7 @@ msgid "announcement.buttonUrl"
 msgstr "https://guide.postman.gov.sg/release-notes"
 
 #: src/config.ts:77
-msgid "announcement.imageUrl"
+msgid "announcement.mediaUrl"
 msgstr "https://file.go.gov.sg/dz52q4.png"
 
 #: src/config.ts:76


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_
This addresses issue #934. Namely,
1. SHA-256 version hashes are now being used instead of manual semantic versioning.
2. Videos can now be displayed (using the ReactPlayer component).
3. A secondary button can now be displayed.
4. The title will now be displayed at the upper left corner in the case of video content.

Closes #934.

## Before & After Screenshots

**BEFORE**:
See issue #934.

**AFTER**:
Screenshots of the updated UI on 3 different form factors (iPad Pro, iPhone 6, Pixel 2 XL): https://drive.google.com/drive/folders/1S5rvXi16geWbjo1jUdbwppMblFTd17ty?usp=sharing

## Tests

**Regarding version hashes:**
Before testing, ensure that `REACT_APP_ANNOUNCEMENT_ACTIVE="true"` is set in `.env`.

Tests:
- After closing the announcement modal, the `announcement_version` field in the `v1/settings` GET API should be updated to a 44-character base64 string.
- The `v1/settings/announcement` PUT API should only succeed with status 200 on 44-char base64 strings.
- The announcement modal should be displayed as long as the `announcement_version` field in the `v1/settings` GET API is different from the one computed in runtime.
- The announcement modal should not be displayed on subsequent runs after closing it.

**Regarding video modals:**
When testing videos, please set `announcement.subtext` to `null`. This allows the video to take up the full space.

Tests (when `announcement.mediaUrl` links to an MP4 file):
- The announcement modal should display a video which takes up most of the space along with a title and 1 or 2 buttons (see the screenshots).
- The video should not be distorted and should not occlude any UI elements (buttons, title).
- The video should display a play/pause button, a seekbar, the video time, and a full-screen option.
- The title should be displayed on the upper left corner.
- The dimensions of modal should not look awkward.

Tests (when `announcement.mediaUrl` links to an image file (e.g. PNG)):
- The announcement modal should now show the image instead of the video.
- The title should now be centered horizontally below the image.

**Regarding secondary buttons:**
Tests (when `announcement.secondaryButtonText` is not `null`:
- The announcement modal should display a secondary text button to the left of the primary button.
- The secondary button should be `3rem` away from the primary button. (see issue #876)
- The secondary button should be underlined on hover.
- The secondary button should have the color `#040651`. (see issue #876)
- Clicking the secondary button should simply close the modal and do nothing else.

Tests (when both `announcement.secondaryButtonText` and `announcement.secondaryButtonUrl` are not `null`):
- Clicking the secondary button should now close the modal _and_ open a new tab to the link.

Tests (when `secondaryButtonText` is `null`):
- The secondary button should no longer appear.