### PR TITLE
fix: remove error message for read status

### DIFF
--- a/frontend/src/classes/EmailCampaign.ts
+++ b/frontend/src/classes/EmailCampaign.ts
@@ -76,6 +76,7 @@ export class EmailCampaignRecipient extends CampaignRecipient {
     switch (this.status) {
       case 'SENDING':
       case 'SUCCESS':
+      case 'READ':
         return ''
       case 'INVALID_RECIPIENT':
         // If error code is null and status is invalid, the email has been blacklisted. Otherwise, the error has not been mapped.


### PR DESCRIPTION
## Problem

Currently, the delivery report gives a `null` value under the error column when the status is `READ`. This confuses users as to whether the status is successful.

## Solution

**Bug Fixes**:

- Provide empty error value if status is `READ`

## Tests
- Send email campaign and open email. Exported delivery report should show that status is `READ` and error column is emtpy.