### PR TITLE
feat(frontend): improve accessibility of dashboard components

### DIFF
--- a/frontend/src/components/common/checkbox/Checkbox.tsx
+++ b/frontend/src/components/common/checkbox/Checkbox.tsx
@@ -16,6 +16,8 @@ const Checkbox = ({
 }) => {
   return (
     <div
+      role="checkbox"
+      aria-checked={checked}
       className={cx(styles.container, className)}
       onClick={() => onChange((val) => !val)}
     >

--- a/frontend/src/components/common/close-button/CloseButton.module.scss
+++ b/frontend/src/components/common/close-button/CloseButton.module.scss
@@ -13,6 +13,9 @@
   border-radius: 50%;
   cursor: pointer;
   user-select: none;
+  border: 0;
+  background: none;
+  padding: 0;
 
   &:hover,
   &:active {

--- a/frontend/src/components/common/close-button/CloseButton.module.scss
+++ b/frontend/src/components/common/close-button/CloseButton.module.scss
@@ -18,7 +18,12 @@
   padding: 0;
 
   &:hover,
-  &:active {
+  &:active,
+  &:focus {
     color: $primary-light;
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
   }
 }

--- a/frontend/src/components/common/close-button/CloseButton.tsx
+++ b/frontend/src/components/common/close-button/CloseButton.tsx
@@ -7,9 +7,9 @@ const CloseButton = (props: any) => {
   const { className, ...otherProps } = props
 
   return (
-    <div className={cx(styles.close, className)} {...otherProps}>
+    <button className={cx(styles.close, className)} {...otherProps}>
       +
-    </div>
+    </button>
   )
 }
 

--- a/frontend/src/components/common/cred-label-input/CredLabelInput.tsx
+++ b/frontend/src/components/common/cred-label-input/CredLabelInput.tsx
@@ -33,8 +33,12 @@ const CredLabelInput = ({
 
   return (
     <>
-      <LabelWithExternalLink label="Credential Label" />
+      <LabelWithExternalLink
+        htmlFor="credentialLabel"
+        label="Credential Label"
+      />
       <TextInput
+        id="credentialLabel"
         className={className}
         placeholder="Enter a label (e.g. default-cred-1)"
         value={value}

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -73,6 +73,7 @@ const Dropdown = ({
         {options.map((o) => (
           <div
             role="option"
+            aria-selected={selectedLabel === o.label}
             className={styles.item}
             key={o.value}
             onClick={() => onItemSelected(o)}

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -59,12 +59,12 @@ const Dropdown = ({
         [styles.open]: isOpen,
       })}
       ref={containerRef}
-      role="listbox"
-      aria-label={ariaLabel}
     >
       <div
         className={cx(styles.select, { [styles.disabled]: disabled })}
         onClick={() => !disabled && setIsOpen(!isOpen)}
+        role="listbox"
+        aria-label={ariaLabel}
       >
         {selectedLabel}
         <i className={cx(styles.caret, 'bx bx-caret-down')}></i>

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -69,6 +69,7 @@ const Dropdown = ({
       <div className={styles.menu}>
         {options.map((o) => (
           <div
+            role="option"
             className={styles.item}
             key={o.value}
             onClick={() => onItemSelected(o)}

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -8,11 +8,13 @@ const Dropdown = ({
   onSelect,
   defaultLabel,
   disabled,
+  'aria-label': ariaLabel,
 }: {
   options: { label: string; value: string }[]
   onSelect: (value: string) => any
   defaultLabel?: string
   disabled?: boolean
+  'aria-label'?: string
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const [isOpen, setIsOpen] = useState(false)
@@ -58,6 +60,7 @@ const Dropdown = ({
       })}
       ref={containerRef}
       role="listbox"
+      aria-label={ariaLabel}
     >
       <div
         className={cx(styles.select, { [styles.disabled]: disabled })}

--- a/frontend/src/components/common/dropdown/Dropdown.tsx
+++ b/frontend/src/components/common/dropdown/Dropdown.tsx
@@ -57,6 +57,7 @@ const Dropdown = ({
         [styles.open]: isOpen,
       })}
       ref={containerRef}
+      role="listbox"
     >
       <div
         className={cx(styles.select, { [styles.disabled]: disabled })}

--- a/frontend/src/components/common/error-block/ErrorBlock.tsx
+++ b/frontend/src/components/common/error-block/ErrorBlock.tsx
@@ -24,6 +24,7 @@ const ErrorBlock = ({
       absolute={absolute}
       onClose={onClose}
       title={title}
+      role="alert"
       {...otherProps}
     >
       {children}

--- a/frontend/src/components/common/file-input/FileInput.tsx
+++ b/frontend/src/components/common/file-input/FileInput.tsx
@@ -24,7 +24,7 @@ const FileInput = ({
         onClick={(e) => ((e.target as HTMLInputElement).value = '')} // reset target value to allow selecting of new files
         onChange={(e) => onFileSelected(e.target.files)}
       />
-      <label htmlFor="recipient-upload-input">
+      <label role="button" htmlFor="recipient-upload-input">
         {isProcessing ? (
           <>
             {label}ing<i className="bx bx-loader-alt bx-spin"></i>

--- a/frontend/src/components/common/label-with-external-link/LabelWithExternalLink.tsx
+++ b/frontend/src/components/common/label-with-external-link/LabelWithExternalLink.tsx
@@ -6,13 +6,15 @@ import styles from './LabelWithExternalLink.module.scss'
 const LabelWithExternalLink = ({
   label,
   link,
+  htmlFor,
 }: {
   label: string
   link?: string
+  htmlFor?: string
 }) => {
   return (
     <div className={styles.label}>
-      <label>{label}</label>
+      <label htmlFor={htmlFor}>{label}</label>
       {link && (
         <OutboundLink
           className={styles.link}

--- a/frontend/src/components/common/message-block/MessageBlock.tsx
+++ b/frontend/src/components/common/message-block/MessageBlock.tsx
@@ -43,7 +43,13 @@ const MessageBlock = ({
           </div>
         </li>
 
-        {onClose && <CloseButton onClick={onClose} className={styles.close} />}
+        {onClose && (
+          <CloseButton
+            onClick={onClose}
+            className={styles.close}
+            title="Close message"
+          />
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/common/message-block/MessageBlock.tsx
+++ b/frontend/src/components/common/message-block/MessageBlock.tsx
@@ -20,6 +20,7 @@ const MessageBlock = ({
   children?: React.ReactNode
   absolute?: boolean
   onClose?: Function
+  role?: string
 }) => {
   if (!children) {
     return null

--- a/frontend/src/components/common/modal/Modal.tsx
+++ b/frontend/src/components/common/modal/Modal.tsx
@@ -38,6 +38,7 @@ const Modal = ({
             className={cx(styles.close, {
               [styles.modalTitleClose]: !!modalTitle,
             })}
+            title="Close modal"
           />
           <div className={styles.content}>{children}</div>
         </div>

--- a/frontend/src/components/common/send-rate/SendRate.tsx
+++ b/frontend/src/components/common/send-rate/SendRate.tsx
@@ -24,31 +24,37 @@ const SendRate = ({
         return (
           <>
             <p>
-              You can send messages at a rapid rate, as long as the requests do
-              not max out Twilio&apos;s REST API concurrency limit.&nbsp;
-              <OutboundLink
-                className={styles.link}
-                eventLabel={i18n._(LINKS.guidePowerUserUrl)}
-                to={i18n._(LINKS.guidePowerUserUrl)}
-                target="_blank"
-              >
-                Learn more about send rate limits
-              </OutboundLink>
+              <label htmlFor="customSendRate">
+                You can send messages at a rapid rate, as long as the requests
+                do not max out Twilio&apos;s REST API concurrency limit.&nbsp;
+                <OutboundLink
+                  className={styles.link}
+                  eventLabel={i18n._(LINKS.guidePowerUserUrl)}
+                  to={i18n._(LINKS.guidePowerUserUrl)}
+                  target="_blank"
+                >
+                  Learn more about send rate limits
+                </OutboundLink>
+              </label>
             </p>
 
             <p>
-              Default rate is 10 messages/ second. If you have raised your send
-              rate with Twilio previously, please enter your new send rate here.
-              We will optimise our sending to match what Twilio has configured
-              for your account.
+              <label htmlFor="customSendRate">
+                Default rate is 10 messages/ second. If you have raised your
+                send rate with Twilio previously, please enter your new send
+                rate here. We will optimise our sending to match what Twilio has
+                configured for your account.
+              </label>
             </p>
           </>
         )
       case ChannelType.Telegram:
         return (
           <p>
-            Default rate is 30 messages/ second. This is the maximum send rate
-            supported by Telegram.
+            <label htmlFor="customSendRate">
+              Default rate is 30 messages/ second. This is the maximum send rate
+              supported by Telegram.
+            </label>
           </p>
         )
       default:
@@ -61,6 +67,7 @@ const SendRate = ({
       <div
         className={styles.title}
         onClick={() => setUseCustomRate(!useCustomRate)}
+        role="button"
       >
         <span>
           <b>Send rate</b> <i>optional</i>
@@ -77,6 +84,7 @@ const SendRate = ({
           {renderInfo()}
 
           <TextInput
+            id="customSendRate"
             type="tel"
             value={sendRate}
             maxLength="3"

--- a/frontend/src/components/common/text-area/TextArea.tsx
+++ b/frontend/src/components/common/text-area/TextArea.tsx
@@ -8,12 +8,14 @@ import styles from './TextArea.module.scss'
 const HIGHLIGHT_REGEX = /{{\s*?\w+\s*?}}/g
 
 const TextArea = ({
+  id,
   highlight = false,
   singleRow,
   placeholder,
   value,
   onChange,
 }: {
+  id?: string
   highlight: boolean
   singleRow?: boolean
   placeholder?: string
@@ -55,6 +57,7 @@ const TextArea = ({
         </div>
       )}
       <TextareaAutosize
+        id={id}
         placeholder={placeholder}
         value={value}
         onChange={(e) => onTextChange(e.target.value)}

--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.tsx
@@ -18,6 +18,7 @@ interface TextInputWithButtonProps
 }
 
 const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = ({
+  id,
   value,
   onChange,
   onClick,
@@ -52,6 +53,7 @@ const TextInputWithButton: React.FunctionComponent<TextInputWithButtonProps> = (
     <form className={styles.textInputForm} onSubmit={asyncSubmit}>
       <div className={styles.inputWithButton}>
         <TextInput
+          id={id}
           className={cx(styles.textInput, { [styles.error]: errorMessage })}
           value={value}
           onChange={onChange}

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -151,3 +151,9 @@
 .protectedPreview {
   border-radius: 1.25rem;
 }
+
+.credentialInputButton {
+  color: $primary;
+  font-weight: normal;
+  height: unset;
+}

--- a/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
+++ b/frontend/src/components/dashboard/create/create-modal/CreateModal.tsx
@@ -69,11 +69,16 @@ const CreateModal = ({
     <>
       <div className={styles.content}>
         <div className={styles.section}>
-          <h2 className={styles.title}>Name your campaign</h2>
+          <h2 className={styles.title}>
+            <label htmlFor="nameCampaign">Name your campaign</label>
+          </h2>
           <h5 className={styles.subtitle}>
-            Give your campaign a descriptive name
+            <label htmlFor="nameCampaign">
+              Give your campaign a descriptive name
+            </label>
           </h5>
           <TextInput
+            id="nameCampaign"
             className={styles.input}
             type="text"
             value={selectedName}

--- a/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
+++ b/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
@@ -44,11 +44,16 @@ const DuplicateCampaignModal = ({ campaign }: { campaign: Campaign }) => {
     <>
       <div className={styles.content}>
         <div className={styles.section}>
-          <h2 className={styles.title}>Name your campaign</h2>
+          <h2 className={styles.title}>
+            <label htmlFor="nameCampaign">Name your campaign</label>
+          </h2>
           <h5 className={styles.subtitle}>
-            Give your campaign a descriptive name
+            <label htmlFor="nameCampaign">
+              Give your campaign a descriptive name
+            </label>
           </h5>
           <TextInput
+            id="nameCampaign"
             className={styles.input}
             type="text"
             value={selectedName}

--- a/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
@@ -52,15 +52,19 @@ const EmailCredentials = ({
           <StepSection>
             <StepHeader title="Send a test email" subtitle="Step 3">
               <p>
-                You can preview your message by sending an email to yourself.{' '}
+                <label htmlFor="validateEmail">
+                  You can preview your message by sending an email to yourself.
+                </label>
               </p>
               {protect && (
                 <p>
-                  You will receive an email from postman.gov.sg showing the
-                  email that the recipient would receive once you click send
-                  campaign. You can click on the unique link and unlock the
-                  password protected page using the corresponding recipient
-                  password in your uploaded csv.
+                  <label htmlFor="validateEmail">
+                    You will receive an email from postman.gov.sg showing the
+                    email that the recipient would receive once you click send
+                    campaign. You can click on the unique link and unlock the
+                    password protected page using the corresponding recipient
+                    password in your uploaded csv.
+                  </label>
                 </p>
               )}
             </StepHeader>

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -139,6 +139,7 @@ const EmailTemplate = ({
             onSelect={setFrom}
             options={customFromAddresses}
             defaultLabel={from || customFromAddresses[0]?.label}
+            aria-label="Custom from"
           ></Dropdown>
         </div>
 

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -143,9 +143,14 @@ const EmailTemplate = ({
         </div>
 
         <div>
-          <h4>Subject</h4>
-          <p>Enter subject of the email</p>
+          <h4>
+            <label htmlFor="subject">Subject</label>
+          </h4>
+          <p>
+            <label htmlFor="subject">Enter subject of the email</label>
+          </p>
           <TextArea
+            id="subject"
             highlight={true}
             singleRow={true}
             placeholder="Enter subject"
@@ -196,9 +201,16 @@ const EmailTemplate = ({
         </div>
 
         <div>
-          <h4 className={styles.replyToHeader}>Replies</h4>
-          <p>If left blank, replies will be directed to {userEmail}</p>
+          <h4 className={styles.replyToHeader}>
+            <label htmlFor="replyTo">Replies</label>
+          </h4>
+          <p>
+            <label htmlFor="replyTo">
+              If left blank, replies will be directed to {userEmail}
+            </label>
+          </p>
           <TextInput
+            id="replyTo"
             placeholder="Enter reply-to email address"
             value={replyTo || ''}
             onChange={setReplyTo}

--- a/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
@@ -20,6 +20,7 @@ const EmailValidationInput = ({
 
   return (
     <TextInputWithButton
+      id="validateEmail"
       type="email"
       value={recipient}
       onChange={setRecipient}

--- a/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/ProtectedEmailRecipients.tsx
@@ -143,7 +143,9 @@ const ProtectedEmailRecipients = ({
           subtitle="Step 2"
         />
         <div>
-          <h4>Message B</h4>
+          <h4>
+            <label htmlFor="protectedMessage">Message B</label>
+          </h4>
           <p>
             The content below is what your recipients see after opening their
             password protected mail using their unique password.
@@ -159,6 +161,7 @@ const ProtectedEmailRecipients = ({
             your tab or go back to Step 1 to edit.
           </p>
           <TextArea
+            id="protectedMessage"
             highlight={true}
             placeholder="Enter password protected message here"
             value={template}

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -158,9 +158,12 @@ const SMSCredentials = ({
                 <TwilioCredentialsInput onFilled={setCreds} />
               </div>
               {storedCredentials.length ? (
-                <p className="clickable" onClick={toggleInputMode}>
+                <TextButton
+                  className={styles.credentialInputButton}
+                  onClick={toggleInputMode}
+                >
                   Select from stored credentials
-                </p>
+                </TextButton>
               ) : null}
             </>
           ) : (
@@ -175,12 +178,13 @@ const SMSCredentials = ({
                 defaultLabel={storedCredentials[0]?.label}
                 disabled={isDemo}
               ></Dropdown>
-              <p
-                className={cx('clickable', { disabled: isDemo })}
+              <TextButton
+                className={styles.credentialInputButton}
+                disabled={isDemo}
                 onClick={() => !isDemo && setIsManual(true)}
               >
                 Input credentials manually
-              </p>
+              </TextButton>
               {isDemo && selectedCredential === DEMO_CREDENTIAL && (
                 <InfoBlock title="Use demo credentials">
                   <span>

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -177,6 +177,7 @@ const SMSCredentials = ({
                 options={storedCredentials}
                 defaultLabel={storedCredentials[0]?.label}
                 disabled={isDemo}
+                aria-label="Twilio credentials"
               ></Dropdown>
               <TextButton
                 className={styles.credentialInputButton}

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -210,9 +210,11 @@ const SMSCredentials = ({
         <StepSection separator={false}>
           <StepHeader title="Validate your credentials by doing a test send">
             <p className={styles.validateCredentialsInfo}>
-              To ensure your credentials are working perfectly, please send a
-              test SMS to an available phone number to receive a preview of your
-              message.
+              <label htmlFor="validateSms">
+                To ensure your credentials are working perfectly, please send a
+                test SMS to an available phone number to receive a preview of
+                your message.
+              </label>
             </p>
           </StepHeader>
           <SMSValidationInput

--- a/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSTemplate.tsx
@@ -105,7 +105,9 @@ const SMSTemplate = ({
       <StepSection>
         <StepHeader title="Create message template" subtitle="Step 1" />
         <div>
-          <h4>Message</h4>
+          <h4>
+            <label htmlFor="message">Message</label>
+          </h4>
           <p>
             To personalise your message, include keywords that are surrounded by
             double curly braces. The keywords in your message template should
@@ -123,6 +125,7 @@ const SMSTemplate = ({
           </p>
         </div>
         <TextArea
+          id="message"
           placeholder="Enter message"
           highlight={true}
           value={body}

--- a/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSValidationInput.tsx
@@ -21,6 +21,7 @@ const SMSValidationInput = ({
 
   return (
     <TextInputWithButton
+      id="validateSms"
       type="tel"
       value={recipient}
       onChange={setRecipient}

--- a/frontend/src/components/dashboard/create/sms/TwilioCredentialsInput.tsx
+++ b/frontend/src/components/dashboard/create/sms/TwilioCredentialsInput.tsx
@@ -32,40 +32,48 @@ const TwilioCredentialsInput = ({
   return (
     <>
       <LabelWithExternalLink
+        htmlFor="accountSid"
         label="Account SID"
         link={i18n._(LINKS.guideSmsAccountSidUrl)}
       />
       <TextInput
+        id="accountSid"
         placeholder="Enter Account SID"
         value={accountSid}
         onChange={setAccountSid}
       />
 
       <LabelWithExternalLink
+        htmlFor="apiKeySid"
         label="API Key SID"
         link={i18n._(LINKS.guideSmsApiKeyUrl)}
       />
       <TextInput
+        id="apiKeySid"
         placeholder="Enter API Key SID"
         value={apiKey}
         onChange={setApiKey}
       />
 
       <LabelWithExternalLink
+        htmlFor="apiSecret"
         label="API Secret"
         link={i18n._(LINKS.guideSmsApiKeyUrl)}
       />
       <TextInput
+        id="apiSecret"
         placeholder="Enter API Secret"
         value={apiSecret}
         onChange={setApiSecret}
       />
 
       <LabelWithExternalLink
+        htmlFor="messagingServiceSid"
         label="Messaging Service ID"
         link={i18n._(LINKS.guideSmsMessagingServiceUrl)}
       />
       <TextInput
+        id="messagingServiceSid"
         placeholder="Enter Messaging Service ID"
         value={messagingServiceSid}
         onChange={setMessagingServiceSid}

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -250,6 +250,7 @@ const TelegramCredentials = ({
                 options={storedCredentials}
                 defaultLabel={storedCredentials[0]?.label}
                 disabled={isDemo}
+                aria-label="Telegram credentials"
               ></Dropdown>
 
               <ErrorBlock>{errorMessage}</ErrorBlock>

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -355,10 +355,12 @@ const TelegramCredentials = ({
               <StepSection>
                 <StepHeader title="Optional: Send a test message">
                   <p className={styles.validateCredentialsInfo}>
-                    To ensure everything is working perfectly, please send a
-                    test message to receive a preview of your message. Do note
-                    that the phone number you are testing with must already be{' '}
-                    <b>subscribed to the bot</b>.
+                    <label htmlFor="validateTelegram">
+                      To ensure everything is working perfectly, please send a
+                      test message to receive a preview of your message. Do note
+                      that the phone number you are testing with must already be{' '}
+                      <b>subscribed to the bot</b>.
+                    </label>
                   </p>
                 </StepHeader>
                 <div>

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -167,9 +167,12 @@ const TelegramCredentials = ({
           <>
             {storedCredentials.length ? (
               <StepSection>
-                <p className="clickable" onClick={toggleInputMode}>
+                <TextButton
+                  className={styles.credentialInputButton}
+                  onClick={toggleInputMode}
+                >
                   Select from stored credentials
-                </p>
+                </TextButton>
               </StepSection>
             ) : null}
 
@@ -251,12 +254,13 @@ const TelegramCredentials = ({
 
               <ErrorBlock>{errorMessage}</ErrorBlock>
 
-              <p
-                className={cx('clickable', { disabled: isDemo })}
+              <TextButton
+                className={styles.credentialInputButton}
+                disabled={isDemo}
                 onClick={() => !isDemo && setIsManual(true)}
               >
                 Add new credentials
-              </p>
+              </TextButton>
 
               {isDemo && selectedCredential === DEMO_CREDENTIAL && (
                 <InfoBlock title="Use demo credentials">

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentialsInput.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentialsInput.tsx
@@ -22,10 +22,12 @@ const TelegramCredentialsInput = ({
   return (
     <>
       <LabelWithExternalLink
+        htmlFor="telegramBotToken"
         label="Telegram Bot Token"
         link={i18n._(LINKS.guideTelegramUrl)}
       />
       <TextInput
+        id="telegramBotToken"
         placeholder="Enter Telegram Bot Token"
         value={telegramBotToken}
         onChange={setTelegramBotToken}

--- a/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramTemplate.tsx
@@ -86,7 +86,9 @@ const TelegramTemplate = ({
       <StepSection>
         <StepHeader title="Create message template" subtitle="Step 1" />
         <div>
-          <h4>Message</h4>
+          <h4>
+            <label htmlFor="message">Message</label>
+          </h4>
           <p>
             To personalise your message, include keywords that are surrounded by
             double curly braces. The keywords in your message template should
@@ -104,6 +106,7 @@ const TelegramTemplate = ({
           </p>
         </div>
         <TextArea
+          id="message"
           placeholder="Enter message"
           highlight={true}
           value={body}

--- a/frontend/src/components/dashboard/create/telegram/TelegramValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramValidationInput.tsx
@@ -21,6 +21,7 @@ const TelegramValidationInput = ({
 
   return (
     <TextInputWithButton
+      id="validateTelegram"
       type="tel"
       value={recipient}
       onChange={setRecipient}

--- a/frontend/src/components/dashboard/demo/demo-bar/DemoBar.tsx
+++ b/frontend/src/components/dashboard/demo/demo-bar/DemoBar.tsx
@@ -72,6 +72,7 @@ const DemoBar = ({
             <CloseButton
               onClick={toggleMenu}
               className={styles.closeButton}
+              title="Close reminder"
             ></CloseButton>
           </div>
           {demoLink()}

--- a/frontend/src/components/error/Error.tsx
+++ b/frontend/src/components/error/Error.tsx
@@ -10,7 +10,7 @@ const Error = () => {
 
   return (
     <div className={styles.rootContainer}>
-      <img src={heroImg} className={styles.heroImg} alt="Hero image" />
+      <img src={heroImg} className={styles.heroImg} alt="Hero" />
       <h2 className={styles.title}>Page Not Found!</h2>
       <p className={styles.description}>
         The link you followed may be broken, or the page may not exist.

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -70,23 +70,6 @@ p {
   font-size: 0.9rem;
 }
 
-.clickable {
-  color: $primary;
-  cursor: pointer;
-  margin-top: 2rem;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &.disabled {
-    color: $grey-500;
-    opacity: 0.7;
-    text-decoration: none;
-    cursor: not-allowed;
-  }
-}
-
 img {
   height: auto;
   max-width: 100%;


### PR DESCRIPTION
## Problem

We want to implement frontend tests soon. However, some dashboard elements are inaccessible to the screen readers. We need to make these elements accessible so that the test environment can easily query them for testing.

## Solution

Where possible, replace generic elements like `div` with semantic elements like `button`. Otherwise, attach appropriate ARIA roles to the elements.

These changes allow the test environment to easily query significant elements by role and/or label.
 
**Improvements**:

- Add the `title` prop to `CloseButton`
- Convert `CloseButton` to an actual `button` (and styled it properly)
- Convert credential input buttons to `TextButton` components (and styled them properly)
- Add labels to the input boxes in the campaign creation pages
- Add semantically appropriate ARIA roles to some custom components:
  - `Checkbox`: role="checkbox"
  - `Dropdown`: role="listbox" (and role="option" for dropdown options)
  - `FileInput` button: role="button"
  - `SendRate` header button: role="button"
  - `ErrorBlock`: role="alert"

ARIA role reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles

## Before & After Screenshots

**1. A tooltip appears when user hovers over close button**
Before:
![Screenshot 2021-03-26 at 6 45 02 PM](https://user-images.githubusercontent.com/4538946/112620361-63ab2880-8e63-11eb-9e1e-ade75cb61af7.png)

After:
![Screenshot 2021-03-26 at 6 44 23 PM](https://user-images.githubusercontent.com/4538946/112620329-57bf6680-8e63-11eb-94e7-68176802e8c9.png)


**2. The credential input buttons are 16px in size (matching the Figma design)**

Before:
![Screenshot 2021-03-26 at 6 45 30 PM](https://user-images.githubusercontent.com/4538946/112620413-77568f00-8e63-11eb-856c-9c49f3c9cc85.png)

After:
![Screenshot 2021-03-26 at 6 47 12 PM](https://user-images.githubusercontent.com/4538946/112620580-b4bb1c80-8e63-11eb-8577-52dcda6c389f.png)

## Tests

These tests have been verified locally, but not on the Amplify staging endpoint yet.

1. Compile and deploy the app on staging.
2. Conduct smoke tests.
3. The app should look and function exactly like before, but the elements should have additional role attributes. Also, some labels are now clickable and focus on the relevant textboxes when clicked.

Smoke tests:
 - Creating and sending email campaign
 - Creating and sending SMS campaign
 - Creating and sending Telegram campaign
 - Creating and sending protected email campaign
 - Viewing and decrypting protected email page
 - Unsubscribing

## Deploy Notes

There are no deployment changes.