### PR TITLE
chore(worker): parallel ecs deploys and exit deploy script on error

### DIFF
--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -24,5 +24,6 @@ docker build -t $TAG .
 docker push $TAG
 
 # Update ECS
-./ecs-deploy -c $CLUSTER -n $SENDING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300
-./ecs-deploy -c $CLUSTER -n $LOGGING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300
+./ecs-deploy -c $CLUSTER -n $SENDING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300 &
+./ecs-deploy -c $CLUSTER -n $LOGGING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300 &
+wait

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Exit on failure of any command
+set -e
+# Keep track of the last executed command
+trap 'LAST_COMMAND=$CURRENT_COMMAND; CURRENT_COMMAND=$BASH_COMMAND' DEBUG
+# Echo an error message before exiting
+trap 'echo "\"${LAST_COMMAND}\" command failed with exit code $?."' EXIT
+
 CLUSTER=$1
 SENDING_SERVICE=$2
 LOGGING_SERVICE=$3

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -24,6 +24,6 @@ docker build -t $TAG .
 docker push $TAG
 
 # Update ECS
-./ecs-deploy -c $CLUSTER -n $SENDING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300 &
-./ecs-deploy -c $CLUSTER -n $LOGGING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 300 &
+./ecs-deploy -c $CLUSTER -n $SENDING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 600 &
+./ecs-deploy -c $CLUSTER -n $LOGGING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 600 &
 wait

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -4,7 +4,7 @@ set -e
 # Keep track of the last executed command
 trap 'LAST_COMMAND=$CURRENT_COMMAND; CURRENT_COMMAND=$BASH_COMMAND' DEBUG
 # Echo an error message before exiting
-trap 'echo "\"${LAST_COMMAND}\" command failed with exit code $?."' EXIT
+trap 'echo "\"${LAST_COMMAND}\" command failed with exit code $?."' ERR
 
 CLUSTER=$1
 SENDING_SERVICE=$2

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -25,5 +25,9 @@ docker push $TAG
 
 # Update ECS
 ./ecs-deploy -c $CLUSTER -n $SENDING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 600 &
+SENDER_DEPLOY_PID=$!
 ./ecs-deploy -c $CLUSTER -n $LOGGING_SERVICE -i $TAG -r $AWS_DEFAULT_REGION --use-latest-task-def -t 600 &
-wait
+LOGGER_DEPLOY_PID=$!
+
+wait $SENDER_DEPLOY_PID
+wait $LOGGER_DEPLOY_PID


### PR DESCRIPTION
## Problem

Closes #1049 

## Solution

**Improvements**:
- Set shell script to exit on error and print out command that failed
- Run `ecs-deploy` in parallel to speed up deploy slightly

## Tests
- Ensure that build and deploy succeed for workers
- Observe that deploys for sender and logger runs in parallel