### PR TITLE
chore: add robots.txt to backend

### DIFF
--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -120,6 +120,11 @@ const expressApp = ({ app }: { app: express.Application }): void => {
     return res.sendStatus(200)
   })
 
+  app.get('/robots.txt', (_req: Request, res: Response) => {
+    res.type('text/plain')
+    res.send('User-agent: *\nDisallow: /')
+  })
+
   app.use(sentrySessionMiddleware)
 
   app.use('/v1', v1Router)


### PR DESCRIPTION
## Problem

Technically, our backend routes should not be publicly indexable. But no harm adding `robots.txt` to disallow all crawlers.

## Solution

**Improvements**:
- Add `robots.txt` to backend server

## Tests
- Visit `/robots.txt`. It should return the following:
```
User-agent: *
Disallow: /
```