### PR TITLE
Update successful delivery status for sms only if error does not exist

### DIFF
--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express'
+import { Op } from 'sequelize'
 import bcrypt from 'bcrypt'
 import config from '@core/config'
 import { SmsMessage } from '@sms/models'
@@ -55,6 +56,9 @@ const parseEvent = async (req: Request): Promise<void> => {
       }
     )
   } else {
+    // longer messages are delivered in multiple segments
+    // each segment has a separate delivery status
+    // Update the message as successful only if there does not exist previous failed status
     await SmsMessage.update(
       {
         receivedAt: new Date(),
@@ -64,6 +68,7 @@ const parseEvent = async (req: Request): Promise<void> => {
         where: {
           id: messageId,
           campaignId,
+          errorCode: { [Op.eq]: null },
         },
       }
     )


### PR DESCRIPTION
## Problem

Some SMS messages delivery statuses logged contained both the error code and a `SUCCESS` status. This will be confusing to users who see this status in their delivery report and does not provide a conclusive delivery status of the message.

Closes #1126 

## Solution

**Bug Fixes**:

SMS messages can be delivered in multiple segments when they exceed the character limit of one SMS. Hence each segment has separate deliverability and results in multiple callbacks. In the case where the first segment of the message failed to deliver but the next segment is successful, there will be a situation where the delivery status is overridden to `SUCCESS` but the `errorCode` still remains.

- Update a successful delivery status of a message only if there does not exist a previous Error status 

## Tests

- Call the `/callback/sms` endpoint with a unsuccessful delivery status - observe that the message status reflects `ERROR` in the db
- Call the `/callback/sms` endpoint with a successful delivery status - observe that the message status still reflects `ERROR` in the db

** You can replicate the bug by following this scenario on dev branch, but you will observe that the delivery status now reflects both the error code and a `SUCCESS` status.
