### PR TITLE
style: fix font size for links in protected email preview

### DIFF
--- a/frontend/src/components/common/protected-preview/ProtectedPreview.module.scss
+++ b/frontend/src/components/common/protected-preview/ProtectedPreview.module.scss
@@ -18,6 +18,10 @@
     // TODO: Remove this if possible
     $transparent-dark-blue: rgba(16, 12, 85, 0.95);
 
+    a {
+      @extend %body-2;
+    }
+
     img {
       display: block;
       margin: 0 auto;


### PR DESCRIPTION
## Problem

Links were of a different font size compared to the normal text in protected preview.

## Solution

**Bug Fixes**:
- Explicitly apply same font size for links in protected preview

## Before & After Screenshots
**Before**
![image](https://user-images.githubusercontent.com/3666479/112804421-fc7db600-90a6-11eb-80c4-2c3b610778f5.png)

**After**
![image](https://user-images.githubusercontent.com/3666479/112804069-88dba900-90a6-11eb-8c10-bb65a3cb86b7.png)

## Tests
- Create and send protected email with link
- Ensure that font size is the same for both Message B preview and the protected message page