### PR TITLE
feat(frontend): styling for rich text editor popups

### DIFF
--- a/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
+++ b/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
@@ -76,4 +76,41 @@
   p {
     @extend %email-body;
   }
+
+  .imagePlaceholder {
+    @extend %body-2;
+    background: $neutral-light;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0px;
+    padding: $layout-3 $layout-5;
+
+    p {
+      font-family: $font-stack;
+      max-width: 100%;
+      margin: 0px;
+      text-align: center;
+      color: $grey-700;
+      word-wrap: break-word;
+    }
+
+    :global {
+      i.bx {
+        font-size: 32px;
+      }
+
+      i.bx-x {
+        font-size: 12px;
+        margin-left: -10px;
+        background: $neutral-light;
+      }
+    }
+
+    a {
+      @extend %body-2;
+      text-decoration: underline;
+    }
+  }
 }

--- a/frontend/src/components/common/email-preview-block/EmailPreviewBlock.tsx
+++ b/frontend/src/components/common/email-preview-block/EmailPreviewBlock.tsx
@@ -1,7 +1,9 @@
 import cx from 'classnames'
+import { useState, useEffect } from 'react'
 import type { FC } from 'react'
 
 import DetailBlock from '../detail-block'
+import { isImgSrcValid, isExternalImage } from '../rich-text-editor/utils/image'
 
 import styles from './EmailPreviewBlock.module.scss'
 
@@ -14,6 +16,61 @@ interface EmailPreviewBlockProps {
   className?: string
 }
 
