### PR TITLE
Add space after email salutation in the email template body

### DIFF
--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -179,7 +179,7 @@ const storeTemplate = async ({
 
   // Add whitespace, if not present, after email salutation
   // to prevent phisy looking email preview
-  sanitizedBody = sanitizedBody.replace(/(^.+?,)([^\s].+?<\/p>.+)/, '$1 $2')
+  sanitizedBody = sanitizedBody.replace(/(^.+?,)([^\s].+?<\/p>.*)/, '$1 $2')
 
   // Append via to sender name if it is not the default from name
   const {

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -170,12 +170,16 @@ const storeTemplate = async ({
 }: StoreTemplateInput): Promise<StoreTemplateOutput> => {
   // extract params from template, save to db (this will be done with hook)
   const sanitizedSubject = client.replaceNewLinesAndSanitize(subject)
-  const sanitizedBody = client.filterXSS(body)
+  let sanitizedBody = client.filterXSS(body)
   if (!sanitizedSubject || !sanitizedBody) {
     throw new TemplateError(
       'Message template is invalid as it only contains invalid HTML tags!'
     )
   }
+
+  // Add whitespace, if not present, after email salutation
+  // to prevent phisy looking email preview
+  sanitizedBody = sanitizedBody.replace(/(^.+?,)([^\s].+?<\/p>.+)/, '$1 $2')
 
   // Append via to sender name if it is not the default from name
   const {


### PR DESCRIPTION
## Problem

When there is no space following the email salutation, in templates such as below, the email preview tends to look phishy.

```
Dear form admin,You are receiving this email because
```

Closes #1149 

## Solution

**Improvements**:

- Add a space after the first comma in the email template, ensuring that there is a space followed by words
- Make this change after sanitising the template body 

e.g.
```
Dear form admin, You are receiving this email because
```

## Before & After Screenshots

**BEFORE**:
<img src="https://user-images.githubusercontent.com/5744384/120971267-060a5500-c79f-11eb-8234-011ba834044a.png" width="50%">
<img src="https://user-images.githubusercontent.com/5744384/120971296-0c003600-c79f-11eb-92cb-828944cf4484.png" width="50%">

**AFTER**:
<img src="https://user-images.githubusercontent.com/5744384/120984577-60121700-c7ad-11eb-8c8b-232d076b4ca7.png" width="50%">
<img src="https://user-images.githubusercontent.com/5744384/120987431-2989cb80-c7b0-11eb-90ad-c34bc87732c8.png" width="50%">

## Tests

- Enter template `Dear form admin,You are receiving this email because` 
- Save template and observe the preview to see that there is now a space after the email salutation