### PR TITLE
chore: upgrade dependencies recommended by snyk

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8413,7 +8413,7 @@
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
-        "mustache": "^4.0.1",
+        "mustache": "^4.1.0",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
         "xss": "=1.0.6"
@@ -12846,9 +12846,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+          "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
         },
         "mute-stream": {
           "version": "0.0.8",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8409,7 +8409,7 @@
       "requires": {
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.168",
-        "@types/mustache": "^4.0.1",
+        "@types/mustache": "^4.1.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
@@ -9370,9 +9370,9 @@
           "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.1.tgz",
+          "integrity": "sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw=="
         },
         "@types/node": {
           "version": "14.14.22",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7096,9 +7096,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8408,7 +8408,7 @@
       "version": "file:../modules/postman-templating",
       "requires": {
         "@types/cheerio": "^0.22.22",
-        "@types/lodash": "^4.14.165",
+        "@types/lodash": "^4.14.168",
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
@@ -9365,9 +9365,9 @@
           "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/lodash": {
-          "version": "4.14.165",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-          "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+          "version": "4.14.168",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+          "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
           "version": "4.0.1",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8410,7 +8410,7 @@
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.165",
         "@types/mustache": "^4.0.1",
-        "@types/node": "^14.14.10",
+        "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
         "mustache": "^4.0.1",
@@ -9375,9 +9375,9 @@
           "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
         },
         "@types/node": {
-          "version": "14.14.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-          "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+          "version": "14.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+          "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
         },
         "@types/normalize-package-data": {
           "version": "2.4.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8412,7 +8412,7 @@
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.10",
         "cheerio": "^1.0.0-rc.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "mustache": "^4.0.1",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
@@ -12713,9 +12713,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.memoize": {
           "version": "4.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,7 +36,7 @@
     "helmet": "^3.22.0",
     "jsonwebtoken": "^8.5.1",
     "libphonenumber-js": "^1.7.54",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "module-alias": "^2.2.2",
     "morgan": "^1.10.0",
     "nodemailer": "^6.4.17",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9488,9 +9488,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12072,7 +12072,7 @@
       "requires": {
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.168",
-        "@types/mustache": "^4.0.1",
+        "@types/mustache": "^4.1.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
@@ -13033,9 +13033,9 @@
           "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.1.tgz",
+          "integrity": "sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw=="
         },
         "@types/node": {
           "version": "14.14.22",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12075,7 +12075,7 @@
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.10",
         "cheerio": "^1.0.0-rc.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "mustache": "^4.0.1",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
@@ -16376,9 +16376,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.memoize": {
           "version": "4.1.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12076,7 +12076,7 @@
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
-        "mustache": "^4.0.1",
+        "mustache": "^4.1.0",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
         "xss": "=1.0.6"
@@ -16509,9 +16509,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+          "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
         },
         "mute-stream": {
           "version": "0.0.8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12073,7 +12073,7 @@
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.165",
         "@types/mustache": "^4.0.1",
-        "@types/node": "^14.14.10",
+        "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
         "mustache": "^4.0.1",
@@ -13038,9 +13038,9 @@
           "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
         },
         "@types/node": {
-          "version": "14.14.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-          "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+          "version": "14.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+          "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
         },
         "@types/normalize-package-data": {
           "version": "2.4.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12071,7 +12071,7 @@
       "version": "file:../modules/postman-templating",
       "requires": {
         "@types/cheerio": "^0.22.22",
-        "@types/lodash": "^4.14.165",
+        "@types/lodash": "^4.14.168",
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
@@ -13028,9 +13028,9 @@
           "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/lodash": {
-          "version": "4.14.165",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-          "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+          "version": "4.14.168",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+          "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
           "version": "4.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "draftjs-to-html": "^0.9.1",
     "escape-html": "^1.0.3",
     "html-to-draftjs": "^1.5.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "moment": "^2.24.0",
     "papaparse": "^5.2.0",
     "postman-templating": "file:../modules/postman-templating",

--- a/modules/postman-templating/package-lock.json
+++ b/modules/postman-templating/package-lock.json
@@ -1046,9 +1046,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.165",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-      "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/mustache": {
       "version": "4.0.1",

--- a/modules/postman-templating/package-lock.json
+++ b/modules/postman-templating/package-lock.json
@@ -4763,9 +4763,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/modules/postman-templating/package-lock.json
+++ b/modules/postman-templating/package-lock.json
@@ -4914,9 +4914,9 @@
       "dev": true
     },
     "mustache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+      "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/modules/postman-templating/package-lock.json
+++ b/modules/postman-templating/package-lock.json
@@ -1051,9 +1051,9 @@
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
     },
     "@types/mustache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
-      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.1.tgz",
+      "integrity": "sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw=="
     },
     "@types/node": {
       "version": "14.14.22",

--- a/modules/postman-templating/package-lock.json
+++ b/modules/postman-templating/package-lock.json
@@ -1056,9 +1056,9 @@
       "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
     },
     "@types/node": {
-      "version": "14.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/modules/postman-templating/package.json
+++ b/modules/postman-templating/package.json
@@ -40,7 +40,7 @@
     "@types/mustache": "^4.0.1",
     "@types/node": "^14.14.10",
     "cheerio": "^1.0.0-rc.3",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "mustache": "^4.0.1",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5",

--- a/modules/postman-templating/package.json
+++ b/modules/postman-templating/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@types/cheerio": "^0.22.22",
-    "@types/lodash": "^4.14.165",
+    "@types/lodash": "^4.14.168",
     "@types/mustache": "^4.0.1",
     "@types/node": "^14.14.22",
     "cheerio": "^1.0.0-rc.3",

--- a/modules/postman-templating/package.json
+++ b/modules/postman-templating/package.json
@@ -38,7 +38,7 @@
     "@types/cheerio": "^0.22.22",
     "@types/lodash": "^4.14.165",
     "@types/mustache": "^4.0.1",
-    "@types/node": "^14.14.10",
+    "@types/node": "^14.14.22",
     "cheerio": "^1.0.0-rc.3",
     "lodash": "^4.17.21",
     "mustache": "^4.0.1",

--- a/modules/postman-templating/package.json
+++ b/modules/postman-templating/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/cheerio": "^0.22.22",
     "@types/lodash": "^4.14.168",
-    "@types/mustache": "^4.0.1",
+    "@types/mustache": "^4.1.1",
     "@types/node": "^14.14.22",
     "cheerio": "^1.0.0-rc.3",
     "lodash": "^4.17.21",

--- a/modules/postman-templating/package.json
+++ b/modules/postman-templating/package.json
@@ -41,7 +41,7 @@
     "@types/node": "^14.14.22",
     "cheerio": "^1.0.0-rc.3",
     "lodash": "^4.17.21",
-    "mustache": "^4.0.1",
+    "mustache": "^4.1.0",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.5",
     "xss": "=1.0.6"

--- a/serverless/unsubscribe-digest/package-lock.json
+++ b/serverless/unsubscribe-digest/package-lock.json
@@ -1295,9 +1295,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
-      "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/serverless/unsubscribe-digest/package.json
+++ b/serverless/unsubscribe-digest/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^8.2.0",
     "nodemailer-direct-transport": "^3.3.2",
     "nodemailer": "^6.4.17",
-    "pg-connection-string": "^2.3.0",
+    "pg-connection-string": "^2.4.0",
     "pg": "^8.5.1",
     "reflect-metadata": "^0.1.13",
     "sequelize-typescript": "^1.1.0",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -3031,7 +3031,7 @@
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
-        "mustache": "^4.0.1",
+        "mustache": "^4.1.0",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
         "xss": "=1.0.6"
@@ -7464,9 +7464,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+          "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
         },
         "mute-stream": {
           "version": "0.0.8",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -2222,9 +2222,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -3030,7 +3030,7 @@
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.10",
         "cheerio": "^1.0.0-rc.3",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "mustache": "^4.0.1",
         "rimraf": "^3.0.2",
         "typescript": "^3.9.5",
@@ -7331,9 +7331,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.20",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.memoize": {
           "version": "4.1.2",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -3028,7 +3028,7 @@
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.165",
         "@types/mustache": "^4.0.1",
-        "@types/node": "^14.14.10",
+        "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
         "mustache": "^4.0.1",
@@ -3993,9 +3993,9 @@
           "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
         },
         "@types/node": {
-          "version": "14.14.10",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
-          "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ=="
+          "version": "14.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+          "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
         },
         "@types/normalize-package-data": {
           "version": "2.4.0",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -3026,7 +3026,7 @@
       "version": "file:../modules/postman-templating",
       "requires": {
         "@types/cheerio": "^0.22.22",
-        "@types/lodash": "^4.14.165",
+        "@types/lodash": "^4.14.168",
         "@types/mustache": "^4.0.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
@@ -3983,9 +3983,9 @@
           "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/lodash": {
-          "version": "4.14.165",
-          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
-          "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg=="
+          "version": "4.14.168",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+          "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
           "version": "4.0.1",

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -3027,7 +3027,7 @@
       "requires": {
         "@types/cheerio": "^0.22.22",
         "@types/lodash": "^4.14.168",
-        "@types/mustache": "^4.0.1",
+        "@types/mustache": "^4.1.1",
         "@types/node": "^14.14.22",
         "cheerio": "^1.0.0-rc.3",
         "lodash": "^4.17.21",
@@ -3988,9 +3988,9 @@
           "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q=="
         },
         "@types/mustache": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
-          "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw=="
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.1.1.tgz",
+          "integrity": "sha512-Sm0NWeLhS2QL7NNGsXvO+Fgp7e3JLHCO6RS3RCnfjAnkw6Y1bsji/AGfISdQZDIR/AeOyzkrxRk9jBkl55zdJw=="
         },
         "@types/node": {
           "version": "14.14.22",

--- a/worker/package.json
+++ b/worker/package.json
@@ -26,7 +26,7 @@
     "convict": "^6.0.0",
     "dotenv": "^8.2.0",
     "libphonenumber-js": "^1.7.55",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "module-alias": "^2.2.2",
     "nodemailer": "^6.4.17",
     "nodemailer-direct-transport": "^3.3.2",


### PR DESCRIPTION
## Deploy Notes

**New dependencies**:

- `lodash` : upgrade from 4.17.20 to 4.17.21 
- `mustache`: upgrade from 4.0.1 to 4.1.0
- `@types/node`: upgrade from 14.14.10 to 14.14.22
- `@types/lodash`: upgrade from 4.14.165 to 4.14.168
- `@types/mustache`: upgrade from 4.0.1 to 4.1.1