+const preprocessImages = async (html: string): Promise<string> => {
+  const parser = new DOMParser()
+  const parsed = parser.parseFromString(html, 'text/html')
+  const images = parsed.body.querySelectorAll('img')
+
+  const createPlaceholder = (src: string, width: number, message: string) => {
+    const placeholder = document.createElement('div')
+    placeholder.className = styles.imagePlaceholder
+    placeholder.style.width = `${width}%`
+    placeholder.innerHTML = `
+      <p>
+        <i class="bx bx-image"></i>
+        <i class="bx bx-x"></i>
+      </p>
+      <p>${message}</p>
+      <p>
+        <a href="${src}" target="_blank" rel="noopener noreferrer">
+          ${src.substring(0, 64) + (src.length > 64 ? '...' : '')}
+        </a>
+      </p>
+    `
+
+    return placeholder
+  }
+
+  for (let i = 0; i < images.length; i++) {
+    const image = images[i]
+    const { src, width } = image
+
+    if (isExternalImage(src)) {
+      const placeholder = createPlaceholder(
+        src,
+        width,
+        'Preview not available for external link:'
+      )
+
+      // Replace the image node with placeholder
+      image.parentNode?.insertBefore(placeholder, image)
+      image.parentNode?.removeChild(image)
+    } else if (!(await isImgSrcValid(src))) {
+      const placeholder = createPlaceholder(
+        src,
+        width,
+        'The following image cannot be displayed:'
+      )
+
+      // Replace the image node with placeholder
+      image.parentNode?.insertBefore(placeholder, image)
+      image.parentNode?.removeChild(image)
+    }
+  }
+
+  return parsed.body.innerHTML
+}
+
 const EmailPreviewBlock: FC<EmailPreviewBlockProps> = ({
   body,
   themedBody,
@@ -22,7 +79,17 @@ const EmailPreviewBlock: FC<EmailPreviewBlockProps> = ({
   from,
   className,
 }) => {
-  if (!body && !subject) {
+  const [preprocessed, setPreprocessed] = useState('')
+  useEffect(() => {
+    const formatHtml = async (html: string) => {
+      const formatted = await preprocessImages(html)
+      setPreprocessed(formatted)
+    }
+
+    if (themedBody) formatHtml(themedBody)
+  }, [themedBody])
+
+  if (!body && !subject && !preprocessed) {
     return (
       <DetailBlock>
         <li>
@@ -48,7 +115,9 @@ const EmailPreviewBlock: FC<EmailPreviewBlockProps> = ({
 
       <div
         className={styles.previewBody}
-        dangerouslySetInnerHTML={{ __html: themedBody ?? '' }}
+        dangerouslySetInnerHTML={{
+          __html: preprocessed,
+        }}
       ></div>
     </>
   )

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -213,10 +213,35 @@
 
     .imagePreview {
       text-align: center;
+      margin: $spacing-3 0;
 
       img {
         max-width: $item-width;
         max-height: 154px;
+      }
+    }
+
+    .externalImagePreview {
+      text-align: center;
+      background: $neutral-light;
+      padding: $spacing-6;
+      margin: $spacing-3 0;
+
+      p {
+        @extend %caption;
+        margin: $spacing-1;
+
+        :global {
+          i.bx {
+            font-size: 32px;
+          }
+
+          i.bx-x {
+            font-size: 12px;
+            margin-left: -6px;
+            background: $neutral-light;
+          }
+        }
       }
     }
 

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -176,7 +176,27 @@
     .submit {
       @extend .item;
       margin-bottom: 0;
-      flex-direction: row-reverse;
+      justify-content: flex-end;
+
+      .guideLink {
+        color: $secondary;
+        font-size: 0.65rem;
+        font-weight: 500;
+        line-height: 1rem;
+        margin-right: 0.75rem;
+
+        &:hover {
+          color: $primary;
+          text-decoration: underline;
+        }
+
+        :global {
+          i.bx {
+            font-size: 0.75rem;
+            line-height: 1rem;
+          }
+        }
+      }
 
       button {
         @extend %secondary-btn;

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -112,18 +112,38 @@
     top: 35px;
     left: 5px;
     background: $white;
-    padding: $spacing-2;
-    border-radius: 5px;
+    padding: $spacing-3 $spacing-4;
+    border-radius: 4px;
     box-shadow: 0px 0px 20px rgba(193, 199, 205, 0.7);
+
+    .top {
+      @include flex-horizontal;
+      margin-bottom: $spacing-1;
+      justify-content: space-between;
+      .header {
+        @extend %body-2;
+        line-height: 1.5rem;
+        font-weight: bold;
+        margin-bottom: 0;
+      }
+
+      .closeButton {
+        color: $grey-700;
+        font-size: 1.5rem;
+        height: 1.5rem;
+        width: 1.5rem;
+        margin-right: -$spacing-1;
+      }
+    }
 
     .item {
       @include flex-horizontal;
       margin-bottom: $spacing-1;
-      width: 300px;
+      width: 18rem;
 
       label {
         @extend %caption;
-        width: 50px;
+        width: 3rem;
       }
 
       .control {
@@ -133,10 +153,19 @@
       }
 
       input {
+        height: 1.75rem;
         width: 100%;
         padding: 0.25rem $spacing-1;
         border: solid 1px $neutral;
         border-radius: 0.25rem;
+        color: $secondary;
+        font-size: 0.75rem;
+        line-height: 1rem;
+
+        &:focus {
+          outline: none;
+          border-color: $primary;
+        }
 
         &::placeholder {
           color: $neutral;
@@ -146,7 +175,17 @@
 
     .submit {
       @extend .item;
+      margin-bottom: 0;
       flex-direction: row-reverse;
+
+      button {
+        @extend %secondary-btn;
+        @extend %caption;
+        height: 1.75rem;
+        min-width: 0;
+        border-radius: 4px;
+        padding: 6px 8px;
+      }
     }
   }
 
@@ -185,6 +224,7 @@
 
   .tableSelector {
     $grid-size: $height-1;
+    padding: $spacing-3;
 
     table {
       border-top: solid 1px $neutral;

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -136,20 +136,27 @@
       }
     }
 
+    $label-width: 3rem;
+    $item-width: 18rem;
+
     .item {
       @include flex-horizontal;
       margin-bottom: $spacing-1;
-      width: 18rem;
+      width: $item-width;
 
       label {
         @extend %caption;
-        width: 3rem;
+        width: $label-width;
       }
 
       .control {
         @include flex-horizontal;
         justify-content: space-between;
         flex: 1;
+
+        &.errorControl input {
+          border-color: $red;
+        }
       }
 
       input {
@@ -170,6 +177,35 @@
         &::placeholder {
           color: $neutral;
         }
+      }
+    }
+
+    .controlErrorMsg {
+      margin-top: -0.375rem;
+      margin-bottom: 0.5rem;
+      margin-left: $label-width;
+      font-size: 0.65rem;
+      line-height: 1rem;
+      color: $red;
+    }
+
+    .loadingIcon {
+      text-align: center;
+      padding: 0.5rem;
+
+      :global {
+        i.bx {
+          font-size: 2rem;
+        }
+      }
+    }
+
+    .imagePreview {
+      text-align: center;
+
+      img {
+        max-width: $item-width;
+        max-height: 154px;
       }
     }
 

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -120,11 +120,22 @@
       @include flex-horizontal;
       margin-bottom: $spacing-1;
       justify-content: space-between;
+
       .header {
         @extend %body-2;
         line-height: 1.5rem;
         font-weight: bold;
         margin-bottom: 0;
+
+        .infoIcon {
+          margin-left: 0.5rem;
+
+          :global {
+            i.bx {
+              line-height: 1.5rem;
+            }
+          }
+        }
       }
 
       .closeButton {

--- a/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.module.scss
+++ b/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.module.scss
@@ -43,3 +43,48 @@ div.popover {
     }
   }
 }
+
+.loading {
+  color: $grey-700;
+  :global {
+    i.bx {
+      margin-right: $spacing-1;
+    }
+  }
+}
+
+.fallback {
+  @extend %body-2;
+  background: $neutral-light;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin: 0px;
+  padding: $layout-3 $layout-5;
+
+  p {
+    max-width: 100%;
+    margin-bottom: 0px;
+    text-align: center;
+    color: $grey-700;
+    word-wrap: break-word;
+  }
+
+  :global {
+    i.bx {
+      font-size: 32px;
+    }
+
+    i.bx-x {
+      font-size: 12px;
+      margin-left: -6px;
+      background: $neutral-light;
+    }
+  }
+
+  a {
+    @extend %body-2;
+    text-decoration: underline;
+  }
+}

--- a/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.module.scss
+++ b/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.module.scss
@@ -1,0 +1,45 @@
+@import 'styles/_variables';
+@import 'styles/_mixins';
+
+// Include both "div" and class ".popover" for selector priority
+div.popover {
+  padding: 8px 12px;
+  font-family: $font-stack;
+
+  .sizeButton {
+    @extend %outline-secondary-btn;
+    @extend %caption;
+    padding: 6px 8px;
+  }
+
+  .textButton {
+    @include button(transparent, rgba($primary-light, 0.5), $primary-light);
+    color: $secondary;
+    font-size: 0.9rem;
+    padding: 2px 4px;
+
+    :global {
+      i.bx {
+        margin: 0;
+        font-size: 0.9rem;
+        line-height: 1rem;
+        padding: 0 4px;
+        width: 1rem;
+      }
+    }
+  }
+
+  .sizeButton,
+  .textButton {
+    font-family: inherit;
+    height: 1.75rem;
+    min-width: 0;
+    border-radius: 4px;
+    margin-left: 12px;
+    font-weight: 400;
+
+    &:first-of-type {
+      margin-left: 0;
+    }
+  }
+}

--- a/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
+++ b/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
@@ -81,7 +81,7 @@ const ImageWithFallback = forwardRef<HTMLImageElement, ImageWithFallbackProps>(
       )
     }
 
-    return !valid ? (
+    return valid ? (
       <img
         ref={ref}
         onClick={onClick}

--- a/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
+++ b/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
@@ -6,11 +6,107 @@ import {
   SelectionState,
   Modifier,
 } from 'draft-js'
-import { useRef, useState, useContext } from 'react'
+import {
+  useRef,
+  useState,
+  useContext,
+  useEffect,
+  useMemo,
+  forwardRef,
+} from 'react'
 
 import { EditorContext } from '../RichTextEditor'
+import { isImgSrcValid, isExternalImage } from '../utils/image'
 
 import styles from './ImageBlock.module.scss'
+
+interface ImageWithFallbackProps {
+  onClick: () => void
+  src: string
+  width: number
+  height: number
+}
+
+const ImageWithFallback = forwardRef<HTMLImageElement, ImageWithFallbackProps>(
+  ({ onClick, src, width, height }, ref) => {
+    const [loading, setLoading] = useState<boolean>(false)
+    const [valid, setValid] = useState<boolean>(false)
+    const isExternal = useMemo(() => isExternalImage(src), [src])
+
+    const truncatedSrc = src.substring(0, 64) + (src.length > 64 ? '...' : '')
+
+    useEffect(() => {
+      const verifyImage = async () => {
+        try {
+          setLoading(true)
+          const valid = await isImgSrcValid(src)
+          setValid(valid)
+        } catch (err) {
+          setValid(false)
+        } finally {
+          setLoading(false)
+        }
+      }
+      if (!isExternal) verifyImage()
+    }, [src, isExternal])
+
+    if (loading) {
+      return (
+        <div className={styles.loading}>
+          <i className="bx bx-loader-alt bx-spin"></i>
+          <span>Loading image...</span>
+        </div>
+      )
+    }
+
+    if (isExternal) {
+      return (
+        <div
+          ref={ref}
+          className={styles.fallback}
+          style={{ width }}
+          onClick={onClick}
+        >
+          <p>
+            <i className="bx bx-image"></i>
+            <i className="bx bx-x"></i>
+          </p>
+          <p>Preview not available for external link:</p>
+          <p>
+            <a href={src} target="_blank" rel="noopener noreferrer">
+              {truncatedSrc}
+            </a>
+          </p>
+        </div>
+      )
+    }
+
+    return !valid ? (
+      <img
+        ref={ref}
+        onClick={onClick}
+        src={src}
+        width={width}
+        height={height}
+        alt=""
+      />
+    ) : (
+      <div className={styles.fallback} style={{ width }} onClick={onClick}>
+        <p>
+          <i className="bx bx-image"></i>
+          <i className="bx bx-x"></i>
+        </p>
+        <p>The following image cannot be displayed:</p>
+        <p>
+          <a href={src} target="_blank" rel="noopener noreferrer">
+            {truncatedSrc}
+          </a>
+        </p>
+      </div>
+    )
+  }
+)
+ImageWithFallback.displayName = 'ImageWithFallback'
 
 export const ImageBlock = ({
   block,
@@ -116,13 +212,12 @@ export const ImageBlock = ({
     renderPreviewImage()
   ) : (
     <span>
-      <img
+      <ImageWithFallback
         ref={imageRef}
         onClick={handleClick}
         src={src}
         width={width}
         height={height}
-        alt=""
       />
       {showPopover && (
         <div contentEditable={false} className={cx('popover', styles.popover)}>

--- a/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
+++ b/frontend/src/components/common/rich-text-editor/blocks/ImageBlock.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames'
 import {
   ContentBlock,
   ContentState,
@@ -8,6 +9,8 @@ import {
 import { useRef, useState, useContext } from 'react'
 
 import { EditorContext } from '../RichTextEditor'
+
+import styles from './ImageBlock.module.scss'
 
 export const ImageBlock = ({
   block,
@@ -122,22 +125,30 @@ export const ImageBlock = ({
         alt=""
       />
       {showPopover && (
-        <div contentEditable={false} className="popover">
-          <button onClick={getUpdateWidth(50)}>50%</button>
+        <div contentEditable={false} className={cx('popover', styles.popover)}>
+          <button onClick={getUpdateWidth(50)} className={styles.sizeButton}>
+            50%
+          </button>
+          <button onClick={getUpdateWidth(75)} className={styles.sizeButton}>
+            75%
+          </button>
+          <button onClick={getUpdateWidth(100)} className={styles.sizeButton}>
+            100%
+          </button>
           <span className="divider"></span>
-          <button onClick={getUpdateWidth(75)}>75%</button>
-          <span className="divider"></span>
-          <button onClick={getUpdateWidth(100)}>100%</button>
-          <span className="divider"></span>
-          <button onClick={handleRemove}>Remove</button>
           {link && (
-            <>
-              <span className="divider"></span>
-              <a href={link} target="_blank" rel="noopener noreferrer">
-                Link <i className="bx bx-link"></i>
-              </a>
-            </>
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.textButton}
+            >
+              Link <i className="bx bx-link"></i>
+            </a>
           )}
+          <button onClick={handleRemove} className={styles.textButton}>
+            Remove
+          </button>
         </div>
       )}
     </span>

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -49,29 +49,33 @@ const ImageForm = ({
   const [previewState, setPreviewState] = useState(ImagePreviewState.Blank)
   const [error, setError] = useState('')
 
+  const isValidUrl = (url: string): boolean => {
+    try {
+      const { protocol } = new URL(url)
+      return protocol === 'http:' || protocol === 'https:'
+    } catch (err) {
+      return false
+    }
+  }
+
   const updatePreviewState = useCallback(async (imgSrc: string) => {
     setError('')
 
     try {
-      if (imgSrc === '') {
-        setPreviewState(ImagePreviewState.Blank)
+      if (!isValidUrl(imgSrc)) {
+        setPreviewState(ImagePreviewState.Error)
+        setError(t`errors.insertImage.notImage`)
       } else if (isExternalImage(imgSrc)) {
         setPreviewState(ImagePreviewState.External)
       } else if (await isImgSrcValid(imgSrc)) {
         setPreviewState(ImagePreviewState.Success)
       } else {
         setPreviewState(ImagePreviewState.Error)
-
-        const url = new URL(imgSrc)
-        setError(
-          url.protocol !== 'https:'
-            ? t`errors.insertImage.notHttps`
-            : t`errors.insertImage.invalidUrl`
-        )
+        setError(t`errors.insertImage.invalidUrl`)
       }
     } catch (err) {
       setPreviewState(ImagePreviewState.Error)
-      setError(t`errors.insertImage.invalidUrl`)
+      setError(t`errors.insertImage.notImage`)
     }
   }, [])
 

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -128,7 +128,9 @@ const ImageForm = ({
 
       {previewState === ImagePreviewState.Error && (
         <div className={styles.controlErrorMsg}>
-          Image not found at this address
+          {isExternalImage(imgSrc)
+            ? 'Image not found at this address'
+            : 'Make sure to use https for file.gov.sg links'}
         </div>
       )}
 

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -13,6 +13,7 @@ import { EditorContext } from '../RichTextEditor'
 import styles from '../RichTextEditor.module.scss'
 
 import CloseButton from 'components/common/close-button'
+import Tooltip from 'components/common/tooltip'
 import { LINKS } from 'config'
 
 const VARIABLE_REGEX = new RegExp(/^{{\s*?\w+\s*?}}$/)
@@ -68,7 +69,15 @@ const ImageForm = ({
     >
       <div className={styles.top}>
         <div>
-          <p className={styles.header}>Insert image</p>
+          <p className={styles.header}>
+            Insert image
+            <Tooltip
+              containerClassName={styles.infoIcon}
+              text="Upload your image to go.gov.sg and copy the file.go.gov.sg link"
+            >
+              <i className="bx bxs-help-circle"></i>
+            </Tooltip>
+          </p>
         </div>
         <CloseButton onClick={doCollapse} className={styles.closeButton} />
       </div>

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -1,13 +1,18 @@
+import { i18n } from '@lingui/core'
+
 import cx from 'classnames'
 import { AtomicBlockUtils } from 'draft-js'
 import { useContext, useState } from 'react'
 
 import type { FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 
+import { OutboundLink } from 'react-ga'
+
 import { EditorContext } from '../RichTextEditor'
 import styles from '../RichTextEditor.module.scss'
 
 import CloseButton from 'components/common/close-button'
+import { LINKS } from 'config'
 
 const VARIABLE_REGEX = new RegExp(/^{{\s*?\w+\s*?}}$/)
 
@@ -76,6 +81,14 @@ const ImageForm = ({
       </div>
 
       <div className={styles.submit}>
+        <OutboundLink
+          className={styles.guideLink}
+          eventLabel={i18n._(LINKS.guideEmailImageUrl)}
+          to={i18n._(LINKS.guideEmailImageUrl)}
+          target="_blank"
+        >
+          View guide <i className="bx bx-link-external"></i>
+        </OutboundLink>
         <button type="submit" disabled={!imgSrc}>
           Insert
         </button>

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -159,7 +159,10 @@ const ImageForm = ({
         >
           View guide <i className="bx bx-link-external"></i>
         </OutboundLink>
-        <button type="submit" disabled={!imgSrc}>
+        <button
+          type="submit"
+          disabled={previewState !== ImagePreviewState.Success}
+        >
           Insert
         </button>
       </div>

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -7,6 +7,8 @@ import type { FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 import { EditorContext } from '../RichTextEditor'
 import styles from '../RichTextEditor.module.scss'
 
+import CloseButton from 'components/common/close-button'
+
 const VARIABLE_REGEX = new RegExp(/^{{\s*?\w+\s*?}}$/)
 
 interface ImageControlProps {
@@ -20,8 +22,10 @@ interface ImageControlProps {
 
 const ImageForm = ({
   onChange,
+  doCollapse,
 }: {
   onChange: (key: string, ...vals: string[]) => void
+  doCollapse: () => void
 }) => {
   const [imgSrc, setImgSrc] = useState('')
   const [link, setLink] = useState('')
@@ -41,13 +45,19 @@ const ImageForm = ({
       onSubmit={handleSubmit}
       className={styles.form}
     >
+      <div className={styles.top}>
+        <div>
+          <p className={styles.header}>Insert image</p>
+        </div>
+        <CloseButton onClick={doCollapse} className={styles.closeButton} />
+      </div>
       <div className={styles.item}>
         <label>Source</label>
         <div className={styles.control}>
           <input
             value={imgSrc}
             type="text"
-            placeholder="file.go.gov.sg link"
+            placeholder="https://file.go.gov.sg/image"
             onChange={(e) => setImgSrc(e.target.value)}
           />
         </div>
@@ -59,7 +69,7 @@ const ImageForm = ({
           <input
             value={link}
             type="text"
-            placeholder="Image click links to this URL"
+            placeholder="(Optional) Image click links to this URL"
             onChange={(e) => setLink(e.target.value)}
           />
         </div>
@@ -67,7 +77,7 @@ const ImageForm = ({
 
       <div className={styles.submit}>
         <button type="submit" disabled={!imgSrc}>
-          Add
+          Insert
         </button>
       </div>
     </form>
@@ -140,7 +150,7 @@ export const ImageControl = (props: ImageControlProps) => {
       >
         <i className="bx bx-image"></i>
       </div>
-      {expanded && <ImageForm onChange={addImage} />}
+      {expanded && <ImageForm onChange={addImage} doCollapse={doCollapse} />}
     </div>
   )
 }

--- a/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/ImageControl.tsx
@@ -1,4 +1,5 @@
 import { i18n } from '@lingui/core'
+import { t } from '@lingui/macro'
 
 import cx from 'classnames'
 import { AtomicBlockUtils } from 'draft-js'
@@ -46,8 +47,11 @@ const ImageForm = ({
   const [imgSrc, setImgSrc] = useState('')
   const [link, setLink] = useState('')
   const [previewState, setPreviewState] = useState(ImagePreviewState.Blank)
+  const [error, setError] = useState('')
 
   const updatePreviewState = useCallback(async (imgSrc: string) => {
+    setError('')
+
     try {
       if (imgSrc === '') {
         setPreviewState(ImagePreviewState.Blank)
@@ -57,9 +61,17 @@ const ImageForm = ({
         setPreviewState(ImagePreviewState.Success)
       } else {
         setPreviewState(ImagePreviewState.Error)
+
+        const url = new URL(imgSrc)
+        setError(
+          url.protocol !== 'https:'
+            ? t`errors.insertImage.notHttps`
+            : t`errors.insertImage.invalidUrl`
+        )
       }
     } catch (err) {
       setPreviewState(ImagePreviewState.Error)
+      setError(t`errors.insertImage.invalidUrl`)
     }
   }, [])
 
@@ -127,11 +139,7 @@ const ImageForm = ({
       </div>
 
       {previewState === ImagePreviewState.Error && (
-        <div className={styles.controlErrorMsg}>
-          {isExternalImage(imgSrc)
-            ? 'Image not found at this address'
-            : 'Make sure to use https for file.gov.sg links'}
-        </div>
+        <div className={styles.controlErrorMsg}>{error}</div>
       )}
 
       <div className={styles.item}>

--- a/frontend/src/components/common/rich-text-editor/controls/LinkControl.tsx
+++ b/frontend/src/components/common/rich-text-editor/controls/LinkControl.tsx
@@ -4,6 +4,8 @@ import type { FormEvent, MouseEvent as ReactMouseEvent } from 'react'
 
 import styles from '../RichTextEditor.module.scss'
 
+import CloseButton from 'components/common/close-button'
+
 interface LinkControlProps {
   currentState: any
   expanded: boolean
@@ -16,9 +18,11 @@ interface LinkControlProps {
 const LinkForm = ({
   initialState,
   onSubmit,
+  doCollapse,
 }: {
   initialState: any
   onSubmit: ({ title, url }: { title: string; url: string }) => void
+  doCollapse: () => void
 }) => {
   const { link, selectionText } = initialState
   const [title, setTitle] = useState(link?.title || selectionText)
@@ -39,27 +43,35 @@ const LinkForm = ({
       onSubmit={handleSubmit}
       className={styles.form}
     >
+      <div className={styles.top}>
+        <div>
+          <p className={styles.header}>Insert link</p>
+        </div>
+        <CloseButton onClick={doCollapse} className={styles.closeButton} />
+      </div>
       <div className={styles.item}>
-        <label>Title</label>
+        <label>Text</label>
         <input
           className={styles.control}
           value={title}
           type="text"
+          placeholder="Text to display"
           onChange={(e) => setTitle(e.target.value)}
         />
       </div>
       <div className={styles.item}>
-        <label>URL</label>
+        <label>Link to</label>
         <input
           className={styles.control}
           value={url}
           type="text"
+          placeholder="URL"
           onChange={(e) => setURL(e.target.value)}
         />
       </div>
       <div className={styles.submit}>
         <button type="submit" disabled={!title || !url}>
-          Add
+          Insert
         </button>
       </div>
     </form>
@@ -67,7 +79,7 @@ const LinkForm = ({
 }
 
 export const LinkControl = (props: LinkControlProps) => {
-  const { currentState, expanded, onChange, onExpandEvent } = props
+  const { currentState, expanded, onChange, onExpandEvent, doCollapse } = props
   function showPopover() {
     onExpandEvent()
   }
@@ -81,7 +93,13 @@ export const LinkControl = (props: LinkControlProps) => {
       <div onClick={showPopover} className="rdw-option-wrapper">
         <i className="bx bx-link"></i>
       </div>
-      {expanded && <LinkForm initialState={currentState} onSubmit={addLink} />}
+      {expanded && (
+        <LinkForm
+          initialState={currentState}
+          onSubmit={addLink}
+          doCollapse={doCollapse}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/common/rich-text-editor/utils/image.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/image.ts
@@ -1,3 +1,7 @@
+import { i18n } from '@lingui/core'
+
+import { ALLOWED_IMAGE_SOURCES } from 'config'
+
 /**
  * Checks if an img src value is valid by creating a non-mounted image element
  * @param imgSrc
@@ -15,6 +19,7 @@ export function isImgSrcValid(imgSrc: string): Promise<boolean> {
 }
 
 export function isExternalImage(imgSrc: string): boolean {
+  const allowed = i18n._(ALLOWED_IMAGE_SOURCES).split(';')
   const url = new URL(imgSrc)
-  return !['file.go.gov.sg'].includes(url.host)
+  return !allowed.includes(url.host)
 }

--- a/frontend/src/components/common/rich-text-editor/utils/image.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/image.ts
@@ -18,6 +18,11 @@ export function isImgSrcValid(imgSrc: string): Promise<boolean> {
   })
 }
 
+/**
+ * Checks if an imgSrc is from an allowed domain
+ * @param imgSrc
+ * @returns whether imgSrc is valid
+ */
 export function isExternalImage(imgSrc: string): boolean {
   const allowed = i18n._(ALLOWED_IMAGE_SOURCES).split(';')
   const url = new URL(imgSrc)

--- a/frontend/src/components/common/rich-text-editor/utils/image.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/image.ts
@@ -1,0 +1,20 @@
+/**
+ * Checks if an img src value is valid by creating a non-mounted image element
+ * @param imgSrc
+ * @returns whether imgSrc is valid
+ */
+export function isImgSrcValid(imgSrc: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const img = document.createElement('img')
+    img.onerror = () => {
+      resolve(false)
+    }
+    img.onload = () => resolve(true)
+    img.src = imgSrc
+  })
+}
+
+export function isExternalImage(imgSrc: string): boolean {
+  const url = new URL(imgSrc)
+  return !['file.go.gov.sg'].includes(url.host)
+}

--- a/frontend/src/components/common/tooltip/Tooltip.module.scss
+++ b/frontend/src/components/common/tooltip/Tooltip.module.scss
@@ -1,0 +1,48 @@
+@import 'styles/_variables';
+@import 'styles/_mixins';
+
+.tooltipContainer {
+  position: relative;
+  display: inline-block;
+
+  .tooltip {
+    // Positioning
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, calc(-100% - 0.5rem));
+    z-index: 1;
+
+    @extend %caption;
+    width: max-content;
+    max-width: 14.5rem;
+    padding: 8px 12px;
+    border-radius: 4px;
+    background-color: $secondary;
+    color: $white;
+
+    opacity: 0%;
+    visibility: hidden;
+    transition: 0.3s;
+
+    // Downward Arrow
+    &::after {
+      $arrow-height: 0.5rem;
+      content: ' ';
+      position: absolute;
+      bottom: -$arrow-height;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 0;
+      height: 0;
+      border-left: $arrow-height solid transparent;
+      border-right: $arrow-height solid transparent;
+      border-top: $arrow-height solid $secondary;
+    }
+  }
+
+  &:hover .tooltip {
+    visibility: visible;
+    opacity: 100%;
+  }
+}

--- a/frontend/src/components/common/tooltip/Tooltip.module.scss
+++ b/frontend/src/components/common/tooltip/Tooltip.module.scss
@@ -22,7 +22,7 @@
     background-color: $secondary;
     color: $white;
 
-    opacity: 0%;
+    opacity: 0;
     visibility: hidden;
     transition: 0.3s;
 
@@ -44,6 +44,6 @@
 
   &:hover .tooltip {
     visibility: visible;
-    opacity: 100%;
+    opacity: 1;
   }
 }

--- a/frontend/src/components/common/tooltip/Tooltip.module.scss
+++ b/frontend/src/components/common/tooltip/Tooltip.module.scss
@@ -4,6 +4,7 @@
 .tooltipContainer {
   position: relative;
   display: inline-block;
+  cursor: pointer;
 
   .tooltip {
     // Positioning

--- a/frontend/src/components/common/tooltip/Tooltip.tsx
+++ b/frontend/src/components/common/tooltip/Tooltip.tsx
@@ -1,0 +1,25 @@
+import cx from 'classnames'
+import type { ReactNode } from 'react'
+
+import styles from './Tooltip.module.scss'
+
+const Tooltip = ({
+  containerClassName,
+  tooltipClassName,
+  children,
+  text,
+}: {
+  containerClassName?: string
+  tooltipClassName?: string
+  children: ReactNode
+  text: string
+}) => {
+  return (
+    <span className={cx(styles.tooltipContainer, containerClassName)}>
+      <span className={cx(styles.tooltip, tooltipClassName)}>{text}</span>
+      {children}
+    </span>
+  )
+}
+
+export default Tooltip

--- a/frontend/src/components/common/tooltip/index.ts
+++ b/frontend/src/components/common/tooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Tooltip'

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -64,6 +64,7 @@ axios.defaults.timeout = 100000 // 100 sec
 export const LINKS = {
   guideUrl: t`link.guideUrl`,
   guideEmailPasswordProtectedUrl: t`link.guideEmailPasswordProtectedUrl`,
+  guideEmailImageUrl: t`link.guideEmailImageUrl`,
   guideSmsUrl: t`link.guideSmsUrl`,
   guideSmsAccountSidUrl: t`link.guideSmsAccountSidUrl`,
   guideSmsApiKeyUrl: t`link.guideSmsApiKeyUrl`,

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -154,14 +154,13 @@ msgstr "Error: Incorrect email formatting. Please check for typos, spaces, and s
 msgid "errors.email.softBounce"
 msgstr "Soft bounce: The email inbox might be full or the recipient might have an out-of-office message."
 
-#: components/common/rich-text-editor/controls/ImageControl.tsx:54
-#: components/common/rich-text-editor/controls/ImageControl.tsx:59
+#: components/common/rich-text-editor/controls/ImageControl.tsx:56
 msgid "errors.insertImage.invalidUrl"
-msgstr "Image not found at this URL. Please check that the URL provided is valid."
+msgstr "This does not seem to be an image"
 
-#: components/common/rich-text-editor/controls/ImageControl.tsx:53
-msgid "errors.insertImage.notHttps"
-msgstr "Make sure to use https for file.gov.sg URLs"
+#: components/common/rich-text-editor/controls/ImageControl.tsx:51
+msgid "errors.insertImage.notImage"
+msgstr "Enter a link to an image"
 
 #: classes/SMSCampaign.ts:44
 msgid "errors.sms.invalidFormat"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -77,40 +77,40 @@ msgstr "Unsubscribe me"
 msgid "Verifying OTP..."
 msgstr "Verifying OTP..."
 
-#: config.ts:89
+#: config.ts:90
 msgid "allowedImageSources"
 msgstr "file.go.gov.sg"
 
-#: config.ts:103
+#: config.ts:104
 msgid "announcement.mediaUrl"
 msgstr "https://file.go.gov.sg/dz52q4.png"
 
-#: config.ts:105
+#: config.ts:106
 msgid "announcement.primaryButtonText"
 msgstr "Read guide"
 
-#: config.ts:104
+#: config.ts:105
 msgid "announcement.primaryButtonUrl"
 msgstr "https://guide.postman.gov.sg/release-notes"
 
-#: config.ts:107
+#: config.ts:108
 msgid "announcement.secondaryButtonText"
 msgstr "null"
 
-#: config.ts:106
+#: config.ts:107
 msgid "announcement.secondaryButtonUrl"
 msgstr "null"
 
-#: config.ts:102
+#: config.ts:103
 msgid "announcement.subtext"
 msgstr "Thanks for using Postman and joining us every step of the way while we mature as a product. We'll be releasing exciting new features this year. For instance, this is an announcement modal that will keep you up-to-date about our new features! Watch this space for things that are brewing. Learn more about Postman's releases by reading our guide."
 
-#: config.ts:101
+#: config.ts:102
 msgid "announcement.title"
 msgstr "Happy New Year! Congrats on making it through 2020."
 
 #: components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
-#: config.ts:87
+#: config.ts:88
 msgid "defaultMailFrom"
 msgstr "donotreply@mail.postman.gov.sg"
 
@@ -122,11 +122,11 @@ msgstr "This demo campaign will be sent to a maximum of 20 recipients."
 msgid "demoMessageLabel"
 msgstr "DEMO"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:171
+#: components/dashboard/create/email/EmailTemplate.tsx:172
 msgid "e.g. Appointment Confirmation"
 msgstr "e.g. Appointment Confirmation"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:157
+#: components/dashboard/create/email/EmailTemplate.tsx:158
 msgid "e.g. Ministry of Health"
 msgstr "e.g. Ministry of Health"
 
@@ -170,63 +170,67 @@ msgstr "Bot has been blocked by the recipient. Please contact the recipient via 
 msgid "errors.telegram.notSubscribed"
 msgstr "Recipient has not subscribed to your agency's bot - please ask them to subscribe before sending a message."
 
-#: config.ts:76
+#: config.ts:77
 msgid "link.contactUsUrl"
 msgstr "https://go.gov.sg/postman-contact-us"
 
-#: config.ts:77
+#: config.ts:78
 msgid "link.contributeUrl"
 msgstr "https://github.com/opengovsg/postmangovsg"
 
-#: config.ts:81
+#: config.ts:82
 msgid "link.customFromAddressRequestUrl"
 msgstr "https://go.gov.sg/postman-custom-from"
 
-#: config.ts:82
+#: config.ts:83
 msgid "link.demoTelegramBotUrl"
 msgstr "https://go.gov.sg/postmangovsgbot"
 
-#: config.ts:83
+#: config.ts:84
 msgid "link.demoVideoUrl"
 msgstr "https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/Demo+Campaign+Mode.mp4"
 
-#: config.ts:84
+#: config.ts:85
 msgid "link.featureRequestUrl"
 msgstr "https://go.gov.sg/postman-featurerequest"
 
-#: config.ts:74
+#: config.ts:75
 msgid "link.guideDemoUrl"
 msgstr "https://guide.postman.gov.sg/before-you-start/demo-mode"
+
+#: config.ts:68
+msgid "link.guideEmailImageUrl"
+msgstr "https://guide.postman.gov.sg/quick-start/email/format-bar#embedding-an-image-in-email"
 
 #: config.ts:67
 msgid "link.guideEmailPasswordProtectedUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/password-protected-email"
 
-#: config.ts:73
+#: config.ts:74
 msgid "link.guidePowerUserUrl"
 msgstr "https://guide.postman.gov.sg/guide/power-users"
 
-#: config.ts:75
+#: config.ts:76
 msgid "link.guideRemoveDuplicatesUrl"
 msgstr "https://guide.postman.gov.sg/quick-start#remove-duplicates-in-excel"
 
-#: config.ts:69
+#: config.ts:70
 msgid "link.guideSmsAccountSidUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-1-account-sid-and-auth-token"
 
-#: config.ts:70
+#: config.ts:71
 msgid "link.guideSmsApiKeyUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-2-set-up-a-standard-api-key"
 
-#: config.ts:71
+#: config.ts:72
 msgid "link.guideSmsMessagingServiceUrl"
 msgstr "https://guide.postman.gov.sg/guide/quick-start/sms#step-3-set-up-your-messaging-service"
 
-#: config.ts:68
+#: config.ts:69
 msgid "link.guideSmsUrl"
 msgstr "https://guide.postman.gov.sg/guide/getting-started/sms#find-twilio-credentials-on-twilio-console"
 
-#: config.ts:72
+#: config.ts:73
 msgid "link.guideTelegramUrl"
 msgstr "https://guide.postman.gov.sg/guide/getting-started/telegram-bot"
 
@@ -234,23 +238,23 @@ msgstr "https://guide.postman.gov.sg/guide/getting-started/telegram-bot"
 msgid "link.guideUrl"
 msgstr "https://guide.postman.gov.sg"
 
-#: config.ts:79
+#: config.ts:80
 msgid "link.privacyUrl"
 msgstr "https://guide.postman.gov.sg/legal/privacy"
 
-#: config.ts:80
+#: config.ts:81
 msgid "link.reportBugUrl"
 msgstr "https://guide.postman.gov.sg/contact-us"
 
-#: config.ts:78
+#: config.ts:79
 msgid "link.tncUrl"
 msgstr "https://guide.postman.gov.sg/legal/t-and-c"
 
-#: config.ts:85
+#: config.ts:86
 msgid "link.uploadLogoUrl"
 msgstr "https://go.gov.sg/postman-upload-logo-request"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:137
+#: components/dashboard/create/email/EmailTemplate.tsx:138
 #: components/dashboard/create/email/tests/EmailTemplate.test.tsx:267
 #: components/dashboard/create/email/tests/EmailTemplate.test.tsx:269
 msgid "mailVia"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -17,7 +17,7 @@ msgstr ""
 msgid "Delivery report has expired and is no longer available for download."
 msgstr "Delivery report has expired and is no longer available for download."
 
-#: components/common/export-recipients/ExportRecipients.tsx:140
+#: components/common/export-recipients/ExportRecipients.tsx:141
 msgid "Delivery report will expire 14 days after sending is completed."
 msgstr "Delivery report will expire 14 days after sending is completed."
 
@@ -153,6 +153,15 @@ msgstr "Error: Incorrect email formatting. Please check for typos, spaces, and s
 #: classes/EmailCampaign.ts:7
 msgid "errors.email.softBounce"
 msgstr "Soft bounce: The email inbox might be full or the recipient might have an out-of-office message."
+
+#: components/common/rich-text-editor/controls/ImageControl.tsx:54
+#: components/common/rich-text-editor/controls/ImageControl.tsx:59
+msgid "errors.insertImage.invalidUrl"
+msgstr "Image not found at this URL. Please check that the URL provided is valid."
+
+#: components/common/rich-text-editor/controls/ImageControl.tsx:53
+msgid "errors.insertImage.notHttps"
+msgstr "Make sure to use https for file.gov.sg URLs"
 
 #: classes/SMSCampaign.ts:44
 msgid "errors.sms.invalidFormat"

--- a/frontend/src/styles/base/_buttons.scss
+++ b/frontend/src/styles/base/_buttons.scss
@@ -59,9 +59,23 @@ $border-radius: $button-height / 2;
 }
 
 %outline-btn {
-  @include button(transparent, $neutral-light, $primary);
+  @include button(transparent, rgba($primary-light, 0.5), $primary);
   border: 1px solid $primary;
   color: $primary;
+
+  &:active {
+    color: $white;
+
+    * {
+      color: $white;
+    }
+  }
+}
+
+%outline-secondary-btn {
+  @include button(transparent, rgba($primary-light, 0.5), $secondary);
+  border: 1px solid $secondary;
+  color: $secondary;
 
   &:active {
     color: $white;


### PR DESCRIPTION
## Problem

Closes #1288
Closes #1305

## Solution

**Features**:
- Show placeholder for external images in rich text editor and preview
- Show placeholder for invalid images in rich text editor and preview
- Validate file.go.gov.sg image links

## Screenshots
![image](https://user-images.githubusercontent.com/3666479/129005581-87642134-97f5-480e-8f9e-31b4ce386299.png)

## Tests
- Insert text that is not a valid URL into the source field. An error message should be shown.
- Insert an image with a link from a non-whitelisted domain. The image should be inserted as a placeholder in the rich text editor. The image should also be a placeholder in the preview. The image width should adjust based on the value set.
- Insert an image with a link from a whitelisted domain. The image should be inserted correctly with link in both the editor and preview.
- Insert an image with a link from a whitelisted domain that is invalid (non-existent file.go.gov.sg link). An error message should be shown.
- Send out campaign with images. Emails should render correctly.