### PR TITLE
fix(rich-text): allow paste within table cells

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
@@ -9,6 +9,7 @@ import {
   DefaultDraftBlockRenderMap,
   RichUtils,
   Modifier,
+  SelectionState,
 } from 'draft-js'
 import { Editor } from 'react-draft-wysiwyg'
 
@@ -236,12 +237,23 @@ const RichTextEditor = ({
     editorState: EditorState
   ): boolean {
     let contentState = editorState.getCurrentContent()
-    const selection = editorState.getSelection()
+    let selection = editorState.getSelection()
     const anchorKey = selection.getAnchorKey()
+    const focusKey = selection.getFocusKey()
     const currentBlock = contentState.getBlockForKey(anchorKey)
 
     // Handle paste within table cells. We only paste as plain text and strip all HTML.
     if (currentBlock.getType() === 'table-cell') {
+      // If user tries to select across multiple cells/blocks, we will replace the selection to just
+      // the whole of the anchor block.
+      if (anchorKey !== focusKey) {
+        selection = SelectionState.createEmpty(anchorKey).merge({
+          focusKey: anchorKey,
+          anchorOffset: selection.getAnchorOffset(),
+          focusOffset: currentBlock.getLength(),
+        })
+      }
+
       if (selection.isCollapsed()) {
         contentState = Modifier.insertText(contentState, selection, text)
       } else {


### PR DESCRIPTION
## Problem

Pasting in table cells were not handled correctly previously as the default paste handler inserts a new block. 

## Solution

**Features**:

- Insert text when pasting within a table cell instead of creating a new block

## Tests
**Inserting text in table cell**
- Create a new email campaign
- Create a table
- Copy and paste text within a single cell
- Text should be pasted

**Replacing text in table cell**
- Create a new email campaign
- Create a table and enter some text within the cell
- Select text within the cell and paste text over selection
- Text should replaced by pasted text

**Multiple cell selected**
- Create a new email campaign
- Create a table with multiple cells
- Select multiple cells and paste text 
- Text should only be pasted in the first cell