### PR TITLE
fix(frontend): fix test flakiness

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -29,7 +29,6 @@ frontend:
     build:
       commands:
         - npm run build
-        - CI=true npm run test
         - npm run upload-source-map
   artifacts:
     # IMPORTANT - Please verify your build output directory

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -7,6 +7,7 @@ import type { InitializeOptions } from 'react-ga'
 // Re-export these later on as constants
 let gaInitializeOptions: InitializeOptions
 let gaTrackingId: string
+let announcementActive: string
 
 /**
  * Configs differentiated between environments
@@ -17,6 +18,9 @@ if (process.env.NODE_ENV === 'test') {
   gaInitializeOptions = {
     testMode: true,
   }
+
+  // Disable announcements in test environments
+  announcementActive = 'false'
 } else {
   /**
    * React env vars are used for injecting variables at build time
@@ -44,6 +48,9 @@ if (process.env.NODE_ENV === 'test') {
   gaInitializeOptions = {
     debug: false, // Set to true only on development
   }
+
+  // `REACT_APP_ANNOUNCEMENT_ACTIVE` must be set to `true` in Amplify if we want the modal to display
+  announcementActive = process.env.REACT_APP_ANNOUNCEMENT_ACTIVE as string
 }
 
 /**
@@ -86,16 +93,10 @@ export const SENTRY_ENVIRONMENT =
   (process.env.REACT_APP_SENTRY_ENVIRONMENT as string) || 'development'
 export const INFO_BANNER = process.env.REACT_APP_INFO_BANNER as string
 
-// `REACT_APP_ANNOUNCEMENT_ACTIVE` must be set to `true` in Amplify if we want the modal to display
-function getAnnouncementActive() {
-  const envVar = process.env.REACT_APP_ANNOUNCEMENT_ACTIVE as string
-  return envVar === 'true'
-}
-
 // Feature Launch Announcements
 // If `isActive` is false, the modal will not proc for ANY user
 export const ANNOUNCEMENT: Record<string, any> = {
-  isActive: getAnnouncementActive(),
+  isActive: announcementActive,
   title: t`announcement.title`,
   subtext: t`announcement.subtext`,
   mediaUrl: t`announcement.mediaUrl`,

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -96,7 +96,7 @@ export const INFO_BANNER = process.env.REACT_APP_INFO_BANNER as string
 // Feature Launch Announcements
 // If `isActive` is false, the modal will not proc for ANY user
 export const ANNOUNCEMENT: Record<string, any> = {
-  isActive: announcementActive,
+  isActive: announcementActive === 'true',
   title: t`announcement.title`,
   subtext: t`announcement.subtext`,
   mediaUrl: t`announcement.mediaUrl`,

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -5,6 +5,8 @@ import { Crypto } from '@peculiar/webcrypto'
 import 'locales' // Locales necessary for I18nProvider
 import { server } from './test-utils'
 
+jest.setTimeout(20000)
+
 // Mock WebCrypto APIs
 // Redeclare the type of `global` as it does not include the `crypto` prop
 interface Global extends NodeJS.Global {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -5,7 +5,10 @@ import { Crypto } from '@peculiar/webcrypto'
 import 'locales' // Locales necessary for I18nProvider
 import { server } from './test-utils'
 
-jest.setTimeout(20000)
+// Some tests take longer than the default 5s to run.
+// Hence, allow the test timeout to be configured.
+const TEST_TIMEOUT = +(process.env.REACT_APP_TEST_TIMEOUT ?? 20000)
+jest.setTimeout(TEST_TIMEOUT)
 
 // Mock WebCrypto APIs
 // Redeclare the type of `global` as it does not include the `crypto` prop

--- a/frontend/src/test-utils/api/index.ts
+++ b/frontend/src/test-utils/api/index.ts
@@ -122,11 +122,9 @@ function mockSettingsApis(state: State) {
       const { announcement_version } = req.body as {
         announcement_version?: string
       }
-
       if (!announcement_version) {
         return res(ctx.status(400))
       }
-
       return res(ctx.status(200))
     }),
     rest.get('/settings/email/from', (_req, res, ctx) => {

--- a/frontend/src/test-utils/api/index.ts
+++ b/frontend/src/test-utils/api/index.ts
@@ -118,6 +118,17 @@ function mockSettingsApis(state: State) {
         })
       )
     }),
+    rest.put('/settings/announcement-version', (req, res, ctx) => {
+      const { announcement_version } = req.body as {
+        announcement_version?: string
+      }
+
+      if (!announcement_version) {
+        return res(ctx.status(400))
+      }
+
+      return res(ctx.status(200))
+    }),
     rest.get('/settings/email/from', (_req, res, ctx) => {
       return res(
         ctx.status(200),


### PR DESCRIPTION
We were experiencing flaky tests as described in issue #1161.

## Problem

2 issues:
1. Some tests were failing with an error saying that the test exceeded the timeout of 5000ms.

2. The integration tests were written under the assumption that `REACT_APP_ANNOUNCEMENT_ACTIVE != "true"`. However, if it is set to `true`, the integration tests will break due to missing API endpoints and the tests not accounting for the need to dismiss the announcement modal.

Closes #1161

## Solution

- Increase the timeout of each test to 20s. 10s works fine locally on a MBP 16", but given that CI servers are likely slower, 2x the timeout to be safe.
- Add a dummy API mock for `/settings/announcement-version`
- Disable announcements for tests to enforce the assumption that `REACT_APP_ANNOUNCEMENT_ACTIVE=false`. This is fine because none of our tests rely on announcements.

Note: a longer term fix would be to add support for `announcement_version` in the API mocks, and configure the initial `announcement_version` appropriately during each test.

## Tests

All CI tests should pass reliably.

## Deploy Notes

 - Amplify no longer runs the tests. Any test failures should be caught on Travis during development. If a test failure does get to deployment, we can manually redeploy an older release.
