### PR TITLE
fix(backend): escape sender name before validation

### DIFF
--- a/backend/src/core/utils/from-address.ts
+++ b/backend/src/core/utils/from-address.ts
@@ -1,7 +1,11 @@
 import config from '@core/config'
 import validator from 'validator'
 import { Joi } from 'celebrate'
-import { parseFromAddress, formatFromAddress } from '@shared/utils/from-address'
+import {
+  parseFromAddress,
+  formatFromAddress,
+  escapeFromAddress,
+} from '@shared/utils/from-address'
 
 /**
  * Determine if a from is using the default from email address
@@ -18,7 +22,10 @@ export const fromAddressValidator = Joi.string()
   .trim()
   .default(config.get('mailFrom'))
   .custom((value: string, helpers: any) => {
-    if (validator.isEmail(value, { allow_display_name: true })) {
+    // Newer versions of validator library require special characters like period to be enclosed in double quotes.
+    // For backward compatibility, we parse and manually quote the sender name before validation.
+    const input = escapeFromAddress(value)
+    if (validator.isEmail(input, { allow_display_name: true })) {
       const { fromName, fromAddress } = parseFromAddress(value)
       return formatFromAddress(fromName, fromAddress)
     }

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -61,6 +61,19 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
     expect(res.body).toEqual({ message: "Invalid 'from' email address." })
   })
 
+  test('Invalid values for email is not accepted', async () => {
+    const res = await request(app)
+      .put(`/campaign/${campaignId}/email/template`)
+      .send({
+        from: 'not an email <not email>',
+        subject: 'test',
+        body: 'test',
+        reply_to: 'user@agency.gov.sg',
+      })
+    expect(res.status).toBe(400)
+    expect(res.body).toMatchObject({ message: '"from" must be a valid email' })
+  })
+
   test('Default from address is used if not provided', async () => {
     const res = await request(app)
       .put(`/campaign/${campaignId}/email/template`)
@@ -75,6 +88,27 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         message: `Template for campaign ${campaignId} updated`,
         template: expect.objectContaining({
           from: 'Postman <donotreply@mail.postman.gov.sg>',
+          reply_to: 'user@agency.gov.sg',
+        }),
+      })
+    )
+  })
+
+  test('Unquoted from address with periods is accepted', async () => {
+    const res = await request(app)
+      .put(`/campaign/${campaignId}/email/template`)
+      .send({
+        from: 'Agency.gov.sg <donotreply@mail.postman.gov.sg>',
+        subject: 'test',
+        body: 'test',
+        reply_to: 'user@agency.gov.sg',
+      })
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        message: `Template for campaign ${campaignId} updated`,
+        template: expect.objectContaining({
+          from: 'Agency.gov.sg via Postman <donotreply@mail.postman.gov.sg>',
           reply_to: 'user@agency.gov.sg',
         }),
       })


### PR DESCRIPTION
## Problem

Sender name with periods need to be quoted. A bug in the older versions of `validator` we were depending on did not enforce this. I am choosing to put in this fix for now to maintain backward compatibility. A better fix but more extensive fix would be to separately store sender name and sender email address, thus giving more flexibility in the formatting for the `from` string.

## Solution

**Bug Fixes**:

- Manually quote sender name before validation

## Tests
- Create a new campaign with period in the sender name. E.g. `Postman.gov.sg`. The template should be saved without an error thrown.