### PR TITLE
backend/routes/settings: Fix API doc for retrieving credentials

### DIFF
--- a/backend/src/core/routes/settings.routes.ts
+++ b/backend/src/core/routes/settings.routes.ts
@@ -128,7 +128,7 @@ router.delete(
  *      tags:
  *        - Settings
  *      parameters:
- *        - name: campaignId
+ *        - name: channelType
  *          in: path
  *          required: true
  *          schema:


### PR DESCRIPTION
The affected API endpoint uses `channelType` as a parameter, not `campaignId`.

**Tests**
Go to the `/docs` path and check that the Swagger doc for `/settings/{channelType}/credentials` shows `channelType` instead of `campaignId` for its parameter.