### PR TITLE
fix(backend): return `400 Bad Request` on invalid protected template

### DIFF
--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -65,7 +65,7 @@ const verifyTemplate = async (
       error: err,
       action: 'verifyTemplate',
     })
-    return res.status(500).json({ message: err.message })
+    return res.status(400).json({ message: err.message })
   }
 }
 

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -278,7 +278,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         body: 'test',
         reply_to: 'user@agency.gov.sg',
       })
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(400)
     expect(res.body).toEqual({
       message:
         'Error: There are missing keywords in the message template: protectedlink. Please return to the previous step to add in the keywords.',
@@ -293,7 +293,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         body: '{{recipient}} {{protectedLink}}',
         reply_to: 'user@agency.gov.sg',
       })
-    expect(testSubject.status).toBe(500)
+    expect(testSubject.status).toBe(400)
     expect(testSubject.body).toEqual({
       message:
         'Error: Only these keywords are allowed in the template: protectedlink,recipient.\nRemove the other keywords from the template: name.',
@@ -309,7 +309,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         reply_to: 'user@agency.gov.sg',
       })
 
-    expect(testBody.status).toBe(500)
+    expect(testBody.status).toBe(400)
     expect(testBody.body).toEqual({
       message:
         'Error: Only these keywords are allowed in the template: protectedlink,recipient.\nRemove the other keywords from the template: name.',


### PR DESCRIPTION
## Problem

Currently, an invalid protected template triggers a `500 Internal Server Error`. This result in false alerts in our monitoring system. Given that this is a result of bad user input, a more appropriate HTTP status code will be `400 Bad Request`.

## Solution

**Bug Fixes**:
- Return `400 Bad Request` when protected template is invalid (e.g. does not contain `{{protectedlink}}`).

## Tests
- Attempt to save an invalid protected email template. Note that the status code returned is `400` in Chrome console.