### PR TITLE
chore(backup): increase timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ jobs:
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
-          timeout: 600
+          timeout: 900
           memory_size: 512
           publish: true
           zip: "../database-backup/code.zip"
@@ -218,7 +218,7 @@ jobs:
           runtime: nodejs12.x
           module_name: build/index
           handler_name: handler
-          timeout: 600
+          timeout: 900
           memory_size: 512
           publish: true
           zip: "../database-backup/code.zip"


### PR DESCRIPTION
## Problem
Database backups were timing out.

## Solution
**Bug fixes**
- Increase timeout to 15 minutes (900s). This is a temporary fix, time required for backup would decrease once I get back to implementing the full redaction from database in #779 

## Tests
- Run backup lambda on staging and ensure that it works as expected

