### PR TITLE
feat(frontend): display govt banner on protected and unsubscribe pages

### DIFF
--- a/frontend/src/components/landing/banner/Banner.module.scss
+++ b/frontend/src/components/landing/banner/Banner.module.scss
@@ -26,6 +26,10 @@
     margin: 0 auto;
     align-items: center;
     color: #484848;
+
+    @include mobile() {
+      justify-content: center;
+    }
   }
 
   a:hover {

--- a/frontend/src/components/protected/Protected.module.scss
+++ b/frontend/src/components/protected/Protected.module.scss
@@ -1,11 +1,17 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
 
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .outer {
   @include flex-center();
   background-color: $neutral-light;
   width: 100vw;
-  min-height: 100vh;
+  flex: 1;
   overflow: auto;
 }
 

--- a/frontend/src/components/protected/Protected.tsx
+++ b/frontend/src/components/protected/Protected.tsx
@@ -7,6 +7,7 @@ import { TextInputWithButton, ProtectedPreview } from 'components/common'
 import styles from './Protected.module.scss'
 import appLogo from 'assets/img/brand/app-logo.svg'
 import landingHero from 'assets/img/landing/landing-hero.png'
+import Banner from 'components/landing/banner'
 
 const Protected = () => {
   const { id } = useParams()
@@ -25,30 +26,33 @@ const Protected = () => {
   }
 
   return (
-    <div className={styles.outer}>
-      <div className={styles.inner}>
-        {decryptedMessage ? (
-          <ProtectedPreview html={decryptedMessage} />
-        ) : (
-          <div className={styles.verification}>
-            <img src={appLogo} className={styles.appLogo} alt="" />
-            <img src={landingHero} className={styles.landingHero} alt="" />
-            <h3 className={styles.title}>You&apos;ve got mail</h3>
-            <div className={styles.passwordInput}>
-              <TextInputWithButton
-                type="password"
-                placeholder="Enter password"
-                value={password}
-                onChange={setPassword}
-                buttonDisabled={!password}
-                onClick={onAccessMail}
-                buttonLabel="Access Mail"
-                loadingButtonLabel="Decrypting your mail"
-                errorMessage={errorMsg}
-              />
+    <div className={styles.container}>
+      <Banner />
+      <div className={styles.outer}>
+        <div className={styles.inner}>
+          {decryptedMessage ? (
+            <ProtectedPreview html={decryptedMessage} />
+          ) : (
+            <div className={styles.verification}>
+              <img src={appLogo} className={styles.appLogo} alt="" />
+              <img src={landingHero} className={styles.landingHero} alt="" />
+              <h3 className={styles.title}>You&apos;ve got mail</h3>
+              <div className={styles.passwordInput}>
+                <TextInputWithButton
+                  type="password"
+                  placeholder="Enter password"
+                  value={password}
+                  onChange={setPassword}
+                  buttonDisabled={!password}
+                  onClick={onAccessMail}
+                  buttonLabel="Access Mail"
+                  loadingButtonLabel="Decrypting your mail"
+                  errorMessage={errorMsg}
+                />
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/protected/Protected.tsx
+++ b/frontend/src/components/protected/Protected.tsx
@@ -3,11 +3,11 @@ import { useParams } from 'react-router-dom'
 
 import { fetchMessage } from 'services/decrypt-mail.service'
 import { TextInputWithButton, ProtectedPreview } from 'components/common'
+import Banner from 'components/landing/banner'
 
 import styles from './Protected.module.scss'
 import appLogo from 'assets/img/brand/app-logo.svg'
 import landingHero from 'assets/img/landing/landing-hero.png'
-import Banner from 'components/landing/banner'
 
 const Protected = () => {
   const { id } = useParams()

--- a/frontend/src/components/unsubscribe/Unsubscribe.module.scss
+++ b/frontend/src/components/unsubscribe/Unsubscribe.module.scss
@@ -1,11 +1,17 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
 
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .outer {
   @include flex-center();
   background-color: $neutral-light;
   width: 100vw;
-  min-height: 100vh;
+  flex: 1;
   overflow: auto;
 }
 

--- a/frontend/src/components/unsubscribe/Unsubscribe.tsx
+++ b/frontend/src/components/unsubscribe/Unsubscribe.tsx
@@ -4,6 +4,7 @@ import querystring from 'querystring'
 import { Trans } from '@lingui/macro'
 
 import { ErrorBlock, PrimaryButton, TextButton } from 'components/common'
+import Banner from 'components/landing/banner'
 
 import styles from './Unsubscribe.module.scss'
 import appLogo from 'assets/img/brand/app-logo.svg'
@@ -11,7 +12,6 @@ import landingHero from 'assets/img/unsubscribe/request-unsubscribe.png'
 import cancelRequestHero from 'assets/img/unsubscribe/cancel-request.png'
 
 import { unsubscribeRequest } from 'services/unsubscribe.service'
-import Banner from 'components/landing/banner'
 
 const Unsubscribe = () => {
   const { version } = useParams()

--- a/frontend/src/components/unsubscribe/Unsubscribe.tsx
+++ b/frontend/src/components/unsubscribe/Unsubscribe.tsx
@@ -11,6 +11,7 @@ import landingHero from 'assets/img/unsubscribe/request-unsubscribe.png'
 import cancelRequestHero from 'assets/img/unsubscribe/cancel-request.png'
 
 import { unsubscribeRequest } from 'services/unsubscribe.service'
+import Banner from 'components/landing/banner'
 
 const Unsubscribe = () => {
   const { version } = useParams()
@@ -102,18 +103,21 @@ const Unsubscribe = () => {
   }
 
   return (
-    <div className={styles.outer}>
-      <div className={styles.inner}>
-        <>
-          <img src={appLogo} alt="Postman logo" className={styles.appLogo} />
-          <img
-            src={isStaying ? cancelRequestHero : landingHero}
-            alt="Landing hero"
-            className={styles.landingHero}
-          />
-          {renderUnsubscribeSection()}
-          <ErrorBlock>{errorMsg}</ErrorBlock>
-        </>
+    <div className={styles.container}>
+      <Banner />
+      <div className={styles.outer}>
+        <div className={styles.inner}>
+          <>
+            <img src={appLogo} alt="Postman logo" className={styles.appLogo} />
+            <img
+              src={isStaying ? cancelRequestHero : landingHero}
+              alt="Landing hero"
+              className={styles.landingHero}
+            />
+            {renderUnsubscribeSection()}
+            <ErrorBlock>{errorMsg}</ErrorBlock>
+          </>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Closes issue #1038

## Problem

The Singapore government banner is not displayed on the protected message page. Recipients may have legitimacy concerns when landing on this page.

Closes #1038

## Solution

**Features**:

- Display the banner on the aforementioned page.

## Before & After Screenshots

**BEFORE**:
![Screenshot 2021-03-12 at 5 08 11 PM](https://user-images.githubusercontent.com/4538946/110918007-8e6e8a80-8355-11eb-9239-c6ff3da4213f.png)
<img width="317" alt="Screenshot 2021-03-15 at 10 29 30 AM" src="https://user-images.githubusercontent.com/4538946/111095924-6eb7ac00-8579-11eb-8b37-99c0d9132db5.png">

**AFTER**:
![Screenshot 2021-03-12 at 5 05 31 PM](https://user-images.githubusercontent.com/4538946/110917780-43ed0e00-8355-11eb-9c7a-d39aa9d50460.png)
<img width="1536" alt="Screenshot 2021-03-15 at 10 19 43 AM" src="https://user-images.githubusercontent.com/4538946/111095242-00beb500-8578-11eb-9e3d-a5f578553602.png">
<img width="366" alt="Screenshot 2021-03-15 at 10 29 08 AM" src="https://user-images.githubusercontent.com/4538946/111095908-68c1cb00-8579-11eb-8607-0e328bf6baba.png">
<img width="317" alt="Screenshot 2021-03-15 at 10 29 23 AM" src="https://user-images.githubusercontent.com/4538946/111095930-711a0600-8579-11eb-915a-fe6ce6a1eb38.png">



## Tests

1. Deploy the change.
2. Open a protected email page and the unsubscribe email page.
3. The Singapore government banner should be displayed at the top of the page.
