### PR TITLE
feat: store `temp_is_vault_link` before recipient list upload finalises

### DIFF
--- a/backend/src/core/interfaces/campaign.interface.ts
+++ b/backend/src/core/interfaces/campaign.interface.ts
@@ -5,6 +5,7 @@ export interface CampaignS3ObjectInterface {
   bucket?: string
   filename?: string
   temp_filename?: string
+  temp_bucket?: string
   error?: string
 }
 
@@ -12,6 +13,7 @@ export interface CsvStatusInterface {
   isCsvProcessing: boolean
   filename?: string
   tempFilename?: string
+  tempBucket?: string
   bucket?: string
   error?: string
 }

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -224,6 +224,7 @@ const getCampaignDetails = async (
   const campaignJobs = '(PARTITION BY "job_queue"."campaign_id")'
   const maxAge = config.get('redaction.maxAge')
 
+  const vaultBucket = config.get('tesseract.vaultBucket')
   const campaignDetails = await Campaign.findOne({
     where: { id: campaignId },
     attributes: [
@@ -238,7 +239,7 @@ const getCampaignDetails = async (
       [literal("s3_object -> 'filename'"), 'csv_filename'],
       [
         literal(
-          `s3_object ->> 'bucket' = '${config.get('tesseract.vaultBucket')}'`
+          `s3_object ->> 'bucket' = '${vaultBucket}' OR s3_object ->> 'temp_bucket' = '${vaultBucket}'`
         ),
         'is_vault_link',
       ],

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -237,12 +237,7 @@ const getCampaignDetails = async (
       'demo_message_limit',
       [literal('cred_name IS NOT NULL'), 'has_credential'],
       [literal("s3_object -> 'filename'"), 'csv_filename'],
-      [
-        literal(
-          `s3_object ->> 'bucket' = '${vaultBucket}' OR s3_object ->> 'temp_bucket' = '${vaultBucket}'`
-        ),
-        'is_vault_link',
-      ],
+      [literal(`s3_object ->> 'bucket' = '${vaultBucket}'`), 'is_vault_link'],
       [
         literal(
           "s3_object -> 'temp_filename' IS NOT NULL AND s3_object -> 'error' IS NULL"

--- a/backend/src/core/services/upload.service.ts
+++ b/backend/src/core/services/upload.service.ts
@@ -101,10 +101,12 @@ const replaceCampaignS3Metadata = (
  */
 const storeS3TempFilename = async (
   campaignId: number,
-  tempFilename: string
+  tempFilename: string,
+  tempBucket: string = FILE_STORAGE_BUCKET_NAME
 ): Promise<void> => {
   return Campaign.updateS3ObjectKey(campaignId, {
     temp_filename: tempFilename,
+    temp_bucket: tempBucket,
     error: undefined,
   })
 }
@@ -134,14 +136,14 @@ const storeS3Error = async (
 const deleteS3TempKeys = async (campaignId: number): Promise<void> => {
   return Campaign.updateS3ObjectKey(campaignId, {
     temp_filename: undefined,
+    temp_bucket: undefined,
     error: undefined,
   })
 }
 
 /*
  * Returns status of csv processing
- * If tempFilename exists in S3Object without errors, processing is still ongoing
- * If error exists in S3Object, processing has failed
+ * If tempFilename exists in S3Object without errors, processing is still ongoing If error exists in S3Object, processing has failed
  * If neither exists, processing is complete
  * If lastUpdated timestamp on campaign has exceeded csvProcessingTimeout, consider processing timedout
  */
@@ -153,8 +155,12 @@ const getCsvStatus = async (
     throw new Error('Campaign does not exist')
   }
   // s3Object is nullable
-  const { filename, temp_filename: tempFilename, bucket } =
-    campaign.s3Object || {}
+  const {
+    filename,
+    temp_filename: tempFilename,
+    temp_bucket: tempBucket,
+    bucket,
+  } = campaign.s3Object || {}
   let { error } = campaign.s3Object || {}
 
   let isCsvProcessing = !!tempFilename && !error
@@ -177,6 +183,7 @@ const getCsvStatus = async (
     isCsvProcessing,
     filename,
     tempFilename,
+    tempBucket,
     bucket,
     error,
   }

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -249,7 +249,8 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
+      temp_is_vault_link: tempBucket === VAULT_BUCKET_NAME,
+      is_vault_link: bucket === VAULT_BUCKET_NAME,
     })
   } catch (err) {
     next(err)

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -227,6 +227,7 @@ const pollCsvStatusHandler = async (
       isCsvProcessing,
       filename,
       tempFilename,
+      tempBucket,
       bucket,
       error,
     } = await UploadService.getCsvStatus(+campaignId)
@@ -248,7 +249,7 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: bucket === config.get('tesseract.vaultBucket'),
+      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
     })
   } catch (err) {
     next(err)
@@ -423,7 +424,11 @@ const tesseractHandler = async (
     }
 
     // Store temp filename
-    await UploadService.storeS3TempFilename(+campaignId, datasetName)
+    await UploadService.storeS3TempFilename(
+      +campaignId,
+      datasetName,
+      config.get('tesseract.vaultBucket')
+    )
 
     // Return early because bulk insert is slow
     res.sendStatus(202)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -224,6 +224,7 @@ const pollCsvStatusHandler = async (
       isCsvProcessing,
       filename,
       tempFilename,
+      tempBucket,
       bucket,
       error,
     } = await UploadService.getCsvStatus(+campaignId)
@@ -245,7 +246,7 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: bucket === config.get('tesseract.vaultBucket'),
+      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
     })
   } catch (err) {
     next(err)
@@ -300,7 +301,11 @@ const tesseractHandler = async (
     }
 
     // Store temp filename
-    await UploadService.storeS3TempFilename(+campaignId, datasetName)
+    await UploadService.storeS3TempFilename(
+      +campaignId,
+      datasetName,
+      config.get('tesseract.vaultBucket')
+    )
 
     // Return early because bulk insert is slow
     res.sendStatus(202)

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -246,7 +246,8 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
+      temp_is_vault_link: tempBucket === VAULT_BUCKET_NAME,
+      is_vault_link: bucket === VAULT_BUCKET_NAME,
     })
   } catch (err) {
     next(err)

--- a/backend/src/telegram/middlewares/telegram-template.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-template.middleware.ts
@@ -233,7 +233,8 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
+      temp_is_vault_link: tempBucket === VAULT_BUCKET_NAME,
+      is_vault_link: bucket === VAULT_BUCKET_NAME,
     })
   } catch (err) {
     next(err)

--- a/backend/src/telegram/middlewares/telegram-template.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-template.middleware.ts
@@ -211,6 +211,7 @@ const pollCsvStatusHandler = async (
       isCsvProcessing,
       filename,
       tempFilename,
+      tempBucket,
       bucket,
       error,
     } = await UploadService.getCsvStatus(+campaignId)
@@ -232,7 +233,7 @@ const pollCsvStatusHandler = async (
       num_recipients: numRecipients,
       preview,
       bucket,
-      is_vault_link: bucket === config.get('tesseract.vaultBucket'),
+      is_vault_link: [bucket, tempBucket].includes(VAULT_BUCKET_NAME),
     })
   } catch (err) {
     next(err)
@@ -289,7 +290,11 @@ const tesseractHandler = async (
     }
 
     // Store temp filename
-    await UploadService.storeS3TempFilename(+campaignId, datasetName)
+    await UploadService.storeS3TempFilename(
+      +campaignId,
+      datasetName,
+      config.get('tesseract.vaultBucket')
+    )
 
     // Return early because bulk insert is slow
     res.sendStatus(202)

--- a/frontend/src/components/common/csv-upload/CsvUpload.tsx
+++ b/frontend/src/components/common/csv-upload/CsvUpload.tsx
@@ -1,32 +1,33 @@
 import React from 'react'
 
-import { DetailBlock, ErrorBlock } from 'components/common'
+import { CsvStatusResponse } from 'services/upload.service'
+import { DetailBlock } from 'components/common'
+import { RecipientListType } from 'classes'
 
 import styles from './CsvUpload.module.scss'
 
 const CsvUpload = ({
   isCsvProcessing,
   csvInfo,
-  onErrorClose,
   children,
 }: {
   isCsvProcessing: boolean
-  csvInfo: {
-    numRecipients?: number
-    csvFilename?: string
-    tempCsvFilename?: string
-    csvError?: string
-  }
+  csvInfo: Omit<CsvStatusResponse, 'isCsvProcessing' | 'preview'>
   onErrorClose: () => void
   children: React.ReactNode
 }) => {
-  const { numRecipients = 0, csvFilename, tempCsvFilename, csvError } = csvInfo
+  const {
+    numRecipients = 0,
+    csvFilename,
+    recipientListType,
+    tempCsvFilename,
+  } = csvInfo
 
   function renderFileUploadInput() {
     if (!isCsvProcessing) {
       return (
         <>
-          {numRecipients > 0 && (
+          {numRecipients > 0 && recipientListType === RecipientListType.Csv && (
             <DetailBlock>
               <li>
                 <i className="bx bx-user-check"></i>
@@ -59,14 +60,7 @@ const CsvUpload = ({
     }
   }
 
-  return (
-    <div className={styles.container}>
-      {renderFileUploadInput()}
-      <ErrorBlock onClose={onErrorClose} title={tempCsvFilename}>
-        {csvError && <span>{csvError}</span>}
-      </ErrorBlock>
-    </div>
-  )
+  return <div className={styles.container}>{renderFileUploadInput()}</div>
 }
 
 export default CsvUpload

--- a/frontend/src/components/common/url-upload/UrlUpload.tsx
+++ b/frontend/src/components/common/url-upload/UrlUpload.tsx
@@ -1,24 +1,25 @@
 import React, { useState } from 'react'
 
-import { TextInputWithButton, DetailBlock, ErrorBlock } from 'components/common'
+import { CsvStatusResponse } from 'services/upload.service'
+import { TextInputWithButton, DetailBlock } from 'components/common'
+import { RecipientListType } from 'classes'
 
 const UrlUpload = ({
   isProcessing,
   onSubmit,
   csvInfo,
-  onErrorClose,
 }: {
   isProcessing: boolean
   onSubmit: (url: string) => any
-  csvInfo: {
-    numRecipients?: number
-    csvFilename?: string
-    tempCsvFilename?: string
-    csvError?: string
-  }
+  csvInfo: Omit<CsvStatusResponse, 'isCsvProcessing' | 'preview'>
   onErrorClose: () => void
 }) => {
-  const { numRecipients = 0, csvFilename, tempCsvFilename, csvError } = csvInfo
+  const {
+    numRecipients = 0,
+    csvFilename,
+    tempCsvFilename,
+    recipientListType,
+  } = csvInfo
   const [url, setUrl] = useState('')
 
   function isValidUrl() {
@@ -57,7 +58,7 @@ const UrlUpload = ({
 
     return (
       <>
-        {numRecipients > 0 && (
+        {numRecipients > 0 && recipientListType === RecipientListType.Vault && (
           <DetailBlock>
             <li>
               <i className="bx bx-user-check"></i>
@@ -95,9 +96,6 @@ const UrlUpload = ({
           placeholder="Paste Vault link here"
         />
       )}
-      <ErrorBlock onClose={onErrorClose} title={tempCsvFilename}>
-        {csvError && <span>{csvError}</span>}
-      </ErrorBlock>
     </>
   )
 }

--- a/frontend/src/components/common/url-upload/UrlUpload.tsx
+++ b/frontend/src/components/common/url-upload/UrlUpload.tsx
@@ -95,7 +95,7 @@ const UrlUpload = ({
           placeholder="Paste Vault link here"
         />
       )}
-      <ErrorBlock onClose={onErrorClose} title={csvFilename}>
+      <ErrorBlock onClose={onErrorClose} title={tempCsvFilename}>
         {csvError && <span>{csvError}</span>}
       </ErrorBlock>
     </>

--- a/frontend/src/components/custom-hooks/use-upload-recipients.tsx
+++ b/frontend/src/components/custom-hooks/use-upload-recipients.tsx
@@ -136,6 +136,7 @@ function useUploadRecipients<
     isProcessing,
     isUploading,
     error,
+    setError,
     preview,
     csvInfo,
     uploadRecipients,

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -57,8 +57,11 @@ const EmailRecipients = ({
   } = useUploadRecipients<EmailPreview>(onFileSelected, forceReset)
   const {
     recipientListType: currentRecipientListType,
+    tempCsvFilename,
     csvFilename,
     numRecipients = 0,
+    csvError,
+    tempRecipientListType,
   } = csvInfo
   const [recipientListType, setRecipientListType] = useState(
     currentRecipientListType
@@ -113,9 +116,7 @@ const EmailRecipients = ({
 
             <UrlUpload
               isProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onSubmit={(url) => uploadRecipients(url)}
               onErrorClose={clearCsvStatus}
             />
@@ -156,8 +157,7 @@ const EmailRecipients = ({
               </p>
             </StepHeader>
 
-            {(currentRecipientListType !== RecipientListType.Csv ||
-              !csvFilename) && (
+            {!csvFilename && (
               <WarningBlock>
                 We do not remove duplicate recipients.{' '}
                 <OutboundLink
@@ -173,9 +173,7 @@ const EmailRecipients = ({
 
             <CsvUpload
               isCsvProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onErrorClose={clearCsvStatus}
             >
               {/* Dont show upload button when upload completed for protected component */}
@@ -239,6 +237,11 @@ const EmailRecipients = ({
 
       <StepSection>
         {renderUploadInput()}
+        {tempRecipientListType === recipientListType && (
+          <ErrorBlock title={tempCsvFilename} onClose={clearCsvStatus}>
+            {csvError}
+          </ErrorBlock>
+        )}
         <ErrorBlock>{error || sampleCsvError}</ErrorBlock>
       </StepSection>
 

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -49,6 +49,7 @@ const EmailRecipients = ({
     isProcessing,
     isUploading,
     error,
+    setError,
     preview,
     csvInfo,
     uploadRecipients,
@@ -74,6 +75,11 @@ const EmailRecipients = ({
 
   async function handleFileSelected(files: FileList) {
     if (files[0]) await uploadRecipients(files[0])
+  }
+
+  function selectRecipientListType(listType: RecipientListType) {
+    setRecipientListType(listType)
+    setError(null)
   }
 
   function isNextDisabled() {
@@ -212,7 +218,7 @@ const EmailRecipients = ({
 
           <div className={styles.recipientTypeSelector}>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Csv)}
+              onClick={() => selectRecipientListType(RecipientListType.Csv)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Csv,
               })}
@@ -220,7 +226,7 @@ const EmailRecipients = ({
               Use CSV<i className={cx('bx', 'bx-spreadsheet')}></i>
             </PrimaryButton>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Vault)}
+              onClick={() => selectRecipientListType(RecipientListType.Vault)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Vault,
               })}

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -43,6 +43,7 @@ const SMSRecipients = ({
     isProcessing,
     isUploading,
     error,
+    setError,
     preview,
     csvInfo,
     uploadRecipients,
@@ -68,6 +69,11 @@ const SMSRecipients = ({
 
   async function handleFileSelected(files: FileList) {
     if (files[0]) await uploadRecipients(files[0])
+  }
+
+  function selectRecipientListType(listType: RecipientListType) {
+    setRecipientListType(listType)
+    setError(null)
   }
 
   function isNextDisabled() {
@@ -192,7 +198,7 @@ const SMSRecipients = ({
 
           <div className={styles.recipientTypeSelector}>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Csv)}
+              onClick={() => selectRecipientListType(RecipientListType.Csv)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Csv,
               })}
@@ -200,7 +206,7 @@ const SMSRecipients = ({
               Use CSV<i className={cx('bx', 'bx-spreadsheet')}></i>
             </PrimaryButton>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Vault)}
+              onClick={() => selectRecipientListType(RecipientListType.Vault)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Vault,
               })}

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -52,7 +52,10 @@ const SMSRecipients = ({
   const {
     recipientListType: currentRecipientListType,
     csvFilename,
+    tempCsvFilename,
     numRecipients = 0,
+    csvError,
+    tempRecipientListType,
   } = csvInfo
   const [recipientListType, setRecipientListType] = useState(
     currentRecipientListType
@@ -107,9 +110,7 @@ const SMSRecipients = ({
 
             <UrlUpload
               isProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onSubmit={(url) => uploadRecipients(url)}
               onErrorClose={clearCsvStatus}
             />
@@ -156,9 +157,7 @@ const SMSRecipients = ({
 
             <CsvUpload
               isCsvProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onErrorClose={clearCsvStatus}
             >
               <FileInput
@@ -219,6 +218,11 @@ const SMSRecipients = ({
 
       <StepSection>
         {renderUploadInput()}
+        {tempRecipientListType === recipientListType && (
+          <ErrorBlock title={tempCsvFilename} onClose={clearCsvStatus}>
+            {csvError}
+          </ErrorBlock>
+        )}
         <ErrorBlock>{error || sampleCsvError}</ErrorBlock>
       </StepSection>
 

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -52,7 +52,10 @@ const TelegramRecipients = ({
   const {
     recipientListType: currentRecipientListType,
     csvFilename,
+    tempCsvFilename,
     numRecipients = 0,
+    csvError,
+    tempRecipientListType,
   } = csvInfo
   const [recipientListType, setRecipientListType] = useState(
     currentRecipientListType
@@ -107,9 +110,7 @@ const TelegramRecipients = ({
 
             <UrlUpload
               isProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onSubmit={(url) => uploadRecipients(url)}
               onErrorClose={clearCsvStatus}
             />
@@ -156,9 +157,7 @@ const TelegramRecipients = ({
 
             <CsvUpload
               isCsvProcessing={isProcessing}
-              csvInfo={
-                currentRecipientListType === recipientListType ? csvInfo : {}
-              }
+              csvInfo={csvInfo}
               onErrorClose={clearCsvStatus}
             >
               <FileInput
@@ -220,6 +219,11 @@ const TelegramRecipients = ({
 
       <StepSection>
         {renderUploadInput()}
+        {tempRecipientListType === recipientListType && (
+          <ErrorBlock title={tempCsvFilename} onClose={clearCsvStatus}>
+            {csvError}
+          </ErrorBlock>
+        )}
         <ErrorBlock>{error || sampleCsvError}</ErrorBlock>
       </StepSection>
 

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -43,6 +43,7 @@ const TelegramRecipients = ({
     isProcessing,
     isUploading,
     error,
+    setError,
     preview,
     csvInfo,
     uploadRecipients,
@@ -68,6 +69,11 @@ const TelegramRecipients = ({
 
   async function handleFileSelected(files: FileList) {
     if (files[0]) await uploadRecipients(files[0])
+  }
+
+  function selectRecipientListType(listType: RecipientListType) {
+    setRecipientListType(listType)
+    setError(null)
   }
 
   function isNextDisabled() {
@@ -193,7 +199,7 @@ const TelegramRecipients = ({
 
           <div className={styles.recipientTypeSelector}>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Csv)}
+              onClick={() => selectRecipientListType(RecipientListType.Csv)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Csv,
               })}
@@ -201,7 +207,7 @@ const TelegramRecipients = ({
               Use CSV<i className={cx('bx', 'bx-spreadsheet')}></i>
             </PrimaryButton>
             <PrimaryButton
-              onClick={() => setRecipientListType(RecipientListType.Vault)}
+              onClick={() => selectRecipientListType(RecipientListType.Vault)}
               className={cx({
                 [styles.active]: recipientListType === RecipientListType.Vault,
               })}

--- a/frontend/src/services/upload.service.ts
+++ b/frontend/src/services/upload.service.ts
@@ -21,6 +21,7 @@ export interface CsvStatusResponse {
   numRecipients?: number
   preview?: EmailPreview | SMSPreview
   recipientListType?: RecipientListType
+  tempRecipientListType?: RecipientListType
 }
 
 async function getMd5(blob: Blob): Promise<string> {
@@ -140,6 +141,7 @@ export async function getCsvStatus(
       is_csv_processing: isCsvProcessing,
       csv_filename: csvFilename,
       temp_csv_filename: tempCsvFilename,
+      temp_is_vault_link: tempIsVaultLink,
       csv_error: csvError,
       num_recipients: numRecipients,
       preview,
@@ -152,6 +154,9 @@ export async function getCsvStatus(
       csvError,
       numRecipients,
       recipientListType: isVaultLink
+        ? RecipientListType.Vault
+        : RecipientListType.Csv,
+      tempRecipientListType: tempIsVaultLink
         ? RecipientListType.Vault
         : RecipientListType.Csv,
     } as CsvStatusResponse


### PR DESCRIPTION
## Problem

If an upload has an error during the processing of a vault link, the error is shown on the CSV tab on refresh as we did not persist the bucket name until the upload has been finalised. 

## Solution

**Features**:
- Introduce `temp_is_vault_link` to track the type of last upload before it finalises
- Clear transient errors (e.g. invalid Vault URL) on selection of a new recipient list type

## Tests
**Invalid Vault URL**
- Upload an invalid Vault URL.
- An error should be shown
- Switch to CSV as the recipient list type
- The error block should not be shown

**Invalid Vault recipient list**
- Upload a valid Vault URL that references an invalid recipient list (e.g. missing column)
- Error should be shown once processing is interrupted
- Switch to CSV as the recipient list type
- Error should not be shown

**Error after successful CSV upload**
- Upload a valid CSV recipient list
- Upload a valid Vault URL that references an invalid recipient list (e.g. missing column)
- Error should be shown only on the Vault tab
- CSV tab should still show the last successful upload
- After refreshing it should default to CSV tab (last successful upload)

**Error after successful Vault upload**
- Upload a valid Vault recipient list
- Upload an invalid CSV recipient list
- Error should be shown only on the CSV tab
- Vault tab should still show the last successful upload
- After refreshing it should default to Vault tab (last successful upload)