### PR TITLE
Fix some P3 UI issues

### DIFF
--- a/frontend/src/components/common/modal/Modal.module.scss
+++ b/frontend/src/components/common/modal/Modal.module.scss
@@ -43,7 +43,7 @@ $title-height: $height-4;
 .close {
   position: absolute;
   top: 2rem;
-  right: 2rem;
+  right: $spacing-1;
   &.modalTitleClose {
     color: $green-900;
     top: calc(#{$title-height} / 2 - 1.5rem); // close button has height of 3rem
@@ -58,6 +58,6 @@ $title-height: $height-4;
   min-height: $title-height;
   text-align: center;
   @include mobile {
-    padding-right: 3rem;
+    padding-right: 3.5rem;
   }
 }

--- a/frontend/src/components/common/modal/Modal.module.scss
+++ b/frontend/src/components/common/modal/Modal.module.scss
@@ -33,7 +33,7 @@ $title-height: $height-4;
 
 .content {
   max-width: 100vw;
-  padding: 3rem ($modal-width - 528px) / 2;
+  padding: 3rem ($modal-width - 600px) / 2;
   margin: auto;
   @include mobile() {
     padding: 6rem 3rem; // Need additional top padding to clear the close button

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -123,7 +123,7 @@ const ProgressDetails = ({
         <tbody>
           <tr>
             <td className={'md'}>
-              <Moment format="LLL">{sentAt}</Moment>
+              <Moment format="MMM DD YYYY, HH:mm">{sentAt}</Moment>
             </td>
 
             <td className={'md'}>{numRecipients}</td>

--- a/frontend/src/components/common/text-area/TextArea.module.scss
+++ b/frontend/src/components/common/text-area/TextArea.module.scss
@@ -21,9 +21,18 @@
       padding-bottom: 0.7rem;
     }
 
+    &:hover,
     &:focus {
       outline: none;
       border-color: $primary;
+    }
+
+    &:hover {
+      border-width: 1.5px;
+    }
+
+    &:focus {
+      border-width: 1px;
     }
 
     &::placeholder {

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -37,9 +37,14 @@ $modal-width: $tablet;
       justify-content: space-between;
       height: 4.5rem;
       border: 1px solid $primary;
+      cursor: default;
 
       .icon {
         @extend %icon-large;
+      }
+
+      &.active:hover {
+        background: $primary;
       }
 
       &:not(.active) {
@@ -49,6 +54,7 @@ $modal-width: $tablet;
         &:hover {
           background: $primary;
           color: white;
+          cursor: pointer;
         }
       }
     }

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -52,7 +52,7 @@ $modal-width: $tablet;
         background: transparent;
 
         &:hover {
-          background: $neutral-light;
+          background: rgba(181, 196, 255, 0.5);
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -49,11 +49,12 @@ $modal-width: $tablet;
 
       &:not(.active) {
         color: $primary;
-        background: $neutral-light;
+        background: transparent;
 
         &:hover {
-          background: $primary;
-          color: white;
+          background: $neutral;
+          border-width: 1.5px;
+          color: $primary;
           cursor: pointer;
         }
       }

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -52,7 +52,7 @@ $modal-width: $tablet;
         background: transparent;
 
         &:hover {
-          background: $neutral;
+          background: $neutral-light;
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -52,7 +52,7 @@ $modal-width: $tablet;
         background: transparent;
 
         &:hover {
-          background: rgba(181, 196, 255, 0.5);
+          background: rgba($primary-light, 0.5);
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.module.scss
@@ -3,10 +3,6 @@
 
 $modal-width: $tablet;
 
-.content {
-  margin-left: calc(78px - (#{$modal-width} - 528px) / 2);
-  margin-right: calc(78px - (#{$modal-width} - 528px) / 2);
-}
 .section {
   margin-bottom: 2rem;
   @include flex-vertical;

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -96,7 +96,11 @@ const CreateModal = ({
                 className={cx(styles.button, {
                   [styles.active]: selectedChannel === ChannelType.SMS,
                 })}
-                onClick={() => setSelectedChannel(ChannelType.SMS)}
+                onClick={
+                  selectedChannel === ChannelType.SMS
+                    ? undefined
+                    : () => setSelectedChannel(ChannelType.SMS)
+                }
               >
                 SMS
                 <i
@@ -127,7 +131,11 @@ const CreateModal = ({
                 className={cx(styles.button, {
                   [styles.active]: selectedChannel === ChannelType.Telegram,
                 })}
-                onClick={() => setSelectedChannel(ChannelType.Telegram)}
+                onClick={
+                  selectedChannel === ChannelType.Telegram
+                    ? undefined
+                    : () => setSelectedChannel(ChannelType.Telegram)
+                }
               >
                 Telegram
                 <i
@@ -156,7 +164,11 @@ const CreateModal = ({
                 className={cx(styles.button, {
                   [styles.active]: selectedChannel === ChannelType.Email,
                 })}
-                onClick={() => setSelectedChannel(ChannelType.Email)}
+                onClick={
+                  selectedChannel === ChannelType.Email
+                    ? undefined
+                    : () => setSelectedChannel(ChannelType.Email)
+                }
               >
                 Email
                 <i

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -42,6 +42,11 @@ $modal-width: $tablet;
       justify-content: space-between;
       height: 4.5rem;
       border: 1px solid $primary;
+      cursor: default;
+
+      &.active:hover {
+        background: $primary;
+      }
 
       &:not(.active) {
         color: $primary;
@@ -50,6 +55,7 @@ $modal-width: $tablet;
         &:hover {
           background: $primary;
           color: white;
+          cursor: pointer;
         }
       }
     }

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -43,11 +43,12 @@
 
       &:not(.active) {
         color: $primary;
-        background: $neutral-light;
+        background: transparent;
 
         &:hover {
-          background: $primary;
-          color: white;
+          background: $neutral;
+          border-width: 1.5px;
+          color: $primary;
           cursor: pointer;
         }
       }

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -1,13 +1,6 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
 
-$modal-width: $tablet;
-
-.content {
-  margin-left: calc(78px - (#{$modal-width} - 528px) / 2);
-  margin-right: calc(78px - (#{$modal-width} - 528px) / 2);
-}
-
 .section {
   margin-bottom: 2rem;
   @include flex-vertical;
@@ -94,24 +87,19 @@ $modal-width: $tablet;
 .actions {
   @include flex-horizontal;
   justify-content: flex-end;
-  button,
-  a {
-    margin: 0 20px;
-    &:last-child {
-      margin-right: 0px;
-    }
+
+  & > .action:not(:first-child) {
+    margin-left: $spacing-7;
   }
 
   @include mobile() {
     @include flex-vertical;
     align-items: center;
     width: 100%;
-    a {
-      margin-bottom: 1rem;
-    }
-    button:last-child,
-    a:last-child {
-      margin-left: 0px;
+
+    & > .action:not(:first-child) {
+      margin-top: $spacing-1;
+      margin-left: 0;
     }
   }
 }

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -46,7 +46,7 @@
         background: transparent;
 
         &:hover {
-          background: $neutral;
+          background: $neutral-light;
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -46,7 +46,7 @@
         background: transparent;
 
         &:hover {
-          background: rgba(181, 196, 255, 0.5);
+          background: rgba($primary-light, 0.5);
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -46,7 +46,7 @@
         background: transparent;
 
         &:hover {
-          background: $neutral-light;
+          background: rgba(181, 196, 255, 0.5);
           border-width: 1.5px;
           color: $primary;
           cursor: pointer;

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
@@ -153,11 +153,15 @@ const CreateDemoModal = ({
         </div>
         <div className="separator"></div>
         <div className={styles.actions}>
-          <TextButton minButtonWidth onClick={showDemoVideoModal}>
+          <TextButton className={styles.action} onClick={showDemoVideoModal}>
             Watch the video
           </TextButton>
 
-          <PrimaryButton onClick={createDemo} disabled={!isCreateEnabled}>
+          <PrimaryButton
+            className={styles.action}
+            onClick={createDemo}
+            disabled={!isCreateEnabled}
+          >
             Create demo campaign
           </PrimaryButton>
         </div>

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
@@ -117,7 +117,11 @@ const CreateDemoModal = ({
               className={cx(styles.button, {
                 [styles.active]: selectedChannel === ChannelType.SMS,
               })}
-              onClick={() => setSelectedChannel(ChannelType.SMS)}
+              onClick={
+                selectedChannel === ChannelType.SMS
+                  ? undefined
+                  : () => setSelectedChannel(ChannelType.SMS)
+              }
             >
               SMS
               <i
@@ -130,7 +134,11 @@ const CreateDemoModal = ({
               className={cx(styles.button, {
                 [styles.active]: selectedChannel === ChannelType.Telegram,
               })}
-              onClick={() => setSelectedChannel(ChannelType.Telegram)}
+              onClick={
+                selectedChannel === ChannelType.Telegram
+                  ? undefined
+                  : () => setSelectedChannel(ChannelType.Telegram)
+              }
             >
               Telegram
               <i

--- a/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.module.scss
@@ -27,18 +27,19 @@
 }
 .options {
   @include flex-horizontal;
+  margin-top: $spacing-4;
 
-  button {
-    margin-top: $spacing-4;
-    margin-right: $spacing-4;
-    &:last-child {
-      margin-right: 0;
-    }
+  & > .option:not(:first-child) {
+    margin-left: $spacing-7;
   }
+
   @include mobile() {
     @include flex-vertical;
-    button {
-      margin-right: 0;
+    align-items: center;
+
+    & > .option:not(:first-child) {
+      margin-left: 0;
+      margin-top: $spacing-1;
     }
   }
 }

--- a/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
+++ b/frontend/src/components/dashboard/demo/demo-video-modal/DemoVideoModal.tsx
@@ -45,11 +45,14 @@ const DemoVideoModal = ({
         .
       </div>
       <div className={styles.options}>
-        <TextButton minButtonWidth onClick={close}>
+        <TextButton className={styles.option} onClick={close}>
           Dismiss
         </TextButton>
         {!!numDemosSms || !!numDemosTelegram ? (
-          <PrimaryButton onClick={showCreateDemoModal}>
+          <PrimaryButton
+            className={styles.option}
+            onClick={showCreateDemoModal}
+          >
             Got it, I&apos;m ready to try
           </PrimaryButton>
         ) : (


### PR DESCRIPTION
## Problem

Addresses various miscellaneous UI issues.

Addresses issues #875, #876, #877, #911, #945.

## Tests

For #875:
- For the TextArea component:
  - Border width should become 1.5px on hover
  - Border color should become #2C2CDC on hover

For #876:
- For the DemoVideoModal and CreateDemoModal components:
  - In desktop mode, margin between the secondary TextButton and the PrimaryButton components should be $spacing-7 (3rem).
  - In mobile mode, the secondary TextButton should above the PrimaryButton, and the both of them should be aligned horizontally

For #877:
- For the CreateModal and CreateDemoModal components:
  - The actively selected campaign type button should not have any hover state
  - The actively selected campaign type button should not do anything on click

For #911:
- For the ProgressDetails component:
  - The sent date format should be MMM DD YYYY, HH:MM

For #945:
- For the CreateModal and CreateDemoModal components:
  - In mobile mode, there should be horizontal margins between the content and the edge of the display.
- Note: this decreases the horizontal padding on all modals in general (see: the change in Modal.tsx), but this should not degrade the UI since the original padding was a bit excessive compared to the Figma design.