### PR TITLE
fix(shared): clean build and reference build config in other modules

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -10,6 +10,6 @@
     "./src/__mocks__"
   ],
   "references": [
-    { "path": "../shared" }
+    { "path": "../shared/tsconfig.build.json" }
   ]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,7 @@
     "./src/server.ts"
   ],
   "references": [
-    { "path": "../shared" }
+    { "path": "../shared/tsconfig.build.json" }
   ],
   "compileOnSave": true,
   "compilerOptions": {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -29,7 +29,7 @@
   ],
   "references": [
     {
-      "path": "../shared"
+      "path": "../shared/tsconfig.build.json"
     }
   ]
 }

--- a/shared/package.json
+++ b/shared/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "dev": "npm run postbuild && tsc --build tsconfig.build.json -w",
-    "build": "rimraf build && tsc -b --clean && tsc --build tsconfig.build.json",
+    "build": "rimraf build && tsc --build tsconfig.build.json --clean && tsc -p tsconfig.build.json",
     "lint-no-fix": "tsc --composite false --noEmit && eslint --ext .js,.ts --cache .",
     "lint": "npm run lint-no-fix -- --fix",
     "postbuild": "npm run copy-assets",

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -9,7 +9,7 @@
     "./src/server.ts"
   ],
   "references": [
-    { "path": "../shared" }
+    { "path": "../shared/tsconfig.build.json" }
   ],
   "compileOnSave": true,
   "compilerOptions": {


### PR DESCRIPTION
## Problem
- Other modules were not correctly referring to the build tsconfig under project references. 
- `tsc --build --clean` command was not referring to the right build tsconfig

## Solution

**Improvements**
- Reference build tsconfig in other modules
- Reference build tsconfig in clean command

## Test
- Run `npm run dev` consecutively, error should not occur as the clean command now clears the right file