### PR TITLE
Increase memory and cpu for verify backup service

### DIFF
--- a/serverless/verify-backup/scripts/deploy.sh
+++ b/serverless/verify-backup/scripts/deploy.sh
@@ -22,5 +22,5 @@ gcloud run deploy $GCLOUD_RUN_SERVICE_NAME \
   --set-env-vars `grep -v '^#' .env | awk -v ORS=, 'NF { print $1 }'` \
   --max-instances 1 \
   --timeout 8m \
-  --cpu 1 \
-  --memory 4Gi
+  --cpu 2 \
+  --memory 6Gi


### PR DESCRIPTION
## Problem

The verify backup production service failed today with the following memory exceeded error.
![image](https://user-images.githubusercontent.com/5744384/108796565-fc7c2900-75c3-11eb-8e6e-f34d14b1c16d.png)

Memory utilisation metrics during failure
![image](https://user-images.githubusercontent.com/5744384/108796707-541a9480-75c4-11eb-8546-e1664cdf8aac.png)

## Solution

Previously the memory allocation was 4Gi and the cpu allocation was 1 core, however for 1 core, raising the memory to 6Gi was not supported. 
The cloud run deploy cli threw the following error: `For 1.0 CPU, memory must be between 0 and 4Gi inclusive.`
Hence I tested with 2 cpu cores, 4Gi and 6Gi memory. 

![image](https://user-images.githubusercontent.com/5744384/108797281-d22b6b00-75c5-11eb-858a-0343a8764e3a.png)

With 4Gi memory allocation, the memory utilisation was hitting above 90% hence I set the final memory allocation to 6Gi to have some buffer.

**Improvements**:

- Increased cpu cores from 1 to 2
- Increased memory from 4Gi to 6Gi

**Observation after a week**
The verify backup service has been running smoothly. The memory utilisation is below 60% currently.
![image](https://user-images.githubusercontent.com/5744384/109911744-91c69e00-7ce5-11eb-8468-ce5b91a22cba.png)


## Tests

Deploy verify backup with the different memory allocations and observe metrics.

