### PR TITLE
fix: fix error when updating Telegram ID for an existing phone number

### DIFF
--- a/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
+++ b/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
@@ -1,0 +1,153 @@
+import { Sequelize } from 'sequelize-typescript'
+import { TelegrafContext } from 'telegraf/typings/context'
+import sequelizeLoader from '@test-utils/sequelize-loader'
+import { RedisService } from '@core/services'
+import { BotSubscriber, TelegramSubscriber } from '@telegram/models'
+import { contactMessageHandler } from '../contact'
+
+let sequelize: Sequelize
+beforeAll(async () => {
+  sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
+})
+
+afterAll(async () => {
+  await sequelize.close()
+  await new Promise((resolve) => {
+    RedisService.otpClient.quit(resolve)
+  })
+  await new Promise((resolve) => {
+    RedisService.sessionClient.quit(resolve)
+  })
+  await new Promise((resolve) => setImmediate(resolve))
+})
+
+describe('contactMessageHandler', () => {
+  const botId = '123456789'
+  const phoneNumber = '+6591234567'
+  const telegramId = 123456789
+
+  const createMockContext = (
+    phoneNumber: string,
+    userId: number
+  ): TelegrafContext => {
+    const ctx: any = {
+      reply: jest.fn(),
+      from: {
+        id: userId,
+      },
+      message: {
+        contact: {
+          phone_number: phoneNumber,
+          user_id: userId,
+        },
+      },
+    }
+    return ctx
+  }
+
+  const insertBotSubscription = async (
+    phoneNumber: string,
+    telegramId: number,
+    botId: string
+  ): Promise<void> => {
+    await TelegramSubscriber.create({
+      phoneNumber,
+      telegramId,
+    })
+    await BotSubscriber.create({
+      botId,
+      telegramId,
+    })
+  }
+
+  afterEach(async () => {
+    await TelegramSubscriber.destroy({ where: {} })
+    await BotSubscriber.destroy({ where: {} })
+  })
+
+  test('Insertion of a new Telegram subscriber', async () => {
+    const ctx = createMockContext(phoneNumber, telegramId)
+
+    await contactMessageHandler(botId)(ctx)
+
+    const subscriber = await TelegramSubscriber.findOne({
+      where: { phoneNumber },
+    })
+    expect(subscriber).not.toBeNull()
+
+    const botSubscriber = await BotSubscriber.findOne({
+      where: { botId, telegramId },
+    })
+    expect(botSubscriber).not.toBeNull()
+
+    expect(
+      ctx.reply
+    ).toBeCalledWith(
+      'You are now subscribed. Your phone number and Telegram ID have been updated.',
+      { reply_markup: { remove_keyboard: true } }
+    )
+  })
+
+  test('Update of phone number for existing Telegram subscriber', async () => {
+    await insertBotSubscription(phoneNumber, telegramId, botId)
+    const newPhoneNumber = '+6581234567'
+    const ctx = createMockContext(newPhoneNumber, telegramId)
+
+    await contactMessageHandler(botId)(ctx)
+
+    const subscriber = await TelegramSubscriber.findOne({
+      where: { phoneNumber: newPhoneNumber },
+    })
+    expect(subscriber?.telegramId).toBe(`${telegramId}`)
+
+    const botSubscriber = await BotSubscriber.findOne({
+      where: { botId, telegramId },
+    })
+    expect(botSubscriber).not.toBeNull()
+
+    expect(
+      ctx.reply
+    ).toBeCalledWith(
+      'You were already subscribed. Your phone number and Telegram ID have been updated.',
+      { reply_markup: { remove_keyboard: true } }
+    )
+  })
+
+  test('Update of Telegram ID for existing Telegram subscriber', async () => {
+    await insertBotSubscription(phoneNumber, telegramId, botId)
+    const newTelegramId = 11111111
+    const ctx = createMockContext(phoneNumber, newTelegramId)
+
+    await contactMessageHandler(botId)(ctx)
+
+    const subscriber = await TelegramSubscriber.findOne({
+      where: { phoneNumber },
+    })
+    expect(subscriber?.telegramId).toBe(`${newTelegramId}`)
+
+    const botSubscriber = await BotSubscriber.findOne({
+      where: { botId, telegramId: newTelegramId },
+    })
+    expect(botSubscriber).not.toBeNull()
+
+    expect(
+      ctx.reply
+    ).toBeCalledWith(
+      'You were already subscribed. Your phone number and Telegram ID have been updated.',
+      { reply_markup: { remove_keyboard: true } }
+    )
+  })
+
+  test('Skip update if contact details remain the same', async () => {
+    await insertBotSubscription(phoneNumber, telegramId, botId)
+    const ctx = createMockContext(phoneNumber, telegramId)
+
+    await contactMessageHandler(botId)(ctx)
+    expect(ctx.reply).toBeCalledWith(
+      'You were already subscribed. Your phone number and Telegram ID have been updated.',
+      {
+        reply_markup: { remove_keyboard: true },
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Problem

Closes issue #1143

## Solution

**Bug Fixes**:

- Try updating either phone number or telegram ID. If no update occurs, insert a new row.

## Tests

These tests have been verified on staging.

**Users should be able to update telegram ID for an existing phone number**
1. Change your `telegram_id` to a different number in the `telegram_subscribers` table.
2. Run the `/updatenumber` command on the Telegram bot
3. The bot should say `Your phone number and Telegram ID have been updated.` and `telegram_id` should be updated in the `telegram_subscribers` table.

**Users should be able to update phone number for an existing telegram ID**
1. Change your `phone_number` to a different number in the `telegram_subscribers` table.
2. Run the `/updatenumber` command on the Telegram bot
3.  The bot should say `Your phone number and Telegram ID have been updated.` and `phone_number` should be updated in the `telegram_subscribers` table.

**Users should be able to create a new `telegram_subscribers` row**
1. Delete the row corresponding to your account in the `telegram_subscribers` table.
2. Run the `/updatenumber` command on the Telegram bot
3.  The bot should say `Your phone number and Telegram ID have been updated.` and there should be a new row reflecting your `phone_number` and `telegram_id` in the table.