### PR TITLE
Backend tests for Credentials (Telegram/Twilio)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -9,6 +9,7 @@ module.exports = {
     '@telegram/(.*)': '<rootDir>/src/telegram/$1',
     '@test-utils/(.*)': '<rootDir>/src/test-utils/$1',
     '@shared/(.*)': '<rootDir>/../shared/src/$1',
+    '@mocks/(.*)': '<rootDir>/src/__mocks__/$1',
   },
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -11,6 +11,7 @@ module.exports = {
     '@shared/(.*)': '<rootDir>/../shared/src/$1',
     '@mocks/(.*)': '<rootDir>/src/__mocks__/$1',
   },
+  modulePathIgnorePatterns: ['<rootDir>/build'],
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },

--- a/backend/src/__mocks__/aws-sdk.ts
+++ b/backend/src/__mocks__/aws-sdk.ts
@@ -1,0 +1,28 @@
+// Defining these in global scope so tests can mock their implementation
+const getSecretValuePromise = jest.fn()
+const createSecretPromise = jest.fn()
+const putSecretValuePromise = jest.fn()
+
+const mockSecretsManager = {
+  getSecretValue: jest.fn(() => ({
+    promise: getSecretValuePromise,
+  })),
+  createSecret: jest.fn(() => ({
+    promise: createSecretPromise,
+  })),
+  putSecretValue: jest.fn(() => ({
+    promise: putSecretValuePromise,
+  })),
+}
+
+const MockAWS = {
+  // By default, use unmocked version of AWS services
+  ...jest.requireActual('aws-sdk'),
+
+  SecretsManager: function (): {} {
+    return mockSecretsManager
+  },
+}
+
+export { mockSecretsManager }
+export default MockAWS

