### PR TITLE
Fix outlook preheader styles

### DIFF
--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -100,10 +100,19 @@
   {{!--
     Preheader text (within a hidden div) is the preview text being shown in email clients
     @see: https://www.litmus.com/blog/the-little-known-preview-text-hack-you-may-want-to-use-in-every-email/
+
+    Table with "mso-hide: all" for Outlook 2007-2016 which apparently doesn't support "display: none"
+    @see: https://litmus.com/community/discussions/6911-display-none-not-working-in-outlook
   --}}
-  <div style="display: none; max-height: 0px; overflow: hidden;">
-    {{preheader}}
-  </div>
+  <table style="mso-hide: all; display: none; max-height: 0px; overflow: hidden;">
+    <tr>
+      <td>
+        <div style="display: none; max-height: 0px; overflow: hidden;">
+          {{preheader}}
+        </div>
+      </td>
+    </tr>
+  </table>
 
   {{!-- Insert spacers to prevent text below from appearing in preheader --}}
   <div style="display: none; max-height: 0px; overflow: hidden;">


### PR DESCRIPTION
## Problem
Text in preheader (a hidden div containing first 200 chars of the body) in the email template gets shown when a user in Outlook clicks the "reply" button

Closes #1251

## Solution

Add outlook specific styles that hide the preheader text

## Tests

1. Send email to Outlook (2007-2016) client
2. Reply to email
3. Open reply in another client - preheader text should no longer be shown