### PR TITLE
fix: avoid calling setState when components are unmounted

### DIFF
--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -27,10 +27,12 @@ import { getUserSettings } from 'services/settings.service'
 import DuplicateCampaignModal from '../create/duplicate-campaign-modal'
 import AnnouncementModal from './announcement-modal'
 import { ANNOUNCEMENT, getAnnouncementVersion } from 'config'
+import useIsMounted from 'components/custom-hooks/use-is-mounted'
 
 const ITEMS_PER_PAGE = 10
 
 const Campaigns = () => {
+  const isMounted = useIsMounted()
   const { email } = useContext(AuthContext)
   const modalContext = useContext(ModalContext)
   const [isLoading, setLoading] = useState(true)
@@ -90,13 +92,18 @@ const Campaigns = () => {
     async function getNumDemosAndAnnouncementVersion() {
       const { demo, announcementVersion } = await getUserSettings()
       const latestAnnouncementVersion = await getAnnouncementVersion()
+
+      if (!isMounted.current) {
+        return
+      }
+
       setIsDemoDisplayed(demo?.isDisplayed)
       setNumDemosSms(demo?.numDemosSms)
       setNumDemosTelegram(demo?.numDemosTelegram)
       displayNewAnnouncement(announcementVersion, latestAnnouncementVersion)
     }
     getNumDemosAndAnnouncementVersion()
-  }, [displayNewAnnouncement])
+  }, [displayNewAnnouncement, isMounted])
 
   /* eslint-disable react/display-name */
   const headers = [

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -127,9 +127,8 @@ const SMSRecipients = ({
       setCsvInfo((info) => ({ ...info, tempCsvFilename }))
     } catch (err) {
       setErrorMessage(err.message)
-    } finally {
-      setIsUploading(false)
     }
+    setIsUploading(false)
   }
 
   // Hide csv error from previous upload and delete from db

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -124,9 +124,8 @@ const TelegramRecipients = ({
       setCsvInfo((info) => ({ ...info, tempCsvFilename }))
     } catch (err) {
       setErrorMessage(err.message)
-    } finally {
-      setIsUploading(false)
     }
+    setIsUploading(false)
   }
 
   // Hide csv error from previous upload and delete from db


### PR DESCRIPTION
## Problem

During tests, React logs errors like so:
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
        in Campaigns (created by Context.Consumer)
```

This is because some components are calling `setState` or its derivatives even when they are unmounted.

## Solution

**Improvements**:

- Check if the components are still mounted before calling `setState`

## Before & After Screenshots

There are no visual changes.

## Tests

These tests have been verified locally but not on the staging branch on Amplify.

**The demo and announcement modal should be unchanged**
1. Load the campaigns dashboard.
2. The demo banner, number of demo SMS campaigns, and number of demo Telegram campaigns should appear just as before.

**Uploading recipients should be unchanged**
1. Upload a valid recipients file to an SMS campaign.
2. The uploading state, loading state, and the processed state should appear in order just as before.
3. Upload an invalid recipients file to the campaign.
4. The uploading state, loading state, and error state should appear in order just as before.
5. Do the same for the Telegram campaign.