### PR TITLE
fix: reset link styles in html email preview

### DIFF
--- a/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
+++ b/frontend/src/components/common/email-preview-block/EmailPreviewBlock.module.scss
@@ -44,6 +44,15 @@
   * {
     font-family: $email-font-stack;
     color: inherit;
+    // revert is a new (2019) feature, keeping inherit above for backwards compat
+    color: revert;
+  }
+
+  a {
+    color: blue;
+    text-decoration: underline;
+    // revert is a new (2019) feature, keeping blue above for backwards compat
+    color: revert;
   }
 
   p,


### PR DESCRIPTION
## Problem

Fix link previews not having the correct styles

Closes [#1289]

## Solution

- Used `color: revert` to reset color for a tags
- Added manual overriding `color: blue; text-decoration: underline;` to ensure backwards compat

## Screenshots
![image](https://user-images.githubusercontent.com/9080115/127290387-2b5d33dc-417d-4cf8-9a6d-4c0168cbf593.png)

## Tests

- [x] Add link to email template, ensure that it is blue and underlined

## Deploy Notes
NA
