### PR TITLE
Improvements to decrease memory usage in verify backup service

### DIFF
--- a/backend/src/test-utils/setup.ts
+++ b/backend/src/test-utils/setup.ts
@@ -1,12 +1,12 @@
-/* eslint-disable no-console */
-global.console = {
-  ...global.console,
-  log: jest.fn(), // console.log are ignored in tests
-  error: console.error,
-  warn: console.warn,
-  info: console.info,
-  debug: console.debug,
-}
+// /* eslint-disable no-console */
+// global.console = {
+//   ...global.console,
+//   log: jest.fn(), // console.log are ignored in tests
+//   error: console.error,
+//   warn: console.warn,
+//   info: console.info,
+//   debug: console.debug,
+// }
 
 // Mock services
 jest.mock('@core/services/mail-client.class')

--- a/backend/src/test-utils/setup.ts
+++ b/backend/src/test-utils/setup.ts
@@ -1,12 +1,12 @@
-// /* eslint-disable no-console */
-// global.console = {
-//   ...global.console,
-//   log: jest.fn(), // console.log are ignored in tests
-//   error: console.error,
-//   warn: console.warn,
-//   info: console.info,
-//   debug: console.debug,
-// }
+/* eslint-disable no-console */
+global.console = {
+  ...global.console,
+  log: jest.fn(), // console.log are ignored in tests
+  error: console.error,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug,
+}
 
 // Mock services
 jest.mock('@core/services/mail-client.class')

--- a/serverless/verify-backup/scripts/deploy.sh
+++ b/serverless/verify-backup/scripts/deploy.sh
@@ -21,6 +21,6 @@ gcloud run deploy $GCLOUD_RUN_SERVICE_NAME \
   --platform managed \
   --set-env-vars `grep -v '^#' .env | awk -v ORS=, 'NF { print $1 }'` \
   --max-instances 1 \
-  --timeout 8m \
+  --timeout 10m \
   --cpu 2 \
-  --memory 6Gi
+  --memory 8Gi

--- a/serverless/verify-backup/scripts/run.sh
+++ b/serverless/verify-backup/scripts/run.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Initialise and start postgres
+# Initialise postgres
 mkdir -p /run/postgresql/
 chown -R postgres:postgres /run/postgresql/
 su - postgres -c "initdb /var/lib/postgresql/data"
-su - postgres -c "pg_ctl start -D /var/lib/postgresql/data -l /var/lib/postgresql/log.log"
 
 # Start server to listen for pubsub messages
 npm run start

--- a/serverless/verify-backup/scripts/verify-backup.sh
+++ b/serverless/verify-backup/scripts/verify-backup.sh
@@ -30,6 +30,9 @@ curl "https://cronitor.link/$CRONITOR_CODE/run"  -m 10 || true
 # Downloads latest backup dump and decrypts it
 npm run decrypt-dump
 
+# Start postgres
+su - postgres -c "pg_ctl start -D /var/lib/postgresql/data -l /var/lib/postgresql/log.log"
+
 # Find for existing db; If exists, drop previously created db
 echo 'Preparing db'
 dropdb --if-exists $PGDATABASE && createdb $PGDATABASE
@@ -57,3 +60,11 @@ notify "$RESTORE_LOG"
 
 # Completed Cronitor job
 curl "https://cronitor.link/$CRONITOR_CODE/complete" -m 10 || true
+
+# Stop postgres
+su - postgres -c "pg_ctl stop -D /var/lib/postgresql/data"
+
+rm postman.decrypted.dump
+rm postman.dump
+rm postman.json
+rm secrets.dump


### PR DESCRIPTION
## Problem

The google cloud run service for verifying backups has been exceeding 90% of memory utilisation in the past few days.This was alerted to us by the monitoring alarm.

Closes #1176

## Solution

Investigation on cloud run service memory utilisation - https://docs.google.com/document/d/1BLi_DvhpIhSnC78bhN7kcDYTr056RQ_IKIJwqCQ14OU/edit

**Improvements**:

- Delete downloaded files and decrypted files after the verify backup is done
- Start and stop postgres service during the request instead of leaving the postgres service running
- Increase memory allocation from 6Gi to 8Gi

![image](https://user-images.githubusercontent.com/5744384/120421306-a07e2900-c398-11eb-9e03-c1ed49550b18.png)


## Deploy Notes

This version has been deployed to cloud run production service.