--- a/backend/src/__mocks__/telegraf.ts
+++ b/backend/src/__mocks__/telegraf.ts
@@ -1,0 +1,14 @@
+const mockTelegram = {
+  sendMessage: jest.fn(),
+  setWebhook: jest.fn(),
+  setMyCommands: jest.fn(),
+  getMe: jest.fn(),
+}
+
+const Telegram = jest.fn(() => mockTelegram)
+
+// For now, return actual Telegraf implementation if it's required
+const Telegraf = jest.requireActual('telegraf')
+
+export { Telegram, mockTelegram }
+export default Telegraf

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -122,7 +122,7 @@ const getTelegramCredential = async (name: string): Promise<string> => {
   const logMeta = { name, action: 'getTelegramCredential' }
   const data = await secretsManager.getSecretValue({ SecretId: name }).promise()
   logger.info({
-    messge: 'Retrieved secret from AWS secrets manager.',
+    message: 'Retrieved secret from AWS secrets manager.',
     ...logMeta,
   })
   const secretString = get(data, 'SecretString', '')

--- a/backend/src/sms/routes/tests/sms-settings.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-settings.routes.test.ts
@@ -1,0 +1,113 @@
+import request from 'supertest'
+import { Sequelize } from 'sequelize-typescript'
+import initialiseServer from '@test-utils/server'
+import { Credential, UserCredential, User } from '@core/models'
+import sequelizeLoader from '@test-utils/sequelize-loader'
+import { RedisService } from '@core/services'
+import { ChannelType } from '@core/constants'
+import { mockSecretsManager } from '@mocks/aws-sdk'
+import { SmsService } from '@sms/services'
+
+const app = initialiseServer(true)
+let sequelize: Sequelize
+
+beforeAll(async () => {
+  sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
+  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+})
+
+afterAll(async () => {
+  await UserCredential.destroy({ where: {} })
+  await Credential.destroy({ where: {} })
+  await User.destroy({ where: {} })
+  await sequelize.close()
+  RedisService.otpClient.quit()
+  RedisService.sessionClient.quit()
+})
+
+describe('POST /settings/sms/credentials', () => {
+  afterEach(async () => {
+    // Reset number of calls for mocked functions
+    jest.clearAllMocks()
+  })
+
+  test('User should not be able to add custom credential using invalid Twilio API key', async () => {
+    // Mock Twilio API to fail
+    const ERROR_MESSAGE = 'Some Error'
+    const mockSendValidationMessage = jest
+      .spyOn(SmsService, 'sendValidationMessage')
+      .mockRejectedValue(new Error(ERROR_MESSAGE))
+
+    const res = await request(app).post('/settings/sms/credentials').send({
+      label: 'sms-credential-1',
+      recipient: '81234567',
+      twilio_account_sid: 'twilio_account_sid',
+      twilio_api_key: 'twilio_api_key',
+      twilio_api_secret: 'twilio_api_secret',
+      twilio_messaging_service_sid: 'twilio_messaging_service_sid',
+    })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Error: ${ERROR_MESSAGE}`,
+    })
+
+    expect(mockSecretsManager.createSecret).not.toHaveBeenCalled()
+    mockSendValidationMessage.mockRestore()
+  })
+
+  test('User should be able to add custom credential using valid Twilio API key', async () => {
+    const CREDENTIAL_LABEL = 'sms-credential-1'
+    const mockSendValidationMessage = jest
+      .spyOn(SmsService, 'sendValidationMessage')
+      .mockResolvedValue()
+
+    // getEncodedHash is used as the stored name in AWS SecretsManager
+    const HASHED_CREDS = 'HASHED_CREDS'
+    const mockGetEncodedHash = jest
+      .spyOn(SmsService, 'getEncodedHash')
+      .mockResolvedValue(HASHED_CREDS)
+
+    const res = await request(app).post('/settings/sms/credentials').send({
+      label: CREDENTIAL_LABEL,
+      recipient: '81234567',
+      twilio_account_sid: 'twilio_account_sid',
+      twilio_api_key: 'twilio_api_key',
+      twilio_api_secret: 'twilio_api_secret',
+      twilio_messaging_service_sid: 'twilio_messaging_service_sid',
+    })
+
+    expect(res.status).toBe(200)
+
+    expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Name: HASHED_CREDS,
+        SecretString: JSON.stringify({
+          accountSid: 'twilio_account_sid',
+          apiKey: 'twilio_api_key',
+          apiSecret: 'twilio_api_secret',
+          messagingServiceSid: 'twilio_messaging_service_sid',
+        }),
+      })
+    )
+
+    // Ensure credential was added into DB
+    const dbCredential = await Credential.findOne({
+      where: {
+        name: HASHED_CREDS,
+      },
+    })
+    expect(dbCredential).not.toBe(null)
+
+    const dbUserCredential = await UserCredential.findOne({
+      where: {
+        label: CREDENTIAL_LABEL,
+        type: ChannelType.SMS,
+        credName: HASHED_CREDS,
+        userId: 1,
+      },
+    })
+    expect(dbUserCredential).not.toBe(null)
+    mockSendValidationMessage.mockRestore()
+    mockGetEncodedHash.mockRestore()
+  })
+})

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -127,6 +127,100 @@ describe('POST /campaign/{campaignId}/telegram/credentials', () => {
   })
 })
 
+describe('POST /campaign/{campaignId}/telegram/new-credentials', () => {
+  beforeAll(async () => {
+    // Mock telegram to always accept credential
+    mockTelegram.setWebhook.mockResolvedValue(true)
+    mockTelegram.setMyCommands.mockResolvedValue(true)
+  })
+
+  afterAll(async () => {
+    mockTelegram.setWebhook.mockReset()
+    mockTelegram.setMyCommands.mockReset()
+  })
+
+  afterEach(async () => {
+    // Reset number of calls for mocked functions
+    jest.clearAllMocks()
+  })
+
+  test('Demo Campaign should not be able to create custom credential', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    const FAKE_API_TOKEN = 'Some API Token'
+
+    const res = await request(app)
+      .post(`/campaign/${demoCampaign.id}/telegram/new-credentials`)
+      .send({
+        telegram_bot_token: FAKE_API_TOKEN,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Action disabled for demo campaign`,
+    })
+
+    expect(mockSecretsManager.createSecret).not.toHaveBeenCalled()
+  })
+
+  test('User should not be able to add custom credential using invalid Telegram API key', async () => {
+    const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const INVALID_API_TOKEN = 'Some Invalid API Token'
+
+    // Mock Telegram API to return 404 error (invalid token)
+    const TELEGRAM_ERROR_STRING = '404: Not Found'
+    mockTelegram.getMe.mockRejectedValue(new Error(TELEGRAM_ERROR_STRING))
+
+    const res = await request(app)
+      .post(`/campaign/${nonDemoCampaign.id}/telegram/new-credentials`)
+      .send({
+        telegram_bot_token: INVALID_API_TOKEN,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Error: Invalid token. ${TELEGRAM_ERROR_STRING}`,
+    })
+
+    expect(mockSecretsManager.createSecret).not.toHaveBeenCalled()
+    mockTelegram.getMe.mockReset()
+  })
+
+  test('User should be able to add custom credential using valid Telegram API key', async () => {
+    const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const VALID_API_TOKEN = '12345:Some Valid API Token'
+
+    // Mock Telegram API to return a bot with user id 12345
+    mockTelegram.getMe.mockResolvedValue({ id: 12345 })
+
+    const res = await request(app)
+      .post(`/campaign/${nonDemoCampaign.id}/telegram/new-credentials`)
+      .send({
+        telegram_bot_token: VALID_API_TOKEN,
+      })
+
+    expect(res.status).toBe(200)
+
+    expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Name: '12345',
+        SecretString: VALID_API_TOKEN,
+      })
+    )
+
+    // Ensure credential was added into DB
+    const dbCredential = await Credential.findOne({
+      where: {
+        name: '12345',
+      },
+    })
+    expect(dbCredential).not.toBe(null)
+    mockTelegram.getMe.mockReset()
+  })
+})
+
 describe('PUT /campaign/{campaignId}/telegram/template', () => {
   test('Template with only invalid HTML tags is not accepted', async () => {
     const testBody = await request(app)

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -1,35 +1,130 @@
 import request from 'supertest'
 import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
-import { Campaign, User } from '@core/models'
+import { Campaign, User, Credential } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { RedisService } from '@core/services'
+import { DefaultCredentialName } from '@core/constants'
+import { formatDefaultCredentialName } from '@core/utils'
 import { TelegramMessage } from '@telegram/models'
 import { ChannelType } from '@core/constants'
+import { mockSecretsManager } from '@mocks/aws-sdk'
+import { mockTelegram, Telegram } from '@mocks/telegraf'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
 let campaignId: number
 
+// Helper function to create demo/non-demo campaign based on parameters
+const createCampaign = async ({
+  isDemo,
+}: {
+  isDemo: boolean
+}): Promise<Campaign> =>
+  await Campaign.create({
+    name: 'test-campaign',
+    userId: 1,
+    type: ChannelType.Telegram,
+    protect: false,
+    valid: false,
+    demoMessageLimit: isDemo ? 20 : null,
+  })
+
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
   await User.create({ id: 1, email: 'user@agency.gov.sg' })
-  const campaign = await Campaign.create({
-    name: 'campaign-1',
-    userId: 1,
-    type: ChannelType.Telegram,
-    valid: false,
-  })
+  const campaign = await createCampaign({ isDemo: false })
   campaignId = campaign.id
 })
 
 afterAll(async () => {
   await TelegramMessage.destroy({ where: {} })
   await Campaign.destroy({ where: {} })
+  await Credential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
   RedisService.otpClient.quit()
   RedisService.sessionClient.quit()
+})
+
+describe('POST /campaign/{campaignId}/telegram/credentials', () => {
+  beforeAll(async () => {
+    // Mock telegram to always accept credential
+    mockTelegram.setWebhook.mockResolvedValue(true)
+    mockTelegram.setMyCommands.mockResolvedValue(true)
+    mockTelegram.getMe.mockResolvedValue({ id: 1 })
+  })
+
+  afterAll(async () => {
+    mockTelegram.setWebhook.mockReset()
+    mockTelegram.setMyCommands.mockReset()
+    mockTelegram.getMe.mockReset()
+  })
+
+  afterEach(async () => {
+    // Reset number of calls for mocked functions
+    jest.clearAllMocks()
+  })
+
+  test('Non-Demo campaign should not be able to use demo credentials', async () => {
+    const nonDemoCampaign = await createCampaign({ isDemo: false })
+
+    const res = await request(app)
+      .post(`/campaign/${nonDemoCampaign.id}/telegram/credentials`)
+      .send({
+        label: DefaultCredentialName.Telegram,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Campaign cannot use demo credentials. ${DefaultCredentialName.Telegram} is not allowed.`,
+    })
+
+    expect(mockSecretsManager.getSecretValue).not.toHaveBeenCalled()
+  })
+
+  test('Demo Campaign should not be able to use non-demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    const NON_DEMO_CREDENTIAL_LABEL = 'Some Credential'
+
+    const res = await request(app)
+      .post(`/campaign/${demoCampaign.id}/telegram/credentials`)
+      .send({
+        label: NON_DEMO_CREDENTIAL_LABEL,
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Demo campaign must use demo credentials. ${NON_DEMO_CREDENTIAL_LABEL} is not allowed.`,
+    })
+
+    expect(mockSecretsManager.getSecretValue).not.toHaveBeenCalled()
+  })
+
+  test('Demo Campaign should be able to use demo credentials', async () => {
+    const demoCampaign = await createCampaign({ isDemo: true })
+
+    const DEFAULT_TELEGRAM_CREDENTIAL = '12345'
+    mockSecretsManager.getSecretValue().promise.mockResolvedValue({
+      SecretString: DEFAULT_TELEGRAM_CREDENTIAL,
+    })
+
+    const res = await request(app)
+      .post(`/campaign/${demoCampaign.id}/telegram/credentials`)
+      .send({
+        label: DefaultCredentialName.Telegram,
+      })
+
+    expect(res.status).toBe(200)
+
+    expect(mockSecretsManager.getSecretValue).toHaveBeenCalledWith({
+      SecretId: formatDefaultCredentialName(DefaultCredentialName.Telegram),
+    })
+    expect(Telegram).toHaveBeenCalledWith(DEFAULT_TELEGRAM_CREDENTIAL)
+
+    mockSecretsManager.getSecretValue().promise.mockReset()
+  })
 })
 
 describe('PUT /campaign/{campaignId}/telegram/template', () => {

--- a/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
@@ -1,0 +1,105 @@
+import request from 'supertest'
+import { Sequelize } from 'sequelize-typescript'
+import initialiseServer from '@test-utils/server'
+import { Credential, UserCredential, User } from '@core/models'
+import sequelizeLoader from '@test-utils/sequelize-loader'
+import { RedisService } from '@core/services'
+import { ChannelType } from '@core/constants'
+import { mockTelegram } from '@mocks/telegraf'
+import { mockSecretsManager } from '@mocks/aws-sdk'
+
+const app = initialiseServer(true)
+let sequelize: Sequelize
+
+beforeAll(async () => {
+  sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
+  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+})
+
+afterAll(async () => {
+  await UserCredential.destroy({ where: {} })
+  await User.destroy({ where: {} })
+  await sequelize.close()
+  RedisService.otpClient.quit()
+  RedisService.sessionClient.quit()
+})
+
+describe('POST /settings/telegram/credentials', () => {
+  beforeAll(async () => {
+    // Mock telegram to always accept credential
+    mockTelegram.setWebhook.mockResolvedValue(true)
+    mockTelegram.setMyCommands.mockResolvedValue(true)
+  })
+
+  afterAll(async () => {
+    mockTelegram.setWebhook.mockReset()
+    mockTelegram.setMyCommands.mockReset()
+  })
+
+  afterEach(async () => {
+    // Reset number of calls for mocked functions
+    jest.clearAllMocks()
+  })
+
+  test('User should not be able to add custom credential using invalid Telegram API key', async () => {
+    const INVALID_API_TOKEN = 'Some Invalid API Token'
+
+    // Mock Telegram API to return 404 error (invalid token)
+    const TELEGRAM_ERROR_STRING = '404: Not Found'
+    mockTelegram.getMe.mockRejectedValue(new Error(TELEGRAM_ERROR_STRING))
+
+    const res = await request(app).post('/settings/telegram/credentials').send({
+      label: 'telegram-credential-1',
+      telegram_bot_token: INVALID_API_TOKEN,
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      message: `Error: Invalid token. ${TELEGRAM_ERROR_STRING}`,
+    })
+
+    expect(mockSecretsManager.createSecret).not.toHaveBeenCalled()
+    mockTelegram.getMe.mockReset()
+  })
+
+  test('User should be able to add custom credential using valid Telegram API key', async () => {
+    const VALID_API_TOKEN = '12345:Some Valid API Token'
+    const CREDENTIAL_LABEL = 'telegram-credential-1'
+
+    // Mock Telegram API to return a bot with user id 12345
+    mockTelegram.getMe.mockResolvedValue({ id: 12345 })
+
+    const res = await request(app).post('/settings/telegram/credentials').send({
+      label: CREDENTIAL_LABEL,
+      telegram_bot_token: VALID_API_TOKEN,
+    })
+
+    expect(res.status).toBe(200)
+
+    expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Name: '12345',
+        SecretString: VALID_API_TOKEN,
+      })
+    )
+
+    // Ensure credential was added into DB
+    const dbCredential = await Credential.findOne({
+      where: {
+        name: '12345',
+      },
+    })
+    expect(dbCredential).not.toBe(null)
+
+    const dbUserCredential = await UserCredential.findOne({
+      where: {
+        label: CREDENTIAL_LABEL,
+        type: ChannelType.Telegram,
+        credName: '12345',
+        userId: 1,
+      },
+    })
+    expect(dbUserCredential).not.toBe(null)
+    mockTelegram.getMe.mockReset()
+  })
+})

--- a/backend/src/telegram/services/telegram-client.class.ts
+++ b/backend/src/telegram/services/telegram-client.class.ts
@@ -51,12 +51,7 @@ export default class TelegramClient {
    */
   public getBotInfo(): Promise<string | number> {
     return this.client.getMe().then((user) => {
-      const { is_bot: isBot, id } = user
-      if (!isBot) {
-        Promise.reject(new Error('User is not a bot.'))
-      }
-
-      return id
+      return user.id
     })
   }
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -41,10 +41,11 @@
       "@email/*": ["email/*"],
       "@telegram/*": ["telegram/*"],
       "@shared/*": ["../../shared/src/*"],
-      "@test-utils/*": ["test-utils/*"]
+      "@test-utils/*": ["test-utils/*"],
+      "@mocks/*": ["__mocks__/*"],
     },
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
   }
 }


### PR DESCRIPTION
Closes [#1167]

- Implements manual mocks for `aws-sdk`, `telegraf`
- Note: Twilio hasn't been mocked because it's not needed here - the SMS tests were mocked at the SMSService level so I don't need to populate SMSTemplates and test the message hydration flow

## Tests
- `/credentials` and `/new-credentials` endpoint for Telegram and SMS
- `/settings/telegram/credentials` and `/settings/sms/credentials`