### PR TITLE
refactor: remove email info block on send test email page

### DIFF
--- a/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailCredentials.tsx
@@ -5,15 +5,7 @@ import { useParams } from 'react-router-dom'
 import EmailValidationInput from './EmailValidationInput'
 
 import { EmailProgress } from 'classes'
-import {
-  NextButton,
-  DetailBlock,
-  ErrorBlock,
-  ButtonGroup,
-  TextButton,
-  StepHeader,
-  StepSection,
-} from 'components/common'
+import { ErrorBlock, StepHeader } from 'components/common'
 import { CampaignContext } from 'contexts/campaign.context'
 
 import { sendPreviewMessage } from 'services/email.service'
@@ -24,8 +16,7 @@ const EmailCredentials = ({
   setActiveStep: Dispatch<SetStateAction<EmailProgress>>
 }) => {
   const { campaign, updateCampaign } = useContext(CampaignContext)
-  const { hasCredential: initialHasCredential, protect } = campaign
-  const [hasCredential, setHasCredential] = useState(initialHasCredential)
+  const { protect } = campaign
   const [errorMsg, setErrorMsg] = useState(null)
   const { id: campaignId } = useParams<{ id: string }>()
 
@@ -39,9 +30,9 @@ const EmailCredentials = ({
         campaignId: +campaignId,
         recipient,
       })
-      setHasCredential(true)
       // Saves hasCredential property but do not advance to next step
       updateCampaign({ hasCredential: true })
+      setActiveStep((s) => s + 1)
     } catch (err) {
       setErrorMsg(err.message)
     }
@@ -51,52 +42,28 @@ const EmailCredentials = ({
     <>
       {
         <>
-          <StepSection>
-            <StepHeader title="Send a test email" subtitle="Step 3">
+          <StepHeader title="Send a test email" subtitle="Step 3">
+            <p>
+              <label htmlFor="validateEmail">
+                You can preview your message by sending an email to yourself.
+              </label>
+            </p>
+            {protect && (
               <p>
                 <label htmlFor="validateEmail">
-                  You can preview your message by sending an email to yourself.
+                  You will receive an email from postman.gov.sg showing the
+                  email that the recipient would receive once you click send
+                  campaign. You can click on the unique link and unlock the
+                  password protected page using the corresponding recipient
+                  password in your uploaded csv.
                 </label>
               </p>
-              {protect && (
-                <p>
-                  <label htmlFor="validateEmail">
-                    You will receive an email from postman.gov.sg showing the
-                    email that the recipient would receive once you click send
-                    campaign. You can click on the unique link and unlock the
-                    password protected page using the corresponding recipient
-                    password in your uploaded csv.
-                  </label>
-                </p>
-              )}
-            </StepHeader>
-            <div>
-              <EmailValidationInput onClick={handleTestSend} />
-            </div>
-            <ErrorBlock>{errorMsg}</ErrorBlock>
-
-            {hasCredential && (
-              <DetailBlock>
-                <li>
-                  <i className="bx bx-check-circle"></i>
-                  <span>
-                    Email credentials have been validated but you may continue
-                    to send test messages.
-                  </span>
-                </li>
-              </DetailBlock>
             )}
-          </StepSection>
-
-          <ButtonGroup>
-            <NextButton
-              disabled={!hasCredential}
-              onClick={() => setActiveStep((s) => s + 1)}
-            />
-            <TextButton onClick={() => setActiveStep((s) => s - 1)}>
-              Previous
-            </TextButton>
-          </ButtonGroup>
+          </StepHeader>
+          <div>
+            <EmailValidationInput onClick={handleTestSend} />
+          </div>
+          <ErrorBlock>{errorMsg}</ErrorBlock>
         </>
       }
     </>

--- a/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailValidationInput.tsx
@@ -22,6 +22,7 @@ const EmailValidationInput = ({
     <TextInputWithButton
       id="validateEmail"
       type="email"
+      placeholder="Enter test email address"
       value={recipient}
       onChange={setRecipient}
       onClick={onClickHandler}

--- a/frontend/src/components/dashboard/tests/integration/email.test.tsx
+++ b/frontend/src/components/dashboard/tests/integration/email.test.tsx
@@ -159,16 +159,6 @@ test('successfully creates and sends a new email campaign', async () => {
       name: /send/i,
     })
   )
-  expect(
-    await screen.findByText(/credentials have been validated/i)
-  ).toBeInTheDocument()
-
-  // Go to the preview and send page
-  userEvent.click(
-    screen.getByRole('button', {
-      name: /next/i,
-    })
-  )
 
   // Wait for the page to load and ensure the necessary elements are shown
   expect(await screen.findByText(DEFAULT_FROM)).toBeInTheDocument()

--- a/frontend/src/components/dashboard/tests/integration/protected-email.test.tsx
+++ b/frontend/src/components/dashboard/tests/integration/protected-email.test.tsx
@@ -178,16 +178,6 @@ test('successfully creates and sends a new protected email campaign', async () =
       name: /send/i,
     })
   )
-  expect(
-    await screen.findByText(/credentials have been validated/i)
-  ).toBeInTheDocument()
-
-  // Go to the preview and send page
-  userEvent.click(
-    screen.getByRole('button', {
-      name: /next/i,
-    })
-  )
 
   // Wait for the page to load and ensure the necessary elements are shown
   expect(await screen.findByText(DEFAULT_FROM)).toBeInTheDocument()


### PR DESCRIPTION
## Problem

Closes #1266 

## Solution

**Improvements**:
- Remove redundant info block on send test email page
- Add placeholder text for test email address input

## Before & After Screenshots

![image](https://user-images.githubusercontent.com/3666479/129139442-6f8eb4bc-7044-49b3-9aa9-eabc59bcf465.png)

## Tests
- Send an email campaign. Users will be automatically directed to next step after sending a test email. Info block should not be shown. Repeat for protected email.
- Send an email campaign and inject an error during the send test email step (manually throw an error on the backend). Error block should be shown and user should not be directed to the next step.