### PR TITLE
fix: add migrations for indices on campaign_id in the messages tables

### DIFF
--- a/backend/src/database/migrations/20210831172021-add-index-to-email_messages.js
+++ b/backend/src/database/migrations/20210831172021-add-index-to-email_messages.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addIndex('email_messages', ['campaign_id'], {
+      concurrently: true,
+      logging: console.log,
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropIndex('email_messages', ['campaign_id'], {
+      logging: console.log,
+    })
+  },
+}

--- a/backend/src/database/migrations/20210831172027-add-index-to-sms_messages.js
+++ b/backend/src/database/migrations/20210831172027-add-index-to-sms_messages.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addIndex('sms_messages', ['campaign_id'], {
+      concurrently: true,
+      logging: console.log,
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropIndex('sms_messages', ['campaign_id'], {
+      logging: console.log,
+    })
+  },
+}

--- a/backend/src/database/migrations/20210831172033-add-index-to-telegram_messages.js
+++ b/backend/src/database/migrations/20210831172033-add-index-to-telegram_messages.js
@@ -1,0 +1,16 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addIndex('telegram_messages', ['campaign_id'], {
+      concurrently: true,
+      logging: console.log,
+    })
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropIndex('telegram_messages', ['campaign_id'], {
+      logging: console.log,
+    })
+  },
+}


### PR DESCRIPTION
## Problem

Queries on the messages tables were getting expensive, in particular, for email callbacks. 
The following screenshot shows our performance insights. The select statement used to determine whether to halt a campaign took up most of the time. 
![Screenshot 2021-08-31 at 5 29 01 PM](https://user-images.githubusercontent.com/33819199/131549229-197bb38d-0fa1-4fbd-a5da-a25f1449a769.png)

## Solution
Keewei moved this query to the read replica. To reduce further CPU use, we decided to add indexes on campaign table to each messages table.

## Before & After Screenshots
Before
<img width="455" alt="Screenshot 2021-09-01 at 1 32 13 AM" src="https://user-images.githubusercontent.com/33819199/131549281-0b5c18ed-a806-4c3a-827c-221865186adc.png">


After
<img width="456" alt="Screenshot 2021-09-01 at 1 07 20 AM" src="https://user-images.githubusercontent.com/33819199/131548730-cb087b40-b0b6-4798-84df-9e99468df3cc.png">


## Deploy Notes

```
cd backend
npm run build
cd build/database
export DB_URI=.... #tunnel to the remote db
PGSSLMODE=no-verify npx sequelize-cli db:migrate --config config.js
```

Output
```
Using environment "production".
== 20210831172021-add-index-to-email_messages: migrating =======
Executing (default): CREATE INDEX CONCURRENTLY "email_messages_campaign_id" ON "email_messages" ("campaign_id")
== 20210831172021-add-index-to-email_messages: migrated (65.641s)

== 20210831172027-add-index-to-sms_messages: migrating =======
Executing (default): CREATE INDEX CONCURRENTLY "sms_messages_campaign_id" ON "sms_messages" ("campaign_id")
== 20210831172027-add-index-to-sms_messages: migrated (32.210s)

== 20210831172033-add-index-to-telegram_messages: migrating =======
Executing (default): CREATE INDEX CONCURRENTLY "telegram_messages_campaign_id" ON "telegram_messages" ("campaign_id")
== 20210831172033-add-index-to-telegram_messages: migrated (0.383s)
```
