### PR TITLE
[develop] v1.23.0

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "description": "Backend / API server for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "private": true,
   "scripts": {
     "start": "react-scripts start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.22.4",
+  "version": "1.23.0",
   "description": "Workers for Postman",
   "main": "build/server.js",
   "scripts": {


### PR DESCRIPTION
**Features**:

- Allow activation of SNS as a fallback for SMS
- Support whitelisting of domains through a new `agencies` table

**Improvements**:

- Upgrade worker and backend Docker instances to use Python 3
- Add frontend tests for critical workflows
- Only prepend "Copy of" when a campaign name doesn't already have it
- Upgrade dependencies

**Bug Fixes**:

- Fix parsing of SendGrid email callbacks and disable custom from for SendGrid emails
- Prevent dashboard rows and campaign titles from overflowing
- Update message delivery statuses only if error does not exist

## Tests

Test frontend tests: #1086
Test campaign title overflow fixes: #1147
Test `agencies` table: #1141
Test SNS fallback: #1019
Test SendGrid fallback: #1026
Test message delivery statuses: #1150

**Frontend tests**
- [x] Frontend tests run and pass on Travis

**Campaign title overflow fixes**
- [x] A long campaign title doesn't cause dashboard rows to overflow
- [x] A long campaign title gets truncated in the edit campaign page
- [x] "Copy of" is only prepended to a campaign title that doesn't already have it

**`agencies` whitelisting title** (tested on staging only)
- [x] Adding `@gmail.com` to the table allows OTPs to be sent to those emails
- [x] Removing `@gmail.com` from the table disallows OTPs from being sent to those emails
- [x] OTPs can be sent to `.gov.sg` emails

**SNS SMS fallback** (tested on staging only)
- [ ] All SMSes are sent with SNS with a sender ID of `Postman` during fallback (SNS receives it, but it isn't delivered due to exceeding the quota)
- [x] Validating a new credential should error during fallback
- [x] Validating an existing credential should error during fallback
- [x] Adding a new credential to a campaign should error during fallback
 
**SendGrid email fallback** (tested on staging only)
- [x] All emails are sent with default from during fallback
- [x] Sends email campaign with SendGrid
- [x] SendGrid delivery statuses are set correctly (`status` and `error_code`)
- [x] Sends email campaign with SES
- [x] SES delivery statuses are set correctly (`status` and `error_code`)
- [x] Storing a template with a custom from address should error during fallback
- [x] Verifying a custom from address should error during fallback

**SMS delivery status** (skipped)
- [ ] Calling /callback/sms with an error then a success should log the status as an ERROR
- [ ] Calling /callback/sms with a success than an error should log the status as an ERROR

**Smoke tests**
- [x] Send email campaign
- [x] Send protected email campaign
- [x] View a protected email
- [x] Unsubscribe from a mailing list
- [x] Send Telegram campaign
- [x] Send SMS campaign

## Deploy Notes

Frontend tests have been added and should be run on every Travis and Amplify build. If any test fails, the entire frontend build should fail. In particular, Amplify should not publish the failed build.

**New environment variables**:

In both backend and worker:
- `SMS_FALLBACK_ACTIVATE` : Switch to true to use SNS as fallback for all SMS campaigns
- `SMS_FALLBACK_SENDER_ID`: Sender ID to use for SNS SMSes
- `EMAIL_FALLBACK_ACTIVATE`: Switch to true to use SendGrid as fallback for all emails. Ensure that the SMTP settings are properly configured as well.

**New dependencies**:

- `@aws-sdk/sns-client` : AWS SNS Client

**New dev dependencies**:

In frontend:
- `msw`: to mock backend API responses
- `@testing-library/react`: for idiomatic react testing APIs
- `@testing-library/jest-dom`: for idiomatic DOM assertion APIs
- `@testing-library/user-event`: for idiomatic DOM user event APIs
- `jest-canvas-mock`: to mock Canvas for Lottie as jsdom doesn't implement it
- `@peculiar/webcrypto`: as jsdom doesn't implement the WebCrypto API

**Upgraded dependencies**:
| Dependency | From | To |
| :------------ | :-----| :-- |
| redis | 3.0.2 | 3.1.2 |
| react-draft-wysiwyg | 1.14.5 | 1.14.6 |
| validator | 13.0.0 | 13.6.0 |
| @types/cheerio | 0.22.24 | 0.22.28 |
| @types/node | 14.14.31 | 14.14.42 |
| twilio | 3.55.1 | 3.58.0 |
| moment | 2.24.0 | 2.29.1 |
| @types/papaparse | 5.0.3 | 5.2.5 |

**New scripts**:

- `test`: Runs the frontend tests. This should be run on every Travis  build. If any test fails, the entire frontend build should fail.

**IAM policy changes**
- Attach `postmangovsg-SNSPublishSMS` to production Beanstalk instance role
- Attach `postmangovsg-SNSPublishSMS` to production ECS task role