### PR TITLE
build(backend): exclude tests and mocks

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -3,7 +3,12 @@
 // See: https://github.com/microsoft/TypeScript/issues/27098
 {
   "extends": "./tsconfig.json",
-  "exclude": ["tests/"],
+  "exclude": [
+    "node_modules",
+    "./src/**/*.test.ts",
+    "./src/test-utils",
+    "./src/__mocks__"
+  ],
   "references": [
     { "path": "../shared" }
   ]

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "include": [
-    "./src/**/*",
-    "./tests/**/*"
+    "./src/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Problem

Closes #1222 

## Solution

**Improvements**:
- Clean up `tsconfig.json` and `tsconfig.build.json` to skip building tests and mocks.

## Tests
- Run `npm run build`
- Check that in build folder, mocks and tests are not built
- Alternatively you can run `npx tsx --showConfig tsconfig.build.json` and check that the files section does not contain any test/mocks.
