### PR TITLE
chore: remove redundant info box from creation step 3

### DIFF
--- a/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
@@ -74,18 +74,6 @@ const EmailCredentials = ({
               <EmailValidationInput onClick={handleTestSend} />
             </div>
             <ErrorBlock>{errorMsg}</ErrorBlock>
-
-            {hasCredential && (
-              <DetailBlock>
-                <li>
-                  <i className="bx bx-check-circle"></i>
-                  <span>
-                    Email credentials have been validated but you may continue
-                    to send test messages.
-                  </span>
-                </li>
-              </DetailBlock>
-            )}
           </StepSection>
 
           <ButtonGroup>


### PR DESCRIPTION
## Problem

A redundant infobox was displayed. Removal was requested.

Closes #1266

## Solution

I removed the offending template block.

**Improvements**:

- Less clutter, yay 🎉 
- 
## Before & After Screenshots

**BEFORE**:
[insert screenshot here]

**AFTER**:
[insert screenshot here]

## Tests

Run the creation wizard. Go the step 3, and voila it's not there.