### PR TITLE
Release 1.27.0

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@ RUN aws configure set default.region ap-southeast-1
 WORKDIR /usr/home/postmangovsg
 
 COPY shared ../shared
-RUN cd ../shared && npm ci && cd ../postmangovsg
+RUN cd ../shared && npm ci
 
 COPY ./package* ./
 RUN npm ci
@@ -23,6 +23,7 @@ COPY tsconfig.json ./
 COPY tsconfig.build.json ./
 
 RUN npm run build
+RUN cd ../shared && npm run postbuild
 RUN npm prune --production
 
 COPY ./docker-entrypoint.sh ./

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Backend / API server for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -456,6 +456,12 @@ const config = convict({
       env: 'EMAIL_FALLBACK_ACTIVATE',
     },
   },
+  showMastheadDomain: {
+    doc:
+      'Show masthead within email template if logged-in user has email ending with this domain',
+    default: '.gov.sg',
+    env: 'SHOW_MASTHEAD_DOMAIN',
+  },
 })
 
 // If mailFrom was not set in an env var, set it using the app_name

--- a/backend/src/core/services/unsubscriber.service.ts
+++ b/backend/src/core/services/unsubscriber.service.ts
@@ -56,28 +56,12 @@ const findOrCreateUnsubscriber = ({
   })
 }
 
-const appendTestEmailUnsubLink = (body: string): string => {
-  const testUnsubUrl = `${UNSUBSCRIBE_URL}/test`
-  const colors = {
-    text: '#697783',
-    link: '#2C2CDC',
-  }
-
-  return `${body} <br><hr> 
-  <p style="font-size:12px;color:${colors.text};line-height:2em">\
-    <a href="https://postman.gov.sg" style="color:${colors.link}" target="_blank">Postman.gov.sg</a>
-    is a mass messaging platform used by the Singapore Government to communicate with stakeholders.
-    For more information, please visit our <a href="https://guide.postman.gov.sg/faqs/faq-recipients" style="color:${colors.link}" target="_blank">site</a>. 
-  </p>
-  <p style="font-size:12px;color:${colors.text};line-height:2em">
-    If you wish to unsubscribe from similar emails from your sender, please click <a href="${testUnsubUrl}" style="color:${colors.link}" target="_blank">here</a>
-    to unsubscribe and we will inform the respective agency.
-  </p>
-  `
+const generateTestUnsubLink = (): string => {
+  return `${UNSUBSCRIBE_URL}/test`
 }
 
 export const UnsubscriberService = {
   validateHash,
   findOrCreateUnsubscriber,
-  appendTestEmailUnsubLink,
+  generateTestUnsubLink,
 }

--- a/backend/src/database/migrations/20210621043226-create-get-messages-to-send-email-with-sender-function.js
+++ b/backend/src/database/migrations/20210621043226-create-get-messages-to-send-email-with-sender-function.js
@@ -1,0 +1,66 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, _) => {
+    await queryInterface.createFunction(
+      'get_messages_to_send_email_with_sender',
+      [
+        { type: 'integer', name: 'jid' },
+        { type: 'integer', name: 'lim' },
+      ],
+      'TABLE(result json)',
+      'plpgsql',
+      `
+        RETURN QUERY
+        -- Set sent_at for messages belonging to a job that is in SENDING state only (it will not pick up any other states like STOPPED or LOGGED)
+        WITH
+          selected_ids AS (
+            SELECT id FROM email_ops WHERE
+            campaign_id = (SELECT q.campaign_id FROM job_queue q WHERE q.id = jid AND status = 'SENDING')
+            AND sent_at IS NULL
+            LIMIT lim
+            FOR UPDATE SKIP LOCKED
+          ),
+          messages AS (
+            UPDATE email_ops SET sent_at=clock_timestamp(), updated_at = clock_timestamp() WHERE
+            id in (SELECT * from selected_ids)
+            RETURNING id, recipient, params, campaign_id
+          )
+          SELECT json_build_object(
+            'id', m.id,
+            'recipient', m.recipient,
+            'params', m.params,
+            'campaignId', m.campaign_id,
+            'body', t.body,
+            'subject', t.subject,
+            'replyTo', t.reply_to,
+            'from', t.from,
+            'senderEmail', u.email
+          )
+          FROM messages m
+          INNER JOIN email_templates t ON m.campaign_id = t.campaign_id
+          INNER JOIN campaigns c ON c.id = m.campaign_id
+          INNER JOIN users u ON u.id = c.user_id;
+
+        -- An edge case exists where the status of a job is set to 'SENT', but the sending client hasn't responded to all the sent messages
+        -- In that case, finalization of the job has to be deferred, so that the response can be updated in the ops table
+        -- The check for this edge case is carried out in the log_next_job function. 
+        IF NOT FOUND THEN
+          UPDATE job_queue SET status = 'SENT', updated_at = clock_timestamp() where id = jid AND status = 'SENDING';
+        END IF;
+      `,
+      [],
+      { force: true }
+    )
+  },
+
+  down: async (queryInterface, _) => {
+    await queryInterface.dropFunction(
+      'get_messages_to_send_email_with_sender',
+      [
+        { type: 'integer', name: 'jid' },
+        { type: 'integer', name: 'lim' },
+      ]
+    )
+  },
+}

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -13,12 +13,14 @@ import {
   UploadService,
   StatsService,
   ParseCsvService,
+  UnsubscriberService,
 } from '@core/services'
 import { EmailTemplateService, EmailService } from '@email/services'
 import S3Client from '@core/services/s3-client.class'
 import { StoreTemplateOutput } from '@email/interfaces'
 import { Campaign } from '@core/models'
 import { loggerWithLabel } from '@core/logger'
