### PR TITLE
Backend tests for default credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,4 @@
 {
-  "custom_plugin_paths": [],
-  "exclude": {
-    "files": "package-lock.json|^.secrets.baseline$",
-    "lines": null
-  },
   "generated_at": "2021-04-09T07:48:36Z",
   "plugins_used": [
     {
@@ -13,8 +8,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -23,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -57,24 +52,64 @@
   "results": {
     "backend/src/test-utils/test-env.ts": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/src/test-utils/test-env.ts",
         "hashed_secret": "c237a19676ad55d8904be354990dd54f92f9572c",
         "is_verified": false,
-        "line_number": 4,
-        "type": "Base64 High Entropy String"
+        "line_number": 4
       }
     ],
     "frontend/.env-example": [
       {
+        "type": "Basic Auth Credentials",
+        "filename": "frontend/.env-example",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 5,
-        "type": "Basic Auth Credentials"
+        "line_number": 5
       }
     ]
   },
-  "version": "0.14.3",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "version": "1.1.0",
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json|^.secrets.baseline$"
+      ]
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    }
+  ]
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,4 +1,9 @@
 {
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": "package-lock.json|^.secrets.baseline$",
+    "lines": null
+  },
   "generated_at": "2021-04-09T07:48:36Z",
   "plugins_used": [
     {
@@ -8,8 +13,8 @@
       "name": "ArtifactoryDetector"
     },
     {
-      "name": "Base64HighEntropyString",
-      "limit": 4.5
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
     },
     {
       "name": "BasicAuthDetector"
@@ -18,8 +23,8 @@
       "name": "CloudantDetector"
     },
     {
-      "name": "HexHighEntropyString",
-      "limit": 3
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
     },
     {
       "name": "IbmCloudIamDetector"
@@ -52,64 +57,24 @@
   "results": {
     "backend/src/test-utils/test-env.ts": [
       {
-        "type": "Base64 High Entropy String",
-        "filename": "backend/src/test-utils/test-env.ts",
         "hashed_secret": "c237a19676ad55d8904be354990dd54f92f9572c",
         "is_verified": false,
-        "line_number": 4
+        "line_number": 4,
+        "type": "Base64 High Entropy String"
       }
     ],
     "frontend/.env-example": [
       {
-        "type": "Basic Auth Credentials",
-        "filename": "frontend/.env-example",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 5
+        "line_number": 5,
+        "type": "Basic Auth Credentials"
       }
     ]
   },
-  "version": "1.1.0",
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "package-lock.json|^.secrets.baseline$"
-      ]
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    }
-  ]
+  "version": "0.14.3",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
 }

--- a/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
@@ -68,7 +68,7 @@ const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
     demoMessageLimit: isDemo ? 20 : null,
   })
 
