### PR TITLE
chore: add docker hub login before worker deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ jobs:
       script:
         - npm run lint-no-fix
       before_deploy:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - cd $TRAVIS_BUILD_DIR/worker && ./before-deploy.sh
       deploy:
         - provider: script


### PR DESCRIPTION
## Problem

Closes #1052 

## Solution

**Improvements**:
- Create Docker hub account and login in Travis

## Tests
- Ensure that build and deploy succeed for workers

## Deploy Notes

**New environment variables**:
- `DOCKER_USERNAME` : Docker Hub username
- `DOCKER_PASSWORD` : Docker Hub access token since we enabled 2FA logins