### PR TITLE
fix: prevent campaign names from causing dashboard rows to overflow

### DIFF
--- a/frontend/src/components/common/title-bar/TitleBar.module.scss
+++ b/frontend/src/components/common/title-bar/TitleBar.module.scss
@@ -15,7 +15,13 @@
 }
 
 .titleText {
+  flex: 1;
   color: $secondary;
   margin-top: 0;
   margin-bottom: 0;
+  margin-right: $spacing-3;
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }

--- a/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.module.scss
@@ -27,6 +27,7 @@
       #{$tablet} - #{$mobile-site-padding} - #{$mobile-site-padding}
     );
     width: 100%;
+    table-layout: fixed;
 
     thead tr {
       th {
@@ -47,6 +48,13 @@
 
       td {
         @extend %body-2;
+
+        .rowName {
+          display: inline-block;
+          width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
       }
     }
   }

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -130,7 +130,7 @@ const Campaigns = () => {
       name: 'Name',
       render: (campaign: Campaign) => (
         <span
-          className={cx({
+          className={cx(styles.rowName, {
             [styles.demo]: !!campaign.demoMessageLimit,
           })}
         >

--- a/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
+++ b/frontend/src/components/dashboard/create/duplicate-campaign-modal/DuplicateCampaignModal.tsx
@@ -22,7 +22,10 @@ const DuplicateCampaignModal = ({ campaign }: { campaign: Campaign }) => {
   const { close } = useContext(ModalContext)
   const history = useHistory()
   const [errorMessage, setErrorMessage] = useState('')
-  const [selectedName, setSelectedName] = useState(`Copy of ${campaign.name}`)
+  const [selectedName, setSelectedName] = useState(
+    // Only prepend 'Copy of' if the campaign name doesn't already have one
+    (campaign.name.startsWith('Copy of') ? '' : 'Copy of ') + campaign.name
+  )
 
   async function handleDuplicateCampaign() {
     try {


### PR DESCRIPTION
## Problem

This is a minor design issue I noticed during testing:

A particularly long campaign name causes the dashboard table to overflow its container. This doesn't look very good.

## Solution

**Improvements**:

- Only prepend `Copy of` to campaign names which don't already have it (explanation in commit 6a3db9a)

**Bug Fixes**:

- Prevent the dashboard table from overflowing its container

## Before & After Screenshots

**BEFORE**:
<details>
<summary>Before screenshots</summary>

![Screenshot 2021-04-15 at 2 19 05 PM](https://user-images.githubusercontent.com/4538946/115492088-afe75e00-a293-11eb-820e-468623ea9580.png)

![Screenshot 2021-04-15 at 2 19 22 PM](https://user-images.githubusercontent.com/4538946/115492164-d73e2b00-a293-11eb-85f6-0c2413621dc7.png)
</details>


**AFTER**:
<details>
<summary>After screenshots</summary>

![Screenshot 2021-04-15 at 2 20 04 PM](https://user-images.githubusercontent.com/4538946/115492175-dd340c00-a293-11eb-9657-c5ca5c9981f4.png)

![Screenshot 2021-04-15 at 2 19 45 PM](https://user-images.githubusercontent.com/4538946/115492183-df966600-a293-11eb-8e8a-bb287318b2f0.png)
</details>

## Tests

**Duplicating a duplicated campaign should not prepend `Copy of` to the campaign's name**
1. Try duplicating a campaign which already has `Copy of` at the start of its name.
2. Assert that the campaign duplication modal does not prepend yet another `Copy of` to the new campaign's name.

**Table should not overflow the container**
1. Create a campaign with a very long name.
2. Assert that the dashboard table does not have a horizontal scrollbar.

## Deploy Notes

No deploy notes.

## Todo

- [ ] Maybe add a unit test for ensuring the `Copy of` prepending functionality works as intended?