### PR TITLE
fix(rich-text): line breaks not preserved and line breaks within blocks

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
@@ -10,6 +10,7 @@ import {
   RichUtils,
   Modifier,
   SelectionState,
+  KeyBindingUtil,
 } from 'draft-js'
 import { Editor } from 'react-draft-wysiwyg'
 
@@ -212,7 +213,7 @@ const RichTextEditor = ({
   }
 
   function handleReturn(
-    _e: React.KeyboardEvent,
+    e: React.KeyboardEvent,
     state: EditorState
   ): 'handled' | 'not-handled' {
     const selection = state.getSelection()
@@ -225,6 +226,12 @@ const RichTextEditor = ({
       if (selection.isCollapsed()) {
         setEditorState(RichUtils.insertSoftNewline(state))
       }
+      return 'handled'
+    }
+
+    // Insert soft new line if shift+enter is pressed.
+    if (KeyBindingUtil.isSoftNewlineEvent(e) && selection.isCollapsed()) {
+      setEditorState(RichUtils.insertSoftNewline(state))
       return 'handled'
     }
 

--- a/frontend/src/components/common/rich-text-editor/utils/Converter.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/Converter.ts
@@ -263,7 +263,7 @@ const renderContent = (
   inlineStyles: HTMLTag[][],
   blockEntities: HTMLTag[][]
 ): string => {
-  const characters = text.split('')
+  const characters = text.split('').map((c) => (c === '\n' ? '<br />' : c))
   for (let i = 0; i < characters.length; i++) {
     const styles = inlineStyles[i]
     let tags = ''


### PR DESCRIPTION
## Problem

Address two issues:
1. Line breaks not preserved within table cells
2. Not able to insert line break without starting a new paragraph

Closes #1044 

## Solution

**Bug Fixes**:
- Replaced `\n` with `<br />` when converting to HTML so that line breaks are preserved
- Allow insertion of soft new line without starting a new paragraph when shift + enter is pressed 

## Tests
**Line breaks in table**
- Create table and enter text with line breaks within
- Send test message and campaign
- Line breaks should be preserved in the table cell

**Insert line break within paragraph**
- Insert a line of text and insert new line with `Shift + Enter`
- Line break should be entered without a new paragraph created
- Repeat and test for each type of block types (`Title`, `Subtitle`, `Header`)
