### PR TITLE
fix: increase backup lambda memory permanently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -198,7 +198,7 @@ jobs:
           module_name: build/index
           handler_name: handler
           timeout: 900
-          memory_size: 512
+          memory_size: 2048
           publish: true
           zip: "../database-backup/code.zip"
           on:
@@ -220,7 +220,7 @@ jobs:
           module_name: build/index
           handler_name: handler
           timeout: 900
-          memory_size: 512
+          memory_size: 2048
           publish: true
           zip: "../database-backup/code.zip"
           on:


### PR DESCRIPTION
## Problem

As the database size gets larger, backups were timing out. Since AWS Lambda scales the compute available based on the amount of allocated memory, increasing the memory should make the backup run faster.

## Solution

**Improvements**:
- Increase memory for backup lambda

## Tests
- Deploy backup lambda to staging and ensure that it can run correctly