+import { ThemeClient } from '@shared/theme'
 
 const logger = loggerWithLabel(module)
 const RETRY_CONFIG = {
@@ -225,12 +227,22 @@ const pollCsvStatusHandler = async (
     } = await UploadService.getCsvStatus(+campaignId)
 
     // If done processing, returns num recipients and preview msg
-    let numRecipients, preview
+    let numRecipients, preview, themedBody
+
     if (!isCsvProcessing) {
       ;[numRecipients, preview] = await Promise.all([
         StatsService.getNumRecipients(+campaignId),
         EmailService.getHydratedMessage(+campaignId),
       ])
+
+      if (preview !== undefined) {
+        const { body, showMasthead } = preview
+        themedBody = await ThemeClient.generateThemedBody({
+          body,
+          unsubLink: UnsubscriberService.generateTestUnsubLink(),
+          showMasthead,
+        })
+      }
     }
 
     res.json({
@@ -239,7 +251,10 @@ const pollCsvStatusHandler = async (
       temp_csv_filename: tempFilename,
       csv_error: error,
       num_recipients: numRecipients,
-      preview,
+      preview: {
+        ...preview,
+        themedBody,
+      },
     })
   } catch (err) {
     next(err)

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -2,9 +2,10 @@ import { Request, Response, NextFunction } from 'express'
 import { EmailService, CustomDomainService } from '@email/services'
 import { isDefaultFromAddress } from '@core/utils/from-address'
 import { parseFromAddress } from '@shared/utils/from-address'
-import { AuthService } from '@core/services'
+import { AuthService, UnsubscriberService } from '@core/services'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
+import { ThemeClient } from '@shared/theme'
 
 const logger = loggerWithLabel(module)
 
@@ -100,13 +101,20 @@ const previewFirstMessage = async (
 
     if (!message) return res.json({})
 
-    const { body, subject, replyTo, from } = message
+    const { body, subject, replyTo, from, showMasthead } = message
+    const themedBody = await ThemeClient.generateThemedBody({
+      body,
+      unsubLink: UnsubscriberService.generateTestUnsubLink(),
+      showMasthead,
+    })
+
     return res.json({
       preview: {
         body,
         subject,
         reply_to: replyTo,
         from,
+        themed_body: themedBody,
       },
     })
   } catch (err) {

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -3,7 +3,7 @@ import { CSVParams } from '@core/types'
 
 import { loggerWithLabel } from '@core/logger'
 import { ChannelType, DefaultCredentialName } from '@core/constants'
-import { Campaign, ProtectedMessage } from '@core/models'
+import { Campaign, ProtectedMessage, User } from '@core/models'
 import {
   MailService,
   CampaignService,
@@ -17,6 +17,8 @@ import { EmailTemplate, EmailMessage } from '@email/models'
 import { EmailTemplateService } from '@email/services'
 import config from '@core/config'
 import { EmailDuplicateCampaignDetails } from '@email/interfaces'
+
+import { ThemeClient } from '@shared/theme'
 
 const logger = loggerWithLabel(module)
 
@@ -46,6 +48,7 @@ const getHydratedMessage = async (
   subject: string
   replyTo: string | null
   from: string
+  showMasthead?: boolean
 } | void> => {
   // get email template
   const template = await EmailTemplateService.getFilledTemplate(campaignId)
@@ -61,11 +64,23 @@ const getHydratedMessage = async (
     params
   )
   const body = EmailTemplateService.client.template(template?.body!, params)
+
+  // Check if campaign user has gov.sg email to determine whether to show masthead
+  const campaign = await Campaign.findOne({
+    where: { id: campaignId },
+    include: [User],
+  })
+
+  const showMasthead = campaign?.user?.email.endsWith(
+    config.get('showMastheadDomain')
+  )
+
   return {
     body,
     subject,
     replyTo: template.replyTo || null,
     from: template?.from!,
+    showMasthead,
   }
   /* eslint-enable @typescript-eslint/no-non-null-assertion */
 }
@@ -82,11 +97,15 @@ const getCampaignMessage = async (
   // get the body and subject
   const message = await getHydratedMessage(campaignId)
   if (message) {
-    const { body, subject, replyTo, from } = message
+    const { body, subject, replyTo, from, showMasthead } = message
     const mailToSend: MailToSend = {
       from: from || config.get('mailFrom'),
       recipients: [recipient],
-      body: UnsubscriberService.appendTestEmailUnsubLink(body),
+      body: await ThemeClient.generateThemedHTMLEmail({
+        body,
+        unsubLink: UnsubscriberService.generateTestUnsubLink(),
+        showMasthead,
+      }),
       subject,
       ...(replyTo ? { replyTo } : {}),
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "private": true,
   "scripts": {
     "start": "react-app-rewired start",

--- a/frontend/src/classes/EmailCampaign.ts
+++ b/frontend/src/classes/EmailCampaign.ts
@@ -20,6 +20,7 @@ export enum EmailProgress {
 
 export interface EmailPreview {
   body: string
+  themedBody: string
   subject: string
   replyTo: string | null
   from: string

--- a/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
+++ b/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
@@ -1,7 +1,8 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
+@import 'styles/_email_typography';
 
-.preview {
+.previewInfo {
   border-radius: 1.25rem;
   padding: $spacing-3 $spacing-5;
   background: $neutral-light;
@@ -18,5 +19,52 @@
     color: $secondary;
     font-size: 1rem;
     margin-block-end: 0;
+  }
+}
+
+.previewBody {
+  margin-top: 3rem;
+
+  // Reset site-wide styles so tables render correctly
+  table {
+    width: auto;
+    tr {
+      height: auto;
+      display: table-row;
+      td,
+      th {
+        display: table-cell;
+      }
+    }
+  }
+
+  // Typography styles to match email theme
+  color: $email-font-color;
+
+  * {
+    font-family: $email-font-stack;
+    color: inherit;
+  }
+
+  p,
+  a,
+  span {
+    font-size: inherit;
+  }
+
+  h1 {
+    @extend %email-heading-1;
+  }
+
+  h2 {
+    @extend %email-heading-2;
+  }
+
+  h4 {
+    @extend %email-heading-4;
+  }
+
+  p {
+    @extend %email-body;
   }
 }

--- a/frontend/src/components/common/email-preview-block/EmailPreviewBlock.tsx
+++ b/frontend/src/components/common/email-preview-block/EmailPreviewBlock.tsx
@@ -2,12 +2,12 @@ import cx from 'classnames'
 import type { FC } from 'react'
 
 import DetailBlock from '../detail-block'
-import RichTextEditor from '../rich-text-editor'
 
 import styles from './EmailPreviewBlock.module.scss'
 
 interface EmailPreviewBlockProps {
   body: string
+  themedBody?: string
   subject?: string
   replyTo?: string | null
   from?: string
@@ -16,11 +16,11 @@ interface EmailPreviewBlockProps {
 
 const EmailPreviewBlock: FC<EmailPreviewBlockProps> = ({
   body,
+  themedBody,
   subject,
   replyTo,
   from,
   className,
-  ...otherProps
 }) => {
   if (!body && !subject) {
     return (
@@ -34,19 +34,23 @@ const EmailPreviewBlock: FC<EmailPreviewBlockProps> = ({
   }
 
   return (
-    <div className={cx(styles.preview, className)}>
-      <h5>From</h5>
-      <p>{from}</p>
+    <>
+      <div className={cx(styles.previewInfo, className)}>
+        <h5>From</h5>
+        <p>{from}</p>
 
-      <h5>Subject</h5>
-      <p>{subject}</p>
+        <h5>Subject</h5>
+        <p>{subject}</p>
 
-      <h5>Body</h5>
-      <RichTextEditor value={body} preview {...otherProps} />
+        <h5>Replies</h5>
+        <p>{replyTo}</p>
+      </div>
 
-      <h5>Replies</h5>
-      <p>{replyTo}</p>
-    </div>
+      <div
+        className={styles.previewBody}
+        dangerouslySetInnerHTML={{ __html: themedBody ?? '' }}
+      ></div>
+    </>
   )
 }
 

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -1,5 +1,6 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
+@import 'styles/_email_typography';
 
 %toolbar-modal-base {
   height: auto;
@@ -262,6 +263,7 @@
     $border-color: adjust-color($primary-light, $alpha: -0.5);
     border: 1px solid $border-color;
     table-layout: fixed;
+    width: auto;
 
     tr {
       display: table-row;
@@ -306,6 +308,41 @@
 
     .rdw-justify-aligned-block .public-DraftStyleDefault-block {
       text-align: justify;
+    }
+  }
+
+  // Typography styles to match email theme
+  // Changes here should also be made in email-theme.mustache to update the actual email theme
+  // These styles are repeated in EmailPreviewBlock.module.scss due to differences in DOM structure
+  color: $email-font-color;
+  font-size: $email-body-font-size;
+
+  * {
+    font-family: $email-font-stack;
+  }
+
+  h1 {
+    @extend %email-heading-1;
+  }
+
+  h2 {
+    @extend %email-heading-2;
+  }
+
+  h4 {
+    @extend %email-heading-4;
+  }
+
+  :global {
+    // This represents a <p> block when rendered
+    .public-DraftStyleDefault-block {
+      @extend %email-body;
+    }
+
+    // Within tables/lists, <p> tags are not created, so reset the margin styles
+    table .public-DraftStyleDefault-block,
+    li .public-DraftStyleDefault-block {
+      margin: 0;
     }
   }
 }

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -229,6 +229,7 @@ const EmailRecipients = ({
           <p className={styles.greyText}>Message preview</p>
           <EmailPreviewBlock
             body={preview?.body}
+            themedBody={preview?.themedBody}
             subject={preview?.subject}
             replyTo={preview?.replyTo}
             from={preview?.from}

--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -38,6 +38,7 @@ const EmailSend = ({
   const [preview, setPreview] = useState(
     {} as {
       body: string
+      themedBody: string
       subject: string
       replyTo: string | null
       from: string
@@ -103,6 +104,7 @@ const EmailSend = ({
           <p className={styles.greyText}>Message</p>
           <EmailPreviewBlock
             body={preview.body}
+            themedBody={preview.themedBody}
             subject={preview.subject}
             replyTo={preview.replyTo}
             from={preview.from}

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -221,12 +221,12 @@ const EmailTemplate = ({
 
         <div>
           <h4>From</h4>
-          <p>Sender details.</p>
+          <p>Sender details</p>
           <TextInput
             {...getFromNameInputProps()}
             onChange={setFromName}
             aria-label="Sender name"
-            placeholder={t`E.g. Ministry of Health`}
+            placeholder={t`e.g. Ministry of Health`}
           />
           <Dropdown
             onSelect={handleSelectFromAddress}
@@ -242,7 +242,10 @@ const EmailTemplate = ({
             <label htmlFor="subject">Subject</label>
           </h4>
           <p>
-            <label htmlFor="subject">Enter subject of the email</label>
+            <label htmlFor="subject">
+              Keep it short, specific and personalised. Try to use less than 10
+              words.
+            </label>
           </p>
           <TextArea
             id="subject"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -26,8 +26,8 @@ msgstr "Delivery report will expire 14 days after sending is completed."
 #~ msgstr "E.g. MOH Appointment"
 
 #: components/dashboard/create/email/EmailTemplate.tsx:140
-msgid "E.g. Ministry of Health"
-msgstr "E.g. Ministry of Health"
+#~ msgid "E.g. Ministry of Health"
+#~ msgstr "E.g. Ministry of Health"
 
 #: components/login/login-input/LoginInput.tsx:88
 msgid "Enter OTP"
@@ -122,9 +122,13 @@ msgstr "This demo campaign will be sent to a maximum of 20 recipients."
 msgid "demoMessageLabel"
 msgstr "DEMO"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:151
+#: components/dashboard/create/email/EmailTemplate.tsx:165
 msgid "e.g. Appointment Confirmation"
 msgstr "e.g. Appointment Confirmation"
+
+#: components/dashboard/create/email/EmailTemplate.tsx:151
+msgid "e.g. Ministry of Health"
+msgstr "e.g. Ministry of Health"
 
 #: components/login/login-input/LoginInput.tsx:88
 msgid "e.g. postman@agency.gov.sg"
@@ -242,6 +246,8 @@ msgstr "https://guide.postman.gov.sg/contact-us"
 msgid "link.tncUrl"
 msgstr "https://guide.postman.gov.sg/legal/t-and-c"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:140
+#: components/dashboard/create/email/EmailTemplate.tsx:131
+#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:267
+#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:269
 msgid "mailVia"
 msgstr "via Postman"

--- a/frontend/src/services/email.service.ts
+++ b/frontend/src/services/email.service.ts
@@ -61,8 +61,14 @@ export async function getPreviewMessage(
 ): Promise<EmailPreview> {
   try {
     const response = await axios.get(`/campaign/${campaignId}/email/preview`)
-    const { body, subject, reply_to: replyTo, from } = response.data?.preview
-    return { body, subject, replyTo, from }
+    const {
+      body,
+      themed_body: themedBody,
+      subject,
+      reply_to: replyTo,
+      from,
+    } = response.data?.preview
+    return { body, themedBody, subject, replyTo, from }
   } catch (e) {
     errorHandler(e, 'Unable to get preview message')
   }

--- a/frontend/src/styles/_email_typography.scss
+++ b/frontend/src/styles/_email_typography.scss
@@ -1,0 +1,36 @@
+/** 
+ * Typography styles to match email theme
+ *
+ * Changes here should also be made in email-theme.mustache to update the actual
+ * theme of the emails being sent
+**/
+
+$email-font-stack: Helvetica, Arial, sans-serif;
+$email-font-color: #000000;
+$email-body-font-size: 14px;
+
+%email-heading-1 {
+  font-size: 28px;
+  line-height: 42px;
+  letter-spacing: 0.25px;
+  font-weight: bold;
+  margin: 32px 0;
+}
+
+%email-heading-2 {
+  font-size: 24.5px;
+  line-height: 35px;
+  font-weight: bold;
+  margin: 24px 0;
+}
+
+%email-heading-4 {
+  font-size: 21px;
+  line-height: 28px;
+  font-weight: 500;
+  margin: 24px 0;
+}
+
+%email-body {
+  margin: 16px 0;
+}

--- a/frontend/src/styles/_variables.scss
+++ b/frontend/src/styles/_variables.scss
@@ -5,7 +5,7 @@
 $light-grey: #a2abb4;
 
 // Dimensions
-$content-max-width: 528px;
+$content-max-width: 728px;
 $side-nav-width: 400px;
 
 // Paddings

--- a/frontend/src/test-utils/api/index.ts
+++ b/frontend/src/test-utils/api/index.ts
@@ -431,10 +431,16 @@ function mockCampaignTemplateApis(state: State) {
     }),
     rest.get('/campaign/:campaignId/email/preview', (req, res, ctx) => {
       const { campaignId } = req.params
+      const preview = state.campaigns[campaignId - 1].email_templates
       return res(
         ctx.status(200),
         ctx.json({
-          preview: state.campaigns[campaignId - 1].email_templates,
+          preview: {
+            ...preview,
+            // Frontend doesn't have access to the actual email theme, so return
+            // body as themed_body for it to render for frontend tests
+            themed_body: preview?.body,
+          },
         })
       )
     }),
@@ -647,6 +653,9 @@ function mockCampaignUploadApis(state: State) {
         preview = {
           ...campaign.email_templates,
           replyTo: campaign.email_templates.reply_to,
+          // Frontend doesn't have access to the actual email theme, so return
+          // body as themed_body for it to render for frontend tests
+          themedBody: campaign.email_templates.body,
         }
       } else if (campaign.sms_templates) {
         preview = campaign.sms_templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1778,6 +1778,87 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2068,6 +2149,12 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4997,6 +5084,42 @@
         }
       }
     },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -5298,6 +5421,12 @@
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -6357,6 +6486,42 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -6593,6 +6758,12 @@
         }
       }
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -6827,13 +6998,19 @@
       "dev": true
     },
     "xss": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.6.tgz",
-      "integrity": "sha512-6Q9TPBeNyoTRxgZFk5Ggaepk/4vUOYdOsIUYvLehcsIZTFjaavbVnsuAkLA5lIFuug5hw8zxcB9tm01gsjph2A==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.9.tgz",
+      "integrity": "sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==",
       "requires": {
-        "commander": "^2.9.0",
+        "commander": "^2.20.3",
         "cssfilter": "0.0.10"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Shared modules for Postman",
   "main": "build/index.js",
   "scripts": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,10 +4,12 @@
   "description": "Shared modules for Postman",
   "main": "build/index.js",
   "scripts": {
-    "dev": "tsc --build -w",
+    "dev": "npm run postbuild && tsc --build -w",
     "build": "rimraf build && tsc -b --clean && tsc",
     "lint-no-fix": "tsc --noEmit && eslint --ext .js,.ts --cache .",
     "lint": "npm run lint-no-fix -- --fix",
+    "postbuild": "npm run copy-assets",
+    "copy-assets": "copyfiles -u 1 src/**/*.mustache build",
     "test": "jest"
   },
   "types": "build/index",
@@ -29,6 +31,7 @@
     "@types/jest": "^25.2.3",
     "@typescript-eslint/eslint-plugin": "^2.25.0",
     "@typescript-eslint/parser": "^2.25.0",
+    "copyfiles": "^2.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
@@ -42,6 +45,6 @@
     "mustache": "^4.2.0",
     "rimraf": "^3.0.2",
     "typescript": "^3.9.9",
-    "xss": "=1.0.6"
+    "xss": "^1.0.9"
   }
 }

--- a/shared/src/templating/template-client.ts
+++ b/shared/src/templating/template-client.ts
@@ -1,6 +1,6 @@
 import cheerio from 'cheerio'
 import { mapKeys } from 'lodash'
-import xss from 'xss'
+import { IFilterXSSOptions, filterXSS } from 'xss'
 import { TemplateError } from './errors'
 import { TemplatingConfig, TemplatingConfigDefault } from './interfaces'
 import { filterImageSources } from './xss-options'
@@ -8,7 +8,7 @@ import { filterImageSources } from './xss-options'
 import mustache from 'mustache'
 
 export class TemplateClient {
-  xssOptions: xss.IFilterXSSOptions
+  xssOptions: IFilterXSSOptions
   lineBreak: string
   allowedImageSources?: Array<string>
 
@@ -17,7 +17,7 @@ export class TemplateClient {
     lineBreak,
     allowedImageSources,
   }: {
-    xssOptions?: xss.IFilterXSSOptions
+    xssOptions?: IFilterXSSOptions
     lineBreak?: string
     allowedImageSources?: Array<string>
   }) {
@@ -35,7 +35,7 @@ export class TemplateClient {
    * @param value Input to be filtered
    */
   filterXSS(value: string): string {
-    return xss.filterXSS(value, this.xssOptions)
+    return filterXSS(value, this.xssOptions)
   }
 
   /**

--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -1,4 +1,4 @@
-import xss, { IFilterXSSOptions } from 'xss'
+import { IFilterXSSOptions, cssFilter, safeAttrValue } from 'xss'
 import { TemplateError } from './errors'
 
 const URL =
@@ -70,7 +70,7 @@ export const XSS_EMAIL_OPTION = {
     }
     // The default safeAttrValue does guard against some edge cases
     // https://github.com/leizongmin/js-xss/blob/446f5daa3b65e9e8f0e9c71276cf61dad73d1ec3/dist/xss.js
-    return xss.safeAttrValue(tag, name, value, xss.cssFilter)
+    return safeAttrValue(tag, name, value, cssFilter)
   },
   stripIgnoreTag: true,
 }
@@ -102,7 +102,7 @@ export const XSS_TELEGRAM_OPTION = {
     ) {
       return value
     }
-    return xss.safeAttrValue(tag, name, value, xss.cssFilter)
+    return safeAttrValue(tag, name, value, cssFilter)
   },
   stripIgnoreTag: true,
 }
@@ -132,8 +132,8 @@ export const filterImageSources = (
 
     const defaultSafeAttrValue = baseOptions?.safeAttrValue
       ? baseOptions.safeAttrValue
-      : xss.safeAttrValue
+      : safeAttrValue
 
-    return defaultSafeAttrValue(tag, name, value, xss.cssFilter)
+    return defaultSafeAttrValue(tag, name, value, cssFilter)
   },
 })

--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -1,0 +1,214 @@
+{{!-- 
+  Email template built with reference to https://www.goodemailcode.com/
+--}}
+<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="format-detection" content="telephone=no, date=no, address=no, email=no, url=no">
+  <meta name="x-apple-disable-message-reformatting">
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <![endif]-->
+
+  {{!--
+    Most styles have been inlined into the HTML below for best email client support
+    Only media queries (for responsive devices) and generic styles remain in the style tag
+
+    NOTE: Styles within the style tag are not rendered on the frontend preview.
+    Any changes made here should be manually added to the frontend email preview styles.
+  --}}
+  <style>
+    @media only screen and (max-width: 500px) {
+      .root-container {
+        min-width: 0 !important;
+        line-height: 20px !important;
+      }
+
+      .masthead {
+        border-radius: 0 !important;
+      }
+
+      .body-content {
+        border-width: 0 !important;
+        padding: 0 16px !important;
+      }
+
+      .body-vertical-spacer-top {
+        margin-bottom: 24px !important;
+      }
+
+      .logo {
+        height: 44px !important;
+        margin-bottom: 24px !important;
+      }
+
+      .body-vertical-spacer-bottom {
+        margin-top: 24px !important;
+        border-bottom: 1px solid #E8EBEE;
+      }
+
+      .footer-content {
+        padding: 0 16px !important;
+        font-size: 10px !important;
+      }
+
+      .footer-vertical-spacer-top {
+        line-height: 24px !important;
+        height: 24px !important;
+      }
+    }
+
+    h1 {
+      font-size: 28px !important;
+      line-height: 42px !important;
+      letter-spacing: 0.25px !important;
+      font-weight: bold;
+      margin: 32px 0;
+    }
+
+    h2 {
+      font-size: 24.5px !important;
+      line-height: 35px !important;
+      font-weight: bold;
+      margin: 24px 0;
+    }
+
+    h4 {
+      font-size: 21px !important;
+      line-height: 28px !important;
+      font-weight: 500;
+      margin: 24px 0;
+    }
+
+    p {
+      margin: 16px 0;
+    }
+  </style>
+</head>
+
+<body style="margin: 0; padding: 0; word-spacing: normal; background-color: #ffffff;">
+  {{!--
+    Preheader text (within a hidden div) is the preview text being shown in email clients
+    @see: https://www.litmus.com/blog/the-little-known-preview-text-hack-you-may-want-to-use-in-every-email/
+  --}}
+  <div style="display: none; max-height: 0px; overflow: hidden;">
+    {{preheader}}
+  </div>
+
+  {{!-- Insert spacers to prevent text below from appearing in preheader --}}
+  <div style="display: none; max-height: 0px; overflow: hidden;">
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+    &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+  </div>
+
+  {{!--
+    The code below uses conditional HTML that only IE/Outlook recognises to maintain compatibility with Outlook
+    [if true] blocks will render only within Outlook and IE
+    [if false] blocks will render only in all other browsers/clients
+  --}}
+
+  <div role="article" aria-roledescription="email" aria-label="email name" lang="en"
+    style="font-size: 14px; line-height: 1.714; font-family: Helvetica, Arial, sans-serif;">
+    <!--[if true]>
+    <table role="presentation" style="width: 728px; border: 1px solid #E8EBEE"
+      align="center" cellspacing="0" cellpadding="0" bgcolor="#E8EBEE">
+    <![endif]-->
+
+    <!--[if false]><!-->
+    <div class="root-container" style="max-width: 728px; min-width: 500px; margin: 0 auto;">
+    <!--<![endif]-->
+
+    {{#showMasthead}}
+    <!--[if true]>
+      <tr><td align="center" valign="middle" style="font-size: 12px; border: 1px solid #E8EBEE; padding: 4px;">
+    <![endif]-->
+
+    <!--[if false]><!-->
+      <div class="masthead"
+        style="text-align: center; font-size: 11px; line-height: 28px; height: 28px; background-color: #E8EBEE;
+          border-top-left-radius: 8px; border-top-right-radius: 8px; white-space: nowrap;">
+    <!--<![endif]-->
+        <span>Singapore government emails are sent from .gov.sg addresses</span>
+    <!--[if false]><!-->
+      </div>
+    <!--<![endif]-->
+    
+    <!--[if true]>
+      </td></tr>
+    <![endif]-->
+    {{/showMasthead}}
+
+    <!--[if true]>
+      <tr><td style="padding: 0 64px; border: 1px solid #E8EBEE;" bgcolor="#FFFFFF">
+    <![endif]-->
+
+    <!--[if false]><!-->
+      <div class="body-content"
+        style="max-width: 728px; padding: 0 64px; border-color: #E8EBEE; border-style: solid;
+                {{#showMasthead}} border-width: 0 2px 2px 2px; border-bottom-left-radius: 8px; border-bottom-right-radius: 8px; {{/showMasthead}}
+                {{^showMasthead}} border-width: 2px; border-radius: 8px; {{/showMasthead}}">
+    <!--<![endif]-->
+
+        <div class="body-vertical-spacer-top" style="line-height: 0px; height: 0px; margin-bottom: 48px;">&#8202;</div>
+
+        {{#agencyLogoURI}}
+        <img class="logo" src="{{agencyLogoURI}}" height="64" style="height: 64px; width: auto; margin-bottom: 32px; display: block;"
+          {{#agencyName}} alt="{{agencyName}} Logo" {{/agencyName}} />
+        {{/agencyLogoURI}}
+        <div>
+          {{{body}}}
+        </div>
+        <div class="body-vertical-spacer-bottom" style="line-height: 0px; height: 0px; margin-top: 48px;">&#8202;</div>
+    
+    <!--[if false]><!-->
+      </div>
+    <!--<![endif]-->
+    
+    <!--[if true]>
+      </tr></td>
+    </table>
+    <table role="presentation" style="width: 728px;" align="center">
+      <tr><td>
+    <![endif]-->
+      <div class="footer-content" style="max-width: 728px; padding: 0 64px; mso-padding-alt: 0 64px; text-align: center; line-height: 1.45;">
+        <div class="footer-vertical-spacer-top" style="line-height: 32px; height: 32px;">&#8202;</div>
+        <div style="font-size: 11px; color: #64707D">
+          This email and any links transmitted with it may contain privileged, confidential or official information. If you are
+          not the intended recipient, please delete this email, refrain from disclosing the contents to any person, and notify the
+          agency or organisation that sent this to you.
+          <br />
+          <br />          
+          If you wish to unsubscribe from similar emails, please click <a href="{{unsubLink}}">here</a> to inform the sender of your email preference.
+          Alternatively, you may also contact the sender agency or organisation directly through their public contact channels for
+          updates to contact details or email preferences.
+          <br />
+          <br />
+          Powered by <a href="https://postman.gov.sg">Postman</a>
+          <div class="footer-vertical-spacer-top" style="line-height: 16px; height: 16px;">&#8202;</div>
+          <img src="https://file.go.gov.sg/postmanlogo-grey.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px;">
+        </div>
+        <div class="footer-vertical-spacer-bottom" style="line-height: 24px; height: 24px;">&#8202;</div>
+      </div>
+    </div>
+  <!--[if true]>
+  </td></tr></table>
+  <![endif]-->
+</body>
+
+</html>

--- a/shared/src/theme/index.ts
+++ b/shared/src/theme/index.ts
@@ -1,0 +1,68 @@
+import mustache from 'mustache'
+import { filterXSS } from 'xss'
+import fs from 'fs'
+import path from 'path'
+
+type EmailThemeFields = {
+  body: string
+  agencyName?: string
+  agencyLogoURI?: string
+  unsubLink: string
+  showMasthead?: boolean
+}
+
+export class ThemeClient {
+  private static emailHTMLTemplate: string
+
+  private static async loadEmailHTMLTemplate(): Promise<void> {
+    if (this.emailHTMLTemplate === undefined) {
+      this.emailHTMLTemplate = await fs.promises.readFile(
+        path.resolve(__dirname, './email-theme.mustache'),
+        'utf-8'
+      )
+    }
+  }
+
+  /**
+   * Take first 200 characters of the body (with html tags stripped) to use as
+   * preheader (preview text of email content)
+   * @param body - HTML body content of email
+   * @returns first 200 characters after stripping html tags
+   */
+  static generatePreheader(body: string): string {
+    return filterXSS(body, {
+      whiteList: {},
+      stripIgnoreTagBody: ['script'],
+      onIgnoreTag: (_tag, _html, options) => {
+        // Append whitespace after each closing tag
+        if (options.isClosing) return ' '
+        else return ''
+      },
+    }).substring(0, 200)
+  }
+
+  static async generateThemedHTMLEmail(
+    emailThemeFields: EmailThemeFields
+  ): Promise<string> {
+    await this.loadEmailHTMLTemplate()
+
+    const preheader = this.generatePreheader(emailThemeFields.body)
+
+    return mustache.render(this.emailHTMLTemplate, {
+      ...emailThemeFields,
+      preheader,
+    })
+  }
+
+  // Returns contents of <body> tag from generateThemedHTMLEmail
+  static async generateThemedBody(emailThemeFields: EmailThemeFields): Promise<string> {
+    const themedHTMLEmail = await this.generateThemedHTMLEmail(emailThemeFields)
+
+    /**
+     * Regex to match contents of <body> tag
+     * @see: https://stackoverflow.com/a/2857261
+     */
+    const themedBody = /<body.*?>([\s\S]*)<\/body>/.exec(themedHTMLEmail)?.[1]
+    return themedBody!
+  }
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -13,7 +13,7 @@ RUN aws configure set default.region ap-southeast-1
 WORKDIR /usr/home/postmangovsg
 
 COPY shared ../shared
-RUN cd ../shared && npm ci && cd ../postmangovsg
+RUN cd ../shared && npm ci
 
 COPY ./package* ./
 RUN npm ci
@@ -22,6 +22,7 @@ COPY src ./src
 COPY tsconfig.json ./
 
 RUN npm run build
+RUN cd ../shared && npm run postbuild
 RUN npm prune --production
 
 COPY ./docker-entrypoint.sh ./

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Workers for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -231,6 +231,12 @@ const config = convict({
       env: 'EMAIL_FALLBACK_ACTIVATE',
     },
   },
+  showMastheadDomain: {
+    doc:
+      'Show masthead within email template if logged-in user has email ending with this domain',
+    default: '.gov.sg',
+    env: 'SHOW_MASTHEAD_DOMAIN',
+  },
 })
 
 // If mailFrom was not set in an env var, set it using the app_name

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -8,6 +8,8 @@ import { loggerWithLabel } from '@core/logger'
 import config from '@core/config'
 import MailClient from '@email/services/mail-client.class'
 import { TemplateClient, XSS_EMAIL_OPTION } from '@shared/templating'
+import { ThemeClient } from '@shared/theme'
+import { Message } from './interface'
 
 const templateClient = new TemplateClient({ xssOptions: XSS_EMAIL_OPTION })
 const logger = loggerWithLabel(module)
@@ -51,27 +53,27 @@ class Email {
       })
   }
 
-  getMessages(
-    jobId: number,
-    rate: number
-  ): Promise<
-    {
-      id: number
-      recipient: string
-      params: { [key: string]: string }
-      body: string
-      subject: string
-      replyTo: string | null
-      from: string
-      campaignId: number
-    }[]
-  > {
-    return this.connection
-      .query('SELECT get_messages_to_send_email(:job_id, :rate);', {
+  async getMessages(jobId: number, rate: number): Promise<Message[]> {
+    interface ResultRow {
+      message: Message & { senderEmail: string }
+    }
+
+    const showMastheadDomain = config.get('showMastheadDomain')
+    const result = await this.connection.query<ResultRow>(
+      'SELECT get_messages_to_send_email_with_sender(:job_id, :rate) AS message;',
+      {
         replacements: { job_id: jobId, rate },
         type: QueryTypes.SELECT,
-      })
-      .then((result) => map(result, 'get_messages_to_send_email'))
+      }
+    )
+    return map(result, (row) => {
+      const { senderEmail } = row.message
+      const showMasthead = senderEmail.endsWith(showMastheadDomain)
+      return {
+        ...row.message,
+        showMasthead,
+      }
+    })
   }
 
   calculateHash(campaignId: number, recipient: string): string {
@@ -98,25 +100,6 @@ class Email {
     return link
   }
 
-  appendUnsubToMessage(msg: string, unsubUrl: string): string {
-    const colors = {
-      text: '#697783',
-      link: '#2C2CDC',
-    }
-
-    return `${msg} <br><hr> 
-    <p style="font-size:12px;color:${colors.text};line-height:2em">\
-      <a href="https://postman.gov.sg" style="color:${colors.link}" target="_blank">Postman.gov.sg</a>
-      is a mass messaging platform used by the Singapore Government to communicate with stakeholders.
-      For more information, please visit our <a href="https://guide.postman.gov.sg/faqs/faq-recipients" style="color:${colors.link}" target="_blank">site</a>. 
-    </p>
-    <p style="font-size:12px;color:${colors.text};line-height:2em">
-      If you wish to unsubscribe from similar emails from your sender, please click <a href="${unsubUrl}" style="color:${colors.link}" target="_blank">here</a>
-      to unsubscribe and we will inform the respective agency.
-    </p>
-    `
-  }
-
   async sendMessage({
     id,
     recipient,
@@ -126,78 +109,56 @@ class Email {
     replyTo,
     from,
     campaignId,
-  }: {
-    id: number
-    recipient: string
-    params: { [key: string]: string }
-    body: string
-    subject?: string
-    replyTo?: string | null
-    from?: string
-    campaignId?: number
-  }): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!validator.isEmail(recipient)) {
-        return reject(new Error('Recipient is incorrectly formatted'))
-      }
-      return resolve()
-    })
-      .then(() => {
-        return {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          subject: templateClient.template(subject!, params),
-          hydratedBody: templateClient.template(body, params),
-        }
+    showMasthead,
+  }: Message): Promise<void> {
+    if (!validator.isEmail(recipient)) {
+      throw new Error('Recipient is incorrectly formatted')
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const hydratedSubject = templateClient.template(subject!, params)
+      const hydratedBody = templateClient.template(body, params)
+      const unsubLink = this.generateUnsubLink(
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        campaignId!,
+        recipient
+      ).toString()
+      const themedHTMLEmail = await ThemeClient.generateThemedHTMLEmail({
+        body: hydratedBody,
+        unsubLink,
+        showMasthead,
       })
-      .then(
-        ({
-          subject,
-          hydratedBody,
-        }: {
-          subject: string
-          hydratedBody: string
-        }) => {
-          const unsubUrl = this.generateUnsubLink(
-            campaignId!,
-            recipient
-          ).toString()
-          const bodyWithUnsub = this.appendUnsubToMessage(
-            hydratedBody,
-            unsubUrl
-          )
-          return this.mailService.sendMail({
-            from: from || config.get('mailFrom'),
-            recipients: [recipient],
-            subject,
-            body: bodyWithUnsub,
-            referenceId: String(id),
-            ...(replyTo ? { replyTo } : {}),
-          })
+
+      const messageId = await this.mailService.sendMail({
+        from: from || config.get('mailFrom'),
+        recipients: [recipient],
+        subject: hydratedSubject,
+        body: themedHTMLEmail,
+        referenceId: String(id),
+        ...(replyTo ? { replyTo } : {}),
+      })
+
+      await this.connection.query(
+        `UPDATE email_ops SET status='SENDING', delivered_at=clock_timestamp(), message_id=:messageId, updated_at=clock_timestamp() WHERE id=:id;`,
+        { replacements: { id, messageId }, type: QueryTypes.UPDATE }
+      )
+    } catch (error) {
+      await this.connection.query(
+        `UPDATE email_ops SET status='ERROR', delivered_at=clock_timestamp(), error_code=:error, updated_at=clock_timestamp() WHERE id=:id;`,
+        {
+          replacements: { id, error: error.message.substring(0, 255) },
+          type: QueryTypes.UPDATE,
         }
       )
-      .then((messageId) => {
-        return this.connection.query(
-          `UPDATE email_ops SET status='SENDING', delivered_at=clock_timestamp(), message_id=:messageId, updated_at=clock_timestamp() WHERE id=:id;`,
-          { replacements: { id, messageId }, type: QueryTypes.UPDATE }
-        )
-      })
-      .catch((error: Error) => {
-        return this.connection.query(
-          `UPDATE email_ops SET status='ERROR', delivered_at=clock_timestamp(), error_code=:error, updated_at=clock_timestamp() WHERE id=:id;`,
-          {
-            replacements: { id, error: error.message.substring(0, 255) },
-            type: QueryTypes.UPDATE,
-          }
-        )
-      })
-      .then(() => {
-        logger.info({
-          message: 'Sent email message',
-          workerId: this.workerId,
-          id,
-          action: 'sendMessage',
-        })
-      })
+    }
+
+    logger.info({
+      message: 'Sent email message',
+      workerId: this.workerId,
+      id,
+      action: 'sendMessage',
+    })
   }
 
   async setSendingService(_: string): Promise<void> {

--- a/worker/src/core/loaders/message-worker/interface.ts
+++ b/worker/src/core/loaders/message-worker/interface.ts
@@ -7,4 +7,5 @@ export interface Message {
   replyTo?: string | null
   campaignId?: number
   from?: string
+  showMasthead?: boolean
 }


### PR DESCRIPTION
## Feature
- Added email template to improve legitimacy of Postman’s emails

## Tests
**Email templates**
- [ ] Send an email campaign and ensure that preview, test message and actual message uses email template
- [ ] Send a protected email campaign and ensure that preview, test message and actual message uses email template
- [ ] Send duplicated email campaign and ensure that template is applied

**General smoke tests**
- [ ] Send Email campaign
- [ ] Send Protected Email campaign 
- [ ] Send SMS campaign 
- [ ] Send Telegram campaign

## Deploy notes
**Database migrations**
- `20210621043226-create-get-messages-to-send-email-with-sender-function` - Adds new get message function that includes sender