### PR TITLE
fix(docker/awscli): upgrade to python3 and install python3-dev

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,11 +2,11 @@ FROM node:12-alpine
 
 # required for node-gyp
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
-  g++ make python tini python2-dev
+  g++ make python3 python3-dev tini
 
-RUN apk add py-pip && apk add jq
+RUN apk add jq
 
-RUN pip install awscli
+RUN python3 -m pip install awscli
 
 RUN aws configure set default.region ap-southeast-1
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine
 
 # required for node-gyp
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
-  g++ make python tini
+  g++ make python tini python2-dev
 
 RUN apk add py-pip && apk add jq
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,11 +2,11 @@ FROM node:12-alpine
 
 # required for node-gyp
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
-  g++ make python tini python2-dev
+  g++ make python3 python3-dev tini
 
-RUN apk add py-pip && apk add jq
+RUN apk add jq
 
-RUN pip install awscli
+RUN python3 -m pip install awscli
 
 RUN aws configure set default.region ap-southeast-1
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine
 
 # required for node-gyp
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \
-  g++ make python tini
+  g++ make python tini python2-dev
 
 RUN apk add py-pip && apk add jq
 


### PR DESCRIPTION
## Problem

A recent change (not sure what) started causing `pip install awscli` to
fail without the python2-dev package. This causes backend and worker
builds on Travis to fail.

Travis build log: https://travis-ci.com/github/opengovsg/postmangovsg/jobs/498665286

## Solution

**Improvements**:

- Upgrade to `python3` and remove `py-pip`
- Install `python3-dev` on the backend and worker Docker instances

## Before & After Screenshots

There are no visual changes.

## Tests

1. Deploy the change.
2. Ensure that the `backend` and `worker` builds and deployments on Travis, AWS EBS, and AWS ECS succeed.

## Deploy Notes

There are no deploy notes.

## Todo
- [x] Look into upgrading Python from 2.7 to 3.x
- [x] Look into upgrading AWS CLI from v1 to v2 (which eliminates the dependency on a system installation of Python)

## Notes regarding AWS CLI v2
There is a prebuilt binary, but it depends on glibc. Our Docker image (Alpine) only includes musl libc, so we can't use the binary as is.

Options:
1. Install glibc ((https://github.com/aws/aws-cli/issues/4685#issuecomment-700923581))
2. Build the binary from scratch using musl (https://github.com/aws/aws-cli/issues/4685#issuecomment-786599941))

Both of these options seem more trouble than they're worth, so I've decided not to upgrade to v2 for now.

## References
- https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/
- https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/