### PR TITLE
feat(frontend): update minor design system styles

### DIFF
--- a/frontend/src/components/common/close-button/CloseButton.module.scss
+++ b/frontend/src/components/common/close-button/CloseButton.module.scss
@@ -3,19 +3,25 @@
 
 .close {
   @include flex-center;
-  color: $primary;
-  font-size: 2.5rem;
-  line-height: 1;
-  font-weight: 100;
-  transform: rotate(45deg);
-  height: 3rem;
-  width: 3rem;
-  border-radius: 50%;
+  font-size: 2rem;
+  height: 2.5rem;
+  width: 2.5rem;
   cursor: pointer;
   user-select: none;
   border: 0;
   background: none;
   padding: 0;
+
+  :global {
+    i.bx {
+      display: block;
+      font-size: inherit;
+      line-height: 1;
+      font-weight: 100;
+      border-radius: 50%;
+      margin: 0;
+    }
+  }
 
   &:hover,
   &:active,

--- a/frontend/src/components/common/close-button/CloseButton.tsx
+++ b/frontend/src/components/common/close-button/CloseButton.tsx
@@ -7,7 +7,7 @@ const CloseButton = (props: any) => {
 
   return (
     <button className={cx(styles.close, className)} {...otherProps}>
-      +
+      <i className="bx bx-x"></i>
     </button>
   )
 }

--- a/frontend/src/components/common/detail-block/DetailBlock.module.scss
+++ b/frontend/src/components/common/detail-block/DetailBlock.module.scss
@@ -2,7 +2,7 @@
 @import 'styles/_mixins';
 
 .detailBlock {
-  @include block($neutral-light, $secondary);
+  @include block($neutral-light, $secondary, $secondary);
   overflow-wrap: anywhere;
   border-left: none;
   margin: 0;

--- a/frontend/src/components/common/error-block/ErrorBlock.module.scss
+++ b/frontend/src/components/common/error-block/ErrorBlock.module.scss
@@ -2,5 +2,5 @@
 @import 'styles/_mixins';
 
 .errorBlock {
-  @include block($error-light, $error);
+  @include block($error-light, $error, $error);
 }

--- a/frontend/src/components/common/info-block/InfoBlock.module.scss
+++ b/frontend/src/components/common/info-block/InfoBlock.module.scss
@@ -2,5 +2,5 @@
 @import 'styles/_mixins';
 
 .infoBlock {
-  @include block($neutral-light, $primary);
+  @include block($neutral-light, $secondary, $primary);
 }

--- a/frontend/src/components/common/warning-block/WarningBlock.module.scss
+++ b/frontend/src/components/common/warning-block/WarningBlock.module.scss
@@ -2,5 +2,5 @@
 @import 'styles/_mixins';
 
 .warningBlock {
-  @include block($warning-light, $warning-dark);
+  @include block($warning-light, $warning-dark, $warning-dark);
 }

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -115,7 +115,7 @@
 }
 
 .greenInfoBlock {
-  @include block(rgba($success, 0.2), $success);
+  @include block(rgba($success, 0.2), $success, $success);
 }
 
 .editBtn {

--- a/frontend/src/components/dashboard/create/Create.module.scss
+++ b/frontend/src/components/dashboard/create/Create.module.scss
@@ -134,14 +134,6 @@
   }
 }
 