-describe('POST /credentials', () => {
+describe('POST /campaign/{campaignId}/sms/credentials', () => {
   test('Non-Demo campaign should not be able to use demo credentials', async () => {
     const nonDemoCampaign = await createCampaign({ isDemo: false })
 

--- a/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
@@ -1,0 +1,111 @@
+import request from 'supertest'
+import { Sequelize } from 'sequelize-typescript'
+import initialiseServer from '@test-utils/server'
+import { Campaign, User } from '@core/models'
+import sequelizeLoader from '@test-utils/sequelize-loader'
+import { RedisService } from '@core/services'
+import { DefaultCredentialName } from '@core/constants'
+
+const app = initialiseServer(true)
+let sequelize: Sequelize
+
+beforeAll(async () => {
+  sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
+  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+})
+
+afterAll(async () => {
+  await Campaign.destroy({ where: {} })
+  await User.destroy({ where: {} })
+  await sequelize.close()
+  RedisService.otpClient.quit()
+  RedisService.sessionClient.quit()
+})
+
+// Setup spy method (for Mock) getSecretValue that always returns TWILIO_SECRET_VALUE
+const TWILIO_SECRET_VALUE = {
+  SecretString: JSON.stringify({
+    accountSid: '',
+    apiKey: '',
+    apiSecret: '',
+    messagingServiceSid: '',
+  }),
+}
+const mockGetSecretValue = jest.fn(() => TWILIO_SECRET_VALUE)
+
+// Setup Mock AWS SecretsManager
+jest.mock('aws-sdk', () => {
+  return {
+    ...jest.requireActual('aws-sdk'),
+    SecretsManager: function () {
+      return {
+        getSecretValue: function () {
+          return {
+            promise: mockGetSecretValue,
+          }
+        },
+      }
+    },
+  }
+})
+
+// Creates demo/non-demo campaign based on parameters
+const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
+  await Campaign.create({
+    name: 'Test Campaign',
+    userId: 1,
+    type: 'SMS',
+    protect: false,
+    valid: false,
+    demoMessageLimit: isDemo ? 20 : null,
+  })
+
+describe('POST /credentials', () => {
+  test('Non-Demo campaign should not be able to use demo credentials', async () => {
+    const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const res = await request(app)
+      .post(`/campaign/${nonDemoCampaign.id}/sms/credentials`)
+      .send({
+        label: DefaultCredentialName.SMS,
+        recipient: '98765432',
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Campaign cannot use demo credentials. ${DefaultCredentialName.SMS} is not allowed.`,
+    })
+  })
+
+  test('Demo Campaign should not be able to use non-demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    const NON_DEMO_CREDENTIAL_LABEL = 'Some Credential'
+
+    const res = await request(app)
+      .post(`/campaign/${demoCampaign.id}/sms/credentials`)
+      .send({
+        label: NON_DEMO_CREDENTIAL_LABEL,
+        recipient: '98765432',
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
+    })
+  })
+
+  test('Demo Campaign should be able to use demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    await request(app)
+      .post(`/campaign/${demoCampaign.id}/sms/credentials`)
+      .send({
+        label: DefaultCredentialName.SMS,
+        recipient: '98765432',
+      })
+
+    // Expect SecretManager to be called
+    expect(mockGetSecretValue).toHaveBeenCalled()
+  })
+})

--- a/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
+import { CredentialService, RedisService } from '@core/services'
 import { DefaultCredentialName } from '@core/constants'
 import { formatDefaultCredentialName } from '@core/utils'
 import { SmsMessage } from '@sms/models'
@@ -26,39 +26,12 @@ afterAll(async () => {
   RedisService.sessionClient.quit()
 })
 
-afterEach(async () => {
-  jest.clearAllMocks()
-})
-
-// Setup spy method (for Mock) getSecretValue that always returns TWILIO_SECRET_VALUE
-const TWILIO_SECRET_VALUE = {
-  SecretString: JSON.stringify({
-    accountSid: '',
-    apiKey: '',
-    apiSecret: '',
-    messagingServiceSid: '',
-  }),
-}
-
-// Take in SecretId as (unused) parameter so arguments can be checked within tests
-const mockGetSecretValue = jest.fn((_) => TWILIO_SECRET_VALUE)
-
-// Setup Mock AWS SecretsManager
-jest.mock('aws-sdk', () => {
-  return {
-    ...jest.requireActual('aws-sdk'),
-    SecretsManager: function () {
-      return {
-        getSecretValue: ({ SecretId }: { SecretId: string }) => ({
-          promise: () => mockGetSecretValue(SecretId),
-        }),
-      }
-    },
-  }
-})
-
 // Creates demo/non-demo campaign based on parameters
-const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
+const createCampaign = async ({
+  isDemo,
+}: {
+  isDemo: boolean
+}): Promise<Campaign> =>
   await Campaign.create({
     name: 'Test Campaign',
     userId: 1,
@@ -69,8 +42,17 @@ const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
   })
 
 describe('POST /campaign/{campaignId}/sms/credentials', () => {
+  afterEach(async () => {
+    jest.restoreAllMocks()
+  })
+
   test('Non-Demo campaign should not be able to use demo credentials', async () => {
     const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const mockGetTwilioCredentials = jest.spyOn(
+      CredentialService,
+      'getTwilioCredentials'
+    )
 
     const res = await request(app)
       .post(`/campaign/${nonDemoCampaign.id}/sms/credentials`)
@@ -84,12 +66,17 @@ describe('POST /campaign/{campaignId}/sms/credentials', () => {
       message: `Campaign cannot use demo credentials. ${DefaultCredentialName.SMS} is not allowed.`,
     })
 
-    // SecretManager should not be called
-    expect(mockGetSecretValue).not.toHaveBeenCalled()
+    // CredentialService should not be called
+    expect(mockGetTwilioCredentials).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should not be able to use non-demo credentials', async () => {
     const demoCampaign = await createCampaign({ isDemo: true })
+
+    const mockGetTwilioCredentials = jest.spyOn(
+      CredentialService,
+      'getTwilioCredentials'
+    )
 
     const NON_DEMO_CREDENTIAL_LABEL = 'Some Credential'
 
@@ -105,12 +92,22 @@ describe('POST /campaign/{campaignId}/sms/credentials', () => {
       message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
     })
 
-    // SecretManager should not be called
-    expect(mockGetSecretValue).not.toHaveBeenCalled()
+    // CredentialService should not be called
+    expect(mockGetTwilioCredentials).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should be able to use demo credentials', async () => {
     const demoCampaign = await createCampaign({ isDemo: true })
+
+    const TEST_TWILIO_CREDENTIALS = {
+      accountSid: '',
+      apiKey: '',
+      apiSecret: '',
+      messagingServiceSid: '',
+    }
+    const mockGetTwilioCredentials = jest
+      .spyOn(CredentialService, 'getTwilioCredentials')
+      .mockResolvedValue(TEST_TWILIO_CREDENTIALS)
 
     await request(app)
       .post(`/campaign/${demoCampaign.id}/sms/credentials`)
@@ -119,8 +116,8 @@ describe('POST /campaign/{campaignId}/sms/credentials', () => {
         recipient: '98765432',
       })
 
-    // Expect SecretManager to be called with default credentials
-    expect(mockGetSecretValue).toHaveBeenCalledWith(
+    // Expect CredentialService to be called with default credentials
+    expect(mockGetTwilioCredentials).toHaveBeenCalledWith(
       formatDefaultCredentialName(DefaultCredentialName.SMS)
     )
   })

--- a/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
@@ -23,6 +23,10 @@ afterAll(async () => {
   RedisService.sessionClient.quit()
 })
 
+afterEach(async () => {
+  jest.clearAllMocks()
+})
+
 // Setup spy method (for Mock) getSecretValue that always returns TWILIO_SECRET_VALUE
 const TWILIO_SECRET_VALUE = {
   SecretString: JSON.stringify({
@@ -76,6 +80,9 @@ describe('POST /credentials', () => {
     expect(res.body).toEqual({
       message: `Campaign cannot use demo credentials. ${DefaultCredentialName.SMS} is not allowed.`,
     })
+
+    // SecretManager should not be called
+    expect(mockGetSecretValue).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should not be able to use non-demo credentials', async () => {
@@ -94,6 +101,9 @@ describe('POST /credentials', () => {
     expect(res.body).toEqual({
       message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
     })
+
+    // SecretManager should not be called
+    expect(mockGetSecretValue).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should be able to use demo credentials', async () => {

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -61,7 +61,7 @@ const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
     demoMessageLimit: isDemo ? 20 : null,
   })
 
-describe('POST /credentials', () => {
+describe('POST /campaign/{campaignId}/telegram/credentials', () => {
   test('Non-Demo campaign should not be able to use demo credentials', async () => {
     const nonDemoCampaign = await createCampaign({ isDemo: false })
 

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -1,0 +1,103 @@
+import request from 'supertest'
+import { Sequelize } from 'sequelize-typescript'
+import initialiseServer from '@test-utils/server'
+import { Campaign, User } from '@core/models'
+import sequelizeLoader from '@test-utils/sequelize-loader'
+import { RedisService } from '@core/services'
+import { DefaultCredentialName } from '@core/constants'
+
+const app = initialiseServer(true)
+let sequelize: Sequelize
+
+beforeAll(async () => {
+  sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
+  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+})
+
+afterAll(async () => {
+  await Campaign.destroy({ where: {} })
+  await User.destroy({ where: {} })
+  await sequelize.close()
+  RedisService.otpClient.quit()
+  RedisService.sessionClient.quit()
+})
+
+// Setup spy method (for Mock) getSecretValue that always returns TELEGRAM_SECRET_VALUE
+const TELEGRAM_SECRET_VALUE = {
+  SecretString: 'TEST_TELEGRAM_API_TOKEN',
+}
+const mockGetSecretValue = jest.fn(() => TELEGRAM_SECRET_VALUE)
+
+// Setup Mock AWS SecretsManager
+jest.mock('aws-sdk', () => {
+  return {
+    ...jest.requireActual('aws-sdk'),
+    SecretsManager: function () {
+      return {
+        getSecretValue: function () {
+          return {
+            promise: mockGetSecretValue,
+          }
+        },
+      }
+    },
+  }
+})
+
+// Creates demo/non-demo campaign based on parameters
+const createCampaign = async ({ isDemo }: { isDemo: boolean }) =>
+  await Campaign.create({
+    name: 'Test Campaign',
+    userId: 1,
+    type: 'TELEGRAM',
+    protect: false,
+    valid: false,
+    demoMessageLimit: isDemo ? 20 : null,
+  })
+
+describe('POST /credentials', () => {
+  test('Non-Demo campaign should not be able to use demo credentials', async () => {
+    const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const res = await request(app)
+      .post(`/campaign/${nonDemoCampaign.id}/telegram/credentials`)
+      .send({
+        label: DefaultCredentialName.Telegram,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Campaign cannot use demo credentials. ${DefaultCredentialName.Telegram} is not allowed.`,
+    })
+  })
+
+  test('Demo Campaign should not be able to use non-demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    const NON_DEMO_CREDENTIAL_LABEL = 'Some Credential'
+
+    const res = await request(app)
+      .post(`/campaign/${demoCampaign.id}/telegram/credentials`)
+      .send({
+        label: NON_DEMO_CREDENTIAL_LABEL,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
+    })
+  })
+
+  test('Demo Campaign should be able to use demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    await request(app)
+      .post(`/campaign/${demoCampaign.id}/telegram/credentials`)
+      .send({
+        label: DefaultCredentialName.Telegram,
+      })
+
+    // Expect SecretManager to be called
+    expect(mockGetSecretValue).toHaveBeenCalled()
+  })
+})

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -23,6 +23,10 @@ afterAll(async () => {
   RedisService.sessionClient.quit()
 })
 
+afterEach(async () => {
+  jest.clearAllMocks()
+})
+
 // Setup spy method (for Mock) getSecretValue that always returns TELEGRAM_SECRET_VALUE
 const TELEGRAM_SECRET_VALUE = {
   SecretString: 'TEST_TELEGRAM_API_TOKEN',
@@ -68,6 +72,9 @@ describe('POST /credentials', () => {
     expect(res.body).toEqual({
       message: `Campaign cannot use demo credentials. ${DefaultCredentialName.Telegram} is not allowed.`,
     })
+
+    // SecretManager should not be called
+    expect(mockGetSecretValue).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should not be able to use non-demo credentials', async () => {
@@ -85,6 +92,9 @@ describe('POST /credentials', () => {
     expect(res.body).toEqual({
       message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
     })
+
+    // SecretManager should not be called
+    expect(mockGetSecretValue).not.toHaveBeenCalled()
   })
 
   test('Demo Campaign should be able to use demo credentials', async () => {


### PR DESCRIPTION
Closes [#1167]

## Tests

- Add tests for SMS and Telegram channel to ensure
  - only demo campaigns can get demo credentials
  - demo campaigns can only get demo credentials