### PR TITLE
Improve UX for duplicating demo campaigns

### DIFF
--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -196,9 +196,16 @@ const Campaigns = () => {
             onClick={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
               event.stopPropagation()
               sendUserEvent(GA_USER_EVENTS.OPEN_DUPLICATE_MODAL, campaign.type)
-              modalContext.setModalContent(
+              const modal = campaign.demoMessageLimit ? (
+                <CreateDemoModal
+                  duplicateCampaignName={campaign.name}
+                  numDemosSms={numDemosSms}
+                  numDemosTelegram={numDemosTelegram}
+                />
+              ) : (
                 <DuplicateCampaignModal campaign={campaign} />
               )
+              modalContext.setModalContent(modal)
             }}
           >
             <i className={cx('bx bx-duplicate', styles.icon)}></i>{' '}

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -198,7 +198,10 @@ const Campaigns = () => {
               sendUserEvent(GA_USER_EVENTS.OPEN_DUPLICATE_MODAL, campaign.type)
               const modal = campaign.demoMessageLimit ? (
                 <CreateDemoModal
-                  duplicateCampaignName={campaign.name}
+                  duplicateCampaign={{
+                    name: campaign.name,
+                    type: campaign.type,
+                  }}
                   numDemosSms={numDemosSms}
                   numDemosTelegram={numDemosTelegram}
                 />

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.module.scss
@@ -52,6 +52,13 @@
           cursor: pointer;
         }
       }
+
+      &:not(.active):disabled {
+        background-color: transparent;
+        border: 1px solid $grey-500;
+        color: $grey-500;
+        cursor: not-allowed;
+      }
     }
   }
 }

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
@@ -15,16 +15,18 @@ import DemoVideoModal from 'components/dashboard/demo/demo-video-modal'
 const CreateDemoModal = ({
   numDemosSms,
   numDemosTelegram,
-  duplicateCampaignName,
+  duplicateCampaign,
 }: {
   numDemosSms: number
   numDemosTelegram: number
-  duplicateCampaignName?: string
+  duplicateCampaign?: { name: string; type: ChannelType }
 }) => {
   const { close, setModalTitle, setModalContent } = useContext(ModalContext)
   const history = useHistory()
   const [errorMessage, setErrorMessage] = useState('')
-  const [selectedChannel, setSelectedChannel] = useState(ChannelType.SMS)
+  const [selectedChannel, setSelectedChannel] = useState(
+    duplicateCampaign?.type || ChannelType.SMS
+  )
   const [selectedName, setSelectedName] = useState('')
   //const [demoCampaignMessage, setDemoCampaignMessage] = useState('')
   const [isCreateEnabled, setIsCreateEnabled] = useState(true)
@@ -33,11 +35,11 @@ const CreateDemoModal = ({
     // Handle case where one of the channels does not have any demos left
     // Set the default selected channel to the channel that still has demos left
     if (numDemosSms) {
-      setSelectedChannel(ChannelType.SMS)
+      setSelectedChannel(duplicateCampaign?.type || ChannelType.SMS)
     } else {
       setSelectedChannel(ChannelType.Telegram)
     }
-  }, [numDemosSms])
+  }, [duplicateCampaign, numDemosSms])
 
   useEffect(() => {
     let numDemosChannel
@@ -55,7 +57,7 @@ const CreateDemoModal = ({
         message = `Demo campaigns are not supported for campaign type ${selectedChannel} `
     }
     setSelectedName(
-      (duplicateCampaignName && `Copy of ${duplicateCampaignName}`) ||
+      (duplicateCampaign && `Copy of ${duplicateCampaign.name}`) ||
         `${selectedChannel} Demo ${
           (numDemosChannel && 4 - numDemosChannel) || ''
         }`
@@ -63,7 +65,7 @@ const CreateDemoModal = ({
     setModalTitle(message)
     setIsCreateEnabled(!!numDemosChannel)
   }, [
-    duplicateCampaignName,
+    duplicateCampaign,
     numDemosSms,
     numDemosTelegram,
     selectedChannel,
@@ -127,6 +129,9 @@ const CreateDemoModal = ({
               className={cx(styles.button, {
                 [styles.active]: selectedChannel === ChannelType.SMS,
               })}
+              disabled={
+                duplicateCampaign && duplicateCampaign.type !== ChannelType.SMS
+              }
               onClick={
                 selectedChannel === ChannelType.SMS
                   ? undefined
@@ -144,6 +149,10 @@ const CreateDemoModal = ({
               className={cx(styles.button, {
                 [styles.active]: selectedChannel === ChannelType.Telegram,
               })}
+              disabled={
+                duplicateCampaign &&
+                duplicateCampaign.type !== ChannelType.Telegram
+              }
               onClick={
                 selectedChannel === ChannelType.Telegram
                   ? undefined
@@ -172,7 +181,7 @@ const CreateDemoModal = ({
             onClick={createDemo}
             disabled={!isCreateEnabled}
           >
-            {duplicateCampaignName ? 'Duplicate' : 'Create'} demo campaign
+            {duplicateCampaign ? 'Duplicate' : 'Create'} demo campaign
           </PrimaryButton>
         </div>
         <ErrorBlock>{errorMessage}</ErrorBlock>

--- a/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
+++ b/frontend/src/components/dashboard/demo/create-demo-modal/CreateDemoModal.tsx
@@ -15,9 +15,11 @@ import DemoVideoModal from 'components/dashboard/demo/demo-video-modal'
 const CreateDemoModal = ({
   numDemosSms,
   numDemosTelegram,
+  duplicateCampaignName,
 }: {
   numDemosSms: number
   numDemosTelegram: number
+  duplicateCampaignName?: string
 }) => {
   const { close, setModalTitle, setModalContent } = useContext(ModalContext)
   const history = useHistory()
@@ -53,13 +55,20 @@ const CreateDemoModal = ({
         message = `Demo campaigns are not supported for campaign type ${selectedChannel} `
     }
     setSelectedName(
-      `${selectedChannel} Demo ${
-        (numDemosChannel && 4 - numDemosChannel) || ''
-      }`
+      (duplicateCampaignName && `Copy of ${duplicateCampaignName}`) ||
+        `${selectedChannel} Demo ${
+          (numDemosChannel && 4 - numDemosChannel) || ''
+        }`
     )
     setModalTitle(message)
     setIsCreateEnabled(!!numDemosChannel)
-  }, [numDemosSms, numDemosTelegram, selectedChannel, setModalTitle])
+  }, [
+    duplicateCampaignName,
+    numDemosSms,
+    numDemosTelegram,
+    selectedChannel,
+    setModalTitle,
+  ])
 
   async function createDemo() {
     try {
@@ -85,6 +94,7 @@ const CreateDemoModal = ({
       />
     )
   }
+
   return (
     <>
       <div className={styles.content}>
@@ -162,7 +172,7 @@ const CreateDemoModal = ({
             onClick={createDemo}
             disabled={!isCreateEnabled}
           >
-            Create demo campaign
+            {duplicateCampaignName ? 'Duplicate' : 'Create'} demo campaign
           </PrimaryButton>
         </div>
         <ErrorBlock>{errorMessage}</ErrorBlock>


### PR DESCRIPTION
## Problem

> Currently, users are able to duplicate demo campaigns if they have remaining campaigns left.
> 
> **Expected behaviour**
> Users should not be able to duplicate demo campaigns at all as we want them to see the "Create demo campaign" modal every time they want to create a demo campaign, so that they can see the demo campaign instructions, how many campaigns they have left for the selected channel, and also the button to the video walkthrough.

Closes #869 

## Before & After Screenshots

**AFTER**:
![image](https://user-images.githubusercontent.com/5744384/111603675-8e680200-880f-11eb-9bf3-7a44e0f5598a.png)

## Tests

- Click on duplicate for SMS and Telegram demo campaigns
- Observe that the selected channel buttons are correct 
- Ensure that a demo campaign is created with the correct campaign name when clicking on `Duplicate demo campaign`
