### PR TITLE
Render rich text link popover in top level html

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -254,28 +254,6 @@
     }
   }
 
-  .popover {
-    @extend %caption;
-    position: absolute;
-    z-index: 999;
-    background: white;
-    width: max-content;
-    border: solid 1px $neutral;
-    box-shadow: 0px 0px 10px rgba(193, 199, 205, 0.5);
-    border-radius: 5px;
-    padding: $spacing-1;
-    margin-top: 0.25rem;
-
-    &.right {
-      right: 0;
-    }
-
-    .divider {
-      border-left: solid 1px $neutral;
-      margin: 0 $spacing-1;
-    }
-  }
-
   table {
     $border-color: adjust-color($primary-light, $alpha: -0.5);
     border: 1px solid $border-color;

--- a/frontend/src/components/common/rich-text-editor/decorators/LinkDecorator.tsx
+++ b/frontend/src/components/common/rich-text-editor/decorators/LinkDecorator.tsx
@@ -111,9 +111,10 @@ const LinkSpan = (props: {
             })}
           >
             <a href={url} onClick={openLink} target={targetOption}>
-              {url} <i className="bx bx-link-external" />
+              <span>{url}</span>
+              <i className="bx bx-link-external" />
             </a>
-            <span className={styles.divider}></span>
+            <span className="divider"></span>
             <button onClick={removeLink}>Remove</button>
           </div>,
           document.body

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -184,12 +184,23 @@ table {
   border-radius: 5px;
   padding: $spacing-1;
   margin-top: 0.25rem;
-  max-width: 500px;
   word-break: break-all;
+  display: flex;
+  align-items: center;
+
+  a {
+    span {
+      display: inline-block;
+      max-width: 360px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin-right: 0.25rem;
+    }
+  }
 
   button {
     display: block;
-    margin-top: 0.5rem;
   }
 
   &.right {
@@ -200,5 +211,6 @@ table {
   .divider {
     border-left: solid 1px $neutral;
     margin: 0 $spacing-1;
+    height: $height-1;
   }
 }

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -172,3 +172,33 @@ table {
 .spinner {
   @include spinner;
 }
+
+.popover {
+  @extend %caption;
+  position: absolute;
+  z-index: 999;
+  background: white;
+  width: max-content;
+  border: solid 1px $neutral;
+  box-shadow: 0px 0px 10px rgba(193, 199, 205, 0.5);
+  border-radius: 5px;
+  padding: $spacing-1;
+  margin-top: 0.25rem;
+  max-width: 500px;
+  word-break: break-all;
+
+  button {
+    display: block;
+    margin-top: 0.5rem;
+  }
+
+  &.right {
+    right: 0.5rem;
+    left: unset !important;
+  }
+
+  .divider {
+    border-left: solid 1px $neutral;
+    margin: 0 $spacing-1;
+  }
+}


### PR DESCRIPTION
## Problem

When linking long links in the rich text editor, the link popover will overflow the textarea and introduced horizontal scroll to the textarea.

![image](https://user-images.githubusercontent.com/5744384/111570307-898b5a00-87df-11eb-8638-6078cb2eea20.png)

Closes #978 

## Solution

**Improvements**:

- Use [ReactDOM createPortal](https://reactjs.org/docs/portals.html) to attach the tooltip as a child of html body tag

I chose to attach the popover element to the html body tag instead of the top level rich text editor div as
1. relative and absolute positioning from the text block to popover does not work anymore (since they are not parent-child anymore)
2. We have to calculate the position of the text block relative to the top level rich text editor div in order to set the position of the popover div
3. Hence I felt it was more straightforward to calculate the position of the text block relative to the browser window

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/5744384/111570994-ecc9bc00-87e0-11eb-9131-920e361f46ab.png)

## Tests

Add long links to text in rich text editor (especially to text situated at the right/left most side of the editor). Observe the position of the rendered popover.

