### PR TITLE
feat: add info banner to dashboard

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -5,14 +5,16 @@ import ModalContextProvider from 'contexts/modal.context'
 import CampaignContextProvider from 'contexts/campaign.context'
 import FinishLaterContextProvider from 'contexts/finish-later.modal.context'
 import Error from 'components/error'
-import { NavBar } from 'components/common'
+import { InfoBanner, NavBar } from 'components/common'
 import Campaigns from './campaigns'
 import Create from './create'
 import Settings from './settings'
+import { INFO_BANNER } from 'config'
 
 const Dashboard = () => {
   return (
     <ModalContextProvider>
+      <InfoBanner>{INFO_BANNER}</InfoBanner>
       <NavBar></NavBar>
       <Switch>
         <Route exact path="/campaigns" component={Campaigns}></Route>


### PR DESCRIPTION
## Problem

Info banner is only visible on landing and the login page. Logged in users might not see the banner.

Closes #1018 

## Solution

**Features**:

- Add info banner to the dashboard

## Screenshots

![image](https://user-images.githubusercontent.com/3666479/109440845-8cabe980-7a6e-11eb-9693-0ca0756994e4.png)

## Tests
- Set `REACT_APP_INFO_BANNER`
- Start/re-deploy frontend
- Banner should be visible on the dashboard