### PR TITLE
fix: disable periodic updates for react-moment components

### DIFF
--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -100,7 +100,10 @@ const ProgressDetails = ({
       return (
         <div className={styles.statsLastUpdated}>
           <span>
-            Stats last retrieved on <Moment format="LLL">{updatedAt}</Moment>
+            Stats last retrieved on{' '}
+            <Moment format="LLL" interval={0}>
+              {updatedAt}
+            </Moment>
           </span>
           <PrimaryButton onClick={handleRefreshStats}>
             Refresh stats
@@ -123,7 +126,9 @@ const ProgressDetails = ({
         <tbody>
           <tr>
             <td className={'md'}>
-              <Moment format="MMM DD YYYY, HH:mm">{sentAt}</Moment>
+              <Moment format="MMM DD YYYY, HH:mm" interval={0}>
+                {sentAt}
+              </Moment>
             </td>
 
             <td className={'md'}>{numRecipients}</td>

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -135,7 +135,9 @@ const Campaigns = () => {
     {
       name: 'Created At',
       render: (campaign: Campaign) => (
-        <Moment format="MMM DD YYYY, HH:mm">{campaign.createdAt}</Moment>
+        <Moment format="MMM DD YYYY, HH:mm" interval={0}>
+          {campaign.createdAt}
+        </Moment>
       ),
       width: 'md',
     },
@@ -143,7 +145,9 @@ const Campaigns = () => {
       name: 'Sent At',
       render: (campaign: Campaign) =>
         campaign.sentAt ? (
-          <Moment format="MMM DD YYYY, HH:mm">{campaign.sentAt}</Moment>
+          <Moment format="MMM DD YYYY, HH:mm" interval={0}>
+            {campaign.sentAt}
+          </Moment>
         ) : (
           <span></span>
         ),


### PR DESCRIPTION
## Problem

During tests, there are instances when periodic updates causes errors
due to calling `setState` when the component is unmounted.

Reason:
By default, the Moment component sets a timer on a 60s interval to
update the time shown.

## Solution

Our time displays are all static so we don't need this feature. Hence, disable it.
This should also slightly improve efficiency since app will do less work.

## Before & After Screenshots

There are no visual changes.

## Tests

These tests have been verified on a local dev machine.

**Assert that there are no visual changes:**
1. Deploy the frontend on Amplify.
2. The time display on the Dashboard and on the ProgressDetails pages should appear the same as before.

**Assert that the Dashboard integration tests run without console errors:**
1. Run the Dashboard integration tests in #1110 
2. The tests should all pass and no console errors should be printed.

## Deploy Notes

There are no deploy notes.