-.warningHelpLink {
-  font-style: italic;
-  color: inherit;
-  &:hover {
-    text-decoration: underline;
-  }
-}
-
 .protectedPreview {
   border-radius: 1.25rem;
 }

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -183,14 +183,16 @@ const EmailRecipients = ({
 
         {!csvFilename && (
           <WarningBlock title={'We do not remove duplicate recipients'}>
+            Learn how to remove duplicates in your excel{' '}
             <OutboundLink
               className={styles.warningHelpLink}
               eventLabel={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               to={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               target="_blank"
             >
-              Learn how to remove duplicates in your excel from our guide.
+              from our guide
             </OutboundLink>
+            .
           </WarningBlock>
         )}
 

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -163,14 +163,16 @@ const SMSRecipients = ({
 
         {!csvFilename && (
           <WarningBlock title={'We do not remove duplicate recipients'}>
+            Learn how to remove duplicates in your excel{' '}
             <OutboundLink
               className={styles.warningHelpLink}
               eventLabel={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               to={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               target="_blank"
             >
-              Learn how to remove duplicates in your excel from our guide.
+              from our guide
             </OutboundLink>
+            .
           </WarningBlock>
         )}
 

--- a/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramRecipients.tsx
@@ -160,14 +160,16 @@ const TelegramRecipients = ({
 
         {!csvFilename && (
           <WarningBlock title={'We do not remove duplicate recipients'}>
+            Learn how to remove duplicates in your excel{' '}
             <OutboundLink
               className={styles.warningHelpLink}
               eventLabel={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               to={i18n._(LINKS.guideRemoveDuplicatesUrl)}
               target="_blank"
             >
-              Learn how to remove duplicates in your excel from our guide.
+              from our guide
             </OutboundLink>
+            .
           </WarningBlock>
         )}
 

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -54,6 +54,7 @@
   a {
     font-size: 1rem;
     color: $primary;
+    text-decoration: underline;
   }
 }
 

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -17,15 +17,15 @@
   align-items: center;
 }
 
-@mixin block($backgroundColor, $color) {
+@mixin block($backgroundColor, $fontColor, $accentColor) {
   padding: 1rem 2rem;
   border-radius: 0.3rem;
   display: flex;
   flex-direction: column;
   background-color: $backgroundColor;
-  border-left: 0.5rem solid $color;
+  border-left: 0.5rem solid $accentColor;
   margin: 2rem 0;
-  color: $color;
+  color: $fontColor;
 
   li {
     margin-bottom: 0.5rem;
@@ -42,16 +42,18 @@
     margin-top: 0.2rem;
     margin-right: 1rem;
     font-size: 1.3rem;
+    color: $accentColor;
   }
 
   p {
-    color: $color;
+    color: $fontColor;
     font-size: 1rem;
     margin-block-end: 0;
   }
 
   a {
     font-size: 1rem;
+    color: $primary;
   }
 }
 

--- a/frontend/src/styles/base/_colours.scss
+++ b/frontend/src/styles/base/_colours.scss
@@ -10,7 +10,7 @@ $blue-700: #2121a5;
 $blue-900: #040651;
 $blue: $blue-500;
 
-$green-100: #b3d8dd;
+$green-100: #cae4e7;
 $green-300: #80bec7;
 $green-500: #007c8f;
 $green-700: #006372;


### PR DESCRIPTION
## Problem

Closes [#1267]

## Solution
Frontend changes only, see screenshots

## Before & After Screenshots

### Update green colour
**BEFORE**:
![image](https://user-images.githubusercontent.com/9080115/126945327-9c864f60-bf67-49f1-adc7-0f0e55edc094.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/9080115/126945303-c05ebcba-2c04-411d-89ab-ddad67200790.png)

### Font color for blue notif box
**BEFORE**
![image](https://user-images.githubusercontent.com/9080115/126946016-509b836a-b9e9-4a97-8d46-17802e22a016.png)

**AFTER**
![image](https://user-images.githubusercontent.com/9080115/126945525-c69b47b4-d638-4084-9d3c-42405ad1697c.png)


### Links for notif boxes
Changed from italics to underlined blue text so it's more clear
**BEFORE**
![image](https://user-images.githubusercontent.com/9080115/126946081-e9899660-a4a3-4984-acfd-14ca9d3c2238.png)
**AFTER**
![image](https://user-images.githubusercontent.com/9080115/126945024-008033fc-4814-4f07-a1bc-49f84ba657e9.png)

### Close button 
(edited to use Box Icons, changed default color to `inherit`)
**BEFORE**
![image](https://user-images.githubusercontent.com/9080115/126946240-73ca83e9-fc75-4c65-bea8-8aea4419fb0d.png)
**AFTER**
![image](https://user-images.githubusercontent.com/9080115/126953030-adf254d5-d048-4f80-a665-6c2084b3cd81.png)

