### PR TITLE
fix(frontend): text wrapping for messages sent on tablet

### DIFF
--- a/frontend/src/components/landing/Landing.module.scss
+++ b/frontend/src/components/landing/Landing.module.scss
@@ -128,22 +128,27 @@ $section-vertical-padding: 4rem;
         transition: opacity 1s ease-out;
         @include overflowHeaderText();
 
+        margin-top: 1.5rem;
+        margin-bottom: 2rem;
+
+        @include mobile() {
+          margin-top: 2vh;
+          margin-bottom: 2vh;
+        }
+
         &.ready {
           opacity: 1;
         }
 
         .numOfMessages {
           @extend %display-1;
-
-          margin-top: 1.5rem;
-          margin-bottom: 2rem;
           margin-right: 1rem;
+          margin-bottom: 0.5rem;
 
           @include mobile() {
             font-size: 3rem;
-            margin-top: 2vh;
-            margin-bottom: 2vh;
             margin-right: 1rem;
+            margin-bottom: 0rem;
           }
         }
       }


### PR DESCRIPTION
## Problem

Text wrapping for "messages sent" is off for certain screen sizes (tablet).

## Solution

**Bug Fixes**:
- Apply margin on the container instead for the message count.

## Before & After Screenshots

**BEFORE**:
![image](https://user-images.githubusercontent.com/3666479/128153812-40915188-2a4c-4812-8772-6304c77f6442.png)

**AFTER**:
![image](https://user-images.githubusercontent.com/3666479/128153859-47435a6a-7e88-4b79-ac28-b55a9baeb37e.png)

## Tests
- Replace the count to a large number (chrome inspector) and observe that the text wrapping looks normal when in tablet sized screen width

