### PR TITLE
fix(backend): docker build and tsc output directory structure

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,6 +19,7 @@ RUN npm ci
 
 COPY src ./src
 COPY tsconfig.json ./
+COPY tsconfig.build.json ./
 
 RUN npm run build
 RUN npm prune --production

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -23,7 +23,7 @@
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./build",                      /* Redirect output structure to the directory. */
-    "rootDir": "./",                          /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src",                          /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "incremental": true,                   /* Enable incremental compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -51,13 +51,13 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    "baseUrl": "./src",                       /* Base directory to resolve non-absolute module names. */
     "paths": {
-      "@core/*": ["src/core/*"],
-      "@sms/*": ["src/sms/*"],
-      "@email/*": ["src/email/*"],
-      "@telegram/*": ["src/telegram/*"],
-      "@test-utils/*": ["src/test-utils/*"],
+      "@core/*": ["core/*"],
+      "@sms/*": ["sms/*"],
+      "@email/*": ["email/*"],
+      "@telegram/*": ["telegram/*"],
+      "@test-utils/*": ["test-utils/*"],
     },                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */


### PR DESCRIPTION
## Problem
Deployments for backends were failing after merging #940 because:
1. `tsconfig.build.json` was not copied into the image during Docker build
2. `rootDir` was changed in `backend/tsconfig.json`, this results in a different build directory structure being created. `npm start` fails because `server.js` now resides in `build/src/server.js`.

## Solution

**Bug Fixes**:

- Copied `tsconfig.build.json` into the Docker image
- Reverted `rootDir` to `./src`. Also reverted `baseUrl` for consistency.

## Tests
- Deploy this branch and observe that the Elastic Beanstalk deploy succeeds on AWS console 
