### PR TITLE
hotfix: Workers dying due to uncaught invalid email error

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Backend / API server for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "scripts": {
     "start": "react-app-rewired start",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postmangovsg",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Shared modules for Postman",
   "main": "build/index.js",
   "scripts": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worker",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Workers for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -111,11 +111,11 @@ class Email {
     campaignId,
     showMasthead,
   }: Message): Promise<void> {
-    if (!validator.isEmail(recipient)) {
-      throw new Error('Recipient is incorrectly formatted')
-    }
-
     try {
+      if (!validator.isEmail(recipient)) {
+        throw new Error('Recipient is incorrectly formatted')
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const hydratedSubject = templateClient.template(subject!, params)
       const hydratedBody = templateClient.template(body, params)


### PR DESCRIPTION
## Problem

Due to refactoring in #1242 within the `sendMessages` method in `email.class`, email service workers will die if it encounters an invalid email due to an unhandled `throw`

## Solution

Moved email validation code into a try/catch block
