### PR TITLE
fix(frontend): do not pre-populate sender from name

### DIFF
--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -179,7 +179,7 @@ const isFromAddressAccepted = async (
     fromAddress: defaultFromAddress,
   } = parseFromAddress(config.get('mailFrom'))
 
-  if (fromAddress !== userEmail && fromAddress !== defaultFromAddress) {
+  if (fromAddress !== userEmail && !isDefaultFromAddress(from)) {
     logger.error({
       message: "Invalid 'from' email address",
       from,

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -14,6 +14,7 @@ import {
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@email/interfaces'
 import { parseFromAddress, formatFromAddress } from '@shared/utils/from-address'
+import { isDefaultFromAddress } from '@core/utils/from-address'
 
 const client = new TemplateClient({ xssOptions: XSS_EMAIL_OPTION })
 
@@ -182,14 +183,11 @@ const storeTemplate = async ({
   }
 
   // Append via to sender name if it is not the default from name
-  const {
-    fromName: defaultFromName,
-    fromAddress: defaultFromAddress,
-  } = parseFromAddress(config.get('mailFrom'))
+  const { fromName: defaultFromName } = parseFromAddress(config.get('mailFrom'))
   const { fromName, fromAddress } = parseFromAddress(from)
 
   let expectedFromName: string | null
-  if (fromAddress === defaultFromAddress) {
+  if (isDefaultFromAddress(from)) {
     expectedFromName = defaultFromName
   } else {
     const customFromAddress = await CustomDomainService.getCustomFromAddress(

--- a/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailTemplate.tsx
@@ -136,8 +136,7 @@ const EmailTemplate = ({
       })
       setCustomFromAddresses(options)
 
-      const { fromName, fromAddress } = parseFromAddress(fromAddresses[0])
-      setFromName((prev) => prev || fromName)
+      const { fromAddress } = parseFromAddress(fromAddresses[0])
       setFromAddress((prev) => prev || fromAddress)
     }
 
@@ -189,20 +188,19 @@ const EmailTemplate = ({
 
   const handleSelectFromAddress = useCallback(
     (selectedFrom: string) => {
-      const {
-        fromName: selectedFromName,
-        fromAddress: selectedFromAddress,
-      } = parseFromAddress(selectedFrom)
-
-      // Use custom from name if it has already been set. For e.g.,
-      // for "Custom <donotreply@mail.postman.gov.sg>"", we should
-      // use "Custom" instead of the default "Postman.gov.sg".
-      setFromName(
-        selectedFromAddress === initialFromAddress
-          ? initialFromName
-          : selectedFromName
+      const { fromAddress: selectedFromAddress } = parseFromAddress(
+        selectedFrom
       )
+
       setFromAddress(selectedFromAddress)
+
+      // Populate from name only if it has been previously saved and from address had not changed.
+      if (initialFromName && initialFromAddress === selectedFromAddress) {
+        setFromName(initialFromName)
+      } else {
+        // Reset from name to empty
+        setFromName('')
+      }
     },
     [initialFromName, initialFromAddress]
   )
@@ -213,7 +211,7 @@ const EmailTemplate = ({
     // Strip mail via that is appended at then end of from name by the backend.
     const inputFromName = fromName?.replace(new RegExp(`\\s${mailVia}$`), '')
     const props: { value?: string; badge?: string } = {
-      value: inputFromName,
+      value: inputFromName ?? '',
     }
 
     const [selectedFrom] = customFromAddresses.filter(
@@ -236,20 +234,22 @@ const EmailTemplate = ({
 
         <div>
           <h4>From</h4>
-          <p>Sender details</p>
+          <p>Sender {customFromAddresses.length > 1 ? 'details' : 'name'}</p>
           <TextInput
             {...getFromNameInputProps()}
             onChange={setFromName}
             aria-label="Sender name"
             placeholder={t`e.g. Ministry of Health`}
           />
-          <Dropdown
-            onSelect={handleSelectFromAddress}
-            options={customFromAddresses}
-            defaultLabel={fromAddress}
-            aria-label="Custom from"
-            disabled={customFromAddresses.length <= 1}
-          ></Dropdown>
+          {customFromAddresses.length > 1 && (
+            <Dropdown
+              onSelect={handleSelectFromAddress}
+              options={customFromAddresses}
+              defaultLabel={fromAddress}
+              aria-label="Custom from"
+              disabled={customFromAddresses.length <= 1}
+            ></Dropdown>
+          )}
         </div>
 
         <div>

--- a/frontend/src/components/dashboard/tests/integration/email.test.tsx
+++ b/frontend/src/components/dashboard/tests/integration/email.test.tsx
@@ -15,7 +15,7 @@ import {
   fireEvent,
   waitFor,
   DEFAULT_FROM,
-  DEFAULT_FROM_ADDRESS,
+  DEFAULT_FROM_NAME,
   VALID_CSV_FILENAME,
   RECIPIENT_EMAIL,
   VALID_EMAIL_CSV_FILE,
@@ -65,17 +65,11 @@ test('successfully creates and sends a new email campaign', async () => {
     await screen.findByRole('heading', { name: CAMPAIGN_NAME })
   ).toBeInTheDocument()
 
-  // Select the default from address
-  const customFromDropdown = screen.getByRole('listbox', {
-    name: /custom from/i,
-  })
-  userEvent.click(customFromDropdown)
-  userEvent.click(
-    await screen.findByRole('option', {
-      name: DEFAULT_FROM_ADDRESS,
-    })
-  )
-  expect(customFromDropdown).toHaveTextContent(DEFAULT_FROM_ADDRESS)
+  // Enter a from name
+  const fromNameInput = (await screen.findByLabelText(
+    /sender name/i
+  )) as HTMLInputElement
+  userEvent.type(fromNameInput, DEFAULT_FROM_NAME)
 
   // Type in email subject
   const subjectTextbox = screen.getByRole('textbox', {

--- a/frontend/src/components/dashboard/tests/integration/protected-email.test.tsx
+++ b/frontend/src/components/dashboard/tests/integration/protected-email.test.tsx
@@ -16,7 +16,7 @@ import {
   fireEvent,
   waitFor,
   DEFAULT_FROM,
-  DEFAULT_FROM_ADDRESS,
+  DEFAULT_FROM_NAME,
   VALID_CSV_FILENAME,
   VALID_EMAIL_CSV_FILE,
   RECIPIENT_EMAIL,
@@ -67,17 +67,11 @@ test('successfully creates and sends a new protected email campaign', async () =
     await screen.findByRole('heading', { name: CAMPAIGN_NAME })
   ).toBeInTheDocument()
 
-  // Select the default from address
-  const customFromDropdown = screen.getByRole('listbox', {
-    name: /custom from/i,
-  })
-  userEvent.click(customFromDropdown)
-  userEvent.click(
-    await screen.findByRole('option', {
-      name: DEFAULT_FROM_ADDRESS,
-    })
-  )
-  expect(customFromDropdown).toHaveTextContent(DEFAULT_FROM_ADDRESS)
+  // Enter a from name
+  const fromNameInput = (await screen.findByLabelText(
+    /sender name/i
+  )) as HTMLInputElement
+  userEvent.type(fromNameInput, DEFAULT_FROM_NAME)
 
   // Type in email subject
   const subjectTextbox = screen.getByRole('textbox', {

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -17,17 +17,9 @@ msgstr ""
 msgid "Delivery report has expired and is no longer available for download."
 msgstr "Delivery report has expired and is no longer available for download."
 
-#: components/common/export-recipients/ExportRecipients.tsx:140
+#: components/common/export-recipients/ExportRecipients.tsx:141
 msgid "Delivery report will expire 14 days after sending is completed."
 msgstr "Delivery report will expire 14 days after sending is completed."
-
-#: components/dashboard/create/email/EmailTemplate.tsx:148
-#~ msgid "E.g. MOH Appointment"
-#~ msgstr "E.g. MOH Appointment"
-
-#: components/dashboard/create/email/EmailTemplate.tsx:140
-#~ msgid "E.g. Ministry of Health"
-#~ msgstr "E.g. Ministry of Health"
 
 #: components/login/login-input/LoginInput.tsx:88
 msgid "Enter OTP"
@@ -122,11 +114,11 @@ msgstr "This demo campaign will be sent to a maximum of 20 recipients."
 msgid "demoMessageLabel"
 msgstr "DEMO"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:171
+#: components/dashboard/create/email/EmailTemplate.tsx:173
 msgid "e.g. Appointment Confirmation"
 msgstr "e.g. Appointment Confirmation"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:157
+#: components/dashboard/create/email/EmailTemplate.tsx:159
 msgid "e.g. Ministry of Health"
 msgstr "e.g. Ministry of Health"
 
@@ -250,8 +242,8 @@ msgstr "https://guide.postman.gov.sg/legal/t-and-c"
 msgid "link.uploadLogoUrl"
 msgstr "https://go.gov.sg/postman-upload-logo-request"
 
-#: components/dashboard/create/email/EmailTemplate.tsx:137
-#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:267
-#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:269
+#: components/dashboard/create/email/EmailTemplate.tsx:139
+#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:260
+#: components/dashboard/create/email/tests/EmailTemplate.test.tsx:262
 msgid "mailVia"
 msgstr "via Postman"


### PR DESCRIPTION
## Problem

Closes #1218 

## Solution

**Improvements**:
- Updated copy for input placeholders
- Do not pre-populate default sender name

## Tests

**Sender name should not be pre-populated**
- Create a new email campaign with default from address
- Observe that sender name is not populated

**Sender name should not be pre-populated for custom from address**
- Ensure that you have a custom from address configured for your logged in user (e.g. `user@agency.gov.sg`)
- Create a new email campaign with default from address
- Observe that sender name is not populated and custom from address is selected by default

**Custom sender name for default from address**
- Create a new email campaign with default from address
- Provide a value for the sender name and proceed to save template
- Navigate back to the template page and observe that sender name is populated with the custom value provided in the previous step
- Send campaign. Test and campaign emails should have the correct from name and address