### PR TITLE
chore(frontend): upgrade typescript to v4.2.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21266,9 +21266,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
     },
     "ua-parser-js": {
       "version": "0.7.22",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,7 +49,7 @@
     "react-textarea-autosize": "^7.1.2",
     "sass-burger": "^1.3.1",
     "spark-md5": "^3.0.1",
-    "typescript": "^3.9.7",
+    "typescript": "^4.2.3",
     "uuidv4": "^6.1.1",
     "validator": "^13.0.0",
     "webcrypto-shim": "^0.1.5"

--- a/frontend/src/components/dashboard/create/Create.tsx
+++ b/frontend/src/components/dashboard/create/Create.tsx
@@ -16,7 +16,7 @@ import TelegramCreate from './telegram/TelegramCreate'
 import styles from './Create.module.scss'
 
 const Create = () => {
-  const { id } = useParams()
+  const { id } = useParams<{ id: string }>()
   const history = useHistory()
 
   const { campaign, setCampaign } = useContext(CampaignContext)

--- a/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
@@ -25,7 +25,7 @@ const EmailCredentials = ({
   const { hasCredential: initialHasCredential, protect } = campaign
   const [hasCredential, setHasCredential] = useState(initialHasCredential)
   const [errorMsg, setErrorMsg] = useState(null)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   async function handleTestSend(recipient: string) {
     setErrorMsg(null)

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -65,7 +65,7 @@ const EmailRecipients = ({
     csvFilename: initialCsvFilename,
   })
   const [preview, setPreview] = useState({} as EmailPreview)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
   const { csvFilename, numRecipients = 0 } = csvInfo
   const isMounted = useIsMounted()
 

--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -40,7 +40,7 @@ const EmailSend = ({
       from: string
     }
   )
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   if (!campaignId) {
     throw new Error('Invalid campaign id')

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -53,7 +53,7 @@ const EmailTemplate = ({
   const [customFromAddresses, setCustomFromAddresses] = useState(
     [] as { label: string; value: string }[]
   )
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   const protectedBodyPlaceholder =
     'Dear {{ recipient }}, \n\n You may access your results via this link <a href="{{ protectedlink }}">{{ protectedlink }}</a> . \n\nPlease login with your birthday (DDMMYYYY) followed by the last 4 characters of your NRIC. E.g. 311290123A'

--- a/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
@@ -55,7 +55,7 @@ const ProtectedEmailRecipients = ({
   const [selectedFile, setSelectedFile] = useState<File>()
   const [removeEmptyLines, setRemoveEmptyLines] = useState(false)
   const [protectedCsvInfo, setProtectedCsvInfo] = useState<ProtectedCsvInfo>()
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   const [phase, setPhase] = useState<ProtectPhase>(
     computePhase(numRecipients, isProcessing)

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -61,7 +61,7 @@ const SMSCredentials = ({
   )
   const [isManual, setIsManual] = useState(false)
   const [errorMessage, setErrorMessage] = useState(null)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   useEffect(() => {
     async function populateStoredCredentials(defaultLabels: string[]) {

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -62,7 +62,7 @@ const SMSRecipients = ({
     csvFilename: initialCsvFilename,
   })
   const [preview, setPreview] = useState({} as SMSPreview)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   const { csvFilename, numRecipients = 0 } = csvInfo
   const isMounted = useIsMounted()

--- a/frontend/src/components/dashboard/create/sms/SMSSend.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSSend.tsx
@@ -36,7 +36,7 @@ const SMSSend = ({
   const modalContext = useContext(ModalContext)
   const [preview, setPreview] = useState({} as { body: string })
   const [sendRate, setSendRate] = useState('')
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   if (!campaignId) {
     throw new Error('Invalid campaign id')

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -32,7 +32,7 @@ const SMSTemplate = ({
   const { setFinishLaterContent } = useContext(FinishLaterModalContext)
   const [body, setBody] = useState(replaceNewLines(campaign.body))
   const [errorMsg, setErrorMsg] = useState(null)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   useEffect(() => {
     if (exceedsCharacterThreshold(body)) {

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -63,7 +63,7 @@ const TelegramCredentials = ({
   const [errorMessage, setErrorMessage] = useState(null)
   const [sendSuccess, setSendSuccess] = useState(false)
   const [isValidating, setIsValidating] = useState(false)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   useEffect(() => {
     async function populateStoredCredentials(defaultLabels: string[]) {

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -62,7 +62,7 @@ const TelegramRecipients = ({
     csvFilename: initialCsvFilename,
   })
   const [preview, setPreview] = useState({} as { body: string })
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   const { csvFilename, numRecipients = 0 } = csvInfo
   const isMounted = useIsMounted()

--- a/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
@@ -36,7 +36,7 @@ const TelegramSend = ({
   const modalContext = useContext(ModalContext)
   const [preview, setPreview] = useState({} as { body: string })
   const [sendRate, setSendRate] = useState('')
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   if (!campaignId) {
     throw new Error('Invalid campaign id')

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -31,7 +31,7 @@ const TelegramTemplate = ({
   const { setFinishLaterContent } = useContext(FinishLaterModalContext)
   const [body, setBody] = useState(replaceNewLines(initialBody))
   const [errorMsg, setErrorMsg] = useState(null)
-  const { id: campaignId } = useParams()
+  const { id: campaignId } = useParams<{ id: string }>()
 
   const handleSaveTemplate = useCallback(async (): Promise<void> => {
     setErrorMsg(null)

--- a/frontend/src/components/protected/Protected.tsx
+++ b/frontend/src/components/protected/Protected.tsx
@@ -10,7 +10,7 @@ import appLogo from 'assets/img/brand/app-logo.svg'
 import landingHero from 'assets/img/landing/landing-hero.png'
 
 const Protected = () => {
-  const { id } = useParams()
+  const { id } = useParams<{ id: string }>()
   const [password, setPassword] = useState('')
   const [decryptedMessage, setDecryptedMessage] = useState('')
   const [errorMsg, setErrorMsg] = useState('')

--- a/frontend/src/components/unsubscribe/Unsubscribe.tsx
+++ b/frontend/src/components/unsubscribe/Unsubscribe.tsx
@@ -14,7 +14,7 @@ import cancelRequestHero from 'assets/img/unsubscribe/cancel-request.png'
 import { unsubscribeRequest } from 'services/unsubscribe.service'
 
 const Unsubscribe = () => {
-  const { version } = useParams()
+  const { version } = useParams<{ version: string }>()
   const [errorMsg, setErrorMsg] = useState('')
   const [isUnsubscribed, setUnsubscribed] = useState(false)
   const [isStaying, setStaying] = useState(false)


### PR DESCRIPTION
## Problem

We want to install `msw` is a useful dependency for mocking API endpoints during tests. However, `msw` requires TypeScript v4+ while we currently only use v3.9.7.

Reference: https://github.com/mswjs/msw/issues/491

## Solution

**Improvements**:

- Upgrade the `typescript` dependency from v3.9.7 to v4.2.3
- Fix a minor compilation error resulting from the upgrade

## Before & After Screenshots

There are no visual changes.

## Tests

These tests have been verified locally, but not on the Amplify staging endpoint yet.

1. Compile the app. There should be no errors.
2. Deploy the app on staging.
3. Conduct smoke tests.
4. The app should look and function exactly like before.

Smoke tests:
 - Creating and sending email campaign
 - Creating and sending SMS campaign
 - Creating and sending Telegram campaign
 - Creating and sending protected email campaign
 - Viewing and decrypting protected email page
 - Unsubscribing

## Deploy Notes

**Updated dependencies**:

- `typescript`: upgraded from v3.9.7 to v4.2.3