### PR TITLE
fix: move domain creation into same transaction

### DIFF
--- a/backend/src/core/models/user/user.ts
+++ b/backend/src/core/models/user/user.ts
@@ -116,10 +116,13 @@ export class User extends Model<User> {
         },
         transaction: options.transaction,
       })
-      await Domain.create({
-        domain: emailDomain,
-        agencyId: defaultAgency.id,
-      })
+      await Domain.create(
+        {
+          domain: emailDomain,
+          agencyId: defaultAgency.id,
+        },
+        { transaction: options.transaction }
+      )
     }
 
     instance.emailDomain = emailDomain


### PR DESCRIPTION
## Problem

**Note:** Not critical, won't occur in prod once `agencies` table has been populated. See below for details.

Fix for Sequelize Foreign Key error when there is a:

- new user signing up
- with unrecognised Domain (not in domains table)
- AND agencies table does not include default agency (based on name set in env var)

Problem is caused within the `BeforeCreate` hook
1. Creation of the `Domain` is not done in the same transaction as the rest of the hook, including `findOrCreate` for the defaultAgency
2. When defaultAgency does not exist, the agency is created **but not commited**, but returns a value to app layer
3. Because no transaction is specified for the domain creation (with a fkey on the default agency id), by default, sequelize attempts to immediately commit the change
4. However, because the creation of defaultAgency has not been committed, the agency id doesn't exist, throwing a fkey error

Issue is not critical because when the default agency has already been inserted to the `agencies` table, `Agency.findOrCreate` returns a id of an agency that already has been commited, hence the Domain creation will pass as well

## Solution

- Create the `Domain` using the same transaction as the rest of the hook
- Update unit tests to use single transaction for user create

## Tests
Run unit tests in `backend/src/core/models/user/user.test.ts`