### PR TITLE
fix: allowed image sources variable not loaded correctly from lingui

### DIFF
--- a/frontend/src/services/validate-csv.service.ts
+++ b/frontend/src/services/validate-csv.service.ts
@@ -13,12 +13,14 @@ export interface ProtectedCsvInfo {
 
 export const PROTECTED_CSV_HEADERS = ['recipient', 'password']
 
-// Using default xss options for registered mail
-const templateClient = new TemplateClient({
-  allowedImageSources: i18n._(ALLOWED_IMAGE_SOURCES).split(';'),
-})
+const getTemplateClient = (): TemplateClient => {
+  return new TemplateClient({
+    allowedImageSources: i18n._(ALLOWED_IMAGE_SOURCES).split(';'),
+  })
+}
 
 export function extractParams(template: string): string[] {
+  const templateClient = getTemplateClient()
   return templateClient.parseTemplate(template).variables
 }
 
@@ -100,6 +102,8 @@ export function hydrateTemplate(
   row: Record<string, any>,
   removeEmptyLines?: boolean
 ) {
+  // Using default xss options for registered mail
+  const templateClient = getTemplateClient()
   const hydrated = templateClient.template(template, row, {
     removeEmptyLines,
     replaceNewLines: true,


### PR DESCRIPTION
## Problem

After upgrading to `lingui 3.x` in #989, we switched to importing `i18n` from `@lingui/core` as it automatically binds to the default `i18n` instance in the new version of the library. 

However, this results in the catalog not being loaded yet when we instantiate `templateClient` in `validate-csv.service.ts`. Previously, we were able to guarantee that the catalog was loaded because we referenced the exported `i18n` from `locales`. 

## Solution
**Bug Fixes**:
- Instantiate `templateClient` within the function calls

## Tests
- Create a protected email campaign
- Insert an image tag within the Message B, referencing an image hosted on `file.go.gov.sg`
- Upload recipient list and note that no error should be thrown