### PR TITLE
Add sequelize retry

### DIFF
--- a/backend/src/core/loaders/sequelize.loader.ts
+++ b/backend/src/core/loaders/sequelize.loader.ts
@@ -31,6 +31,20 @@ const sequelizeLoader = async (): Promise<void> => {
     query: {
       useMaster: true,
     },
+    retry: {
+      max: 5,
+      match: [
+        /ConnectionError/,
+        /SequelizeConnectionError/,
+        /SequelizeConnectionRefusedError/,
+        /SequelizeHostNotFoundError/,
+        /SequelizeHostNotReachableError/,
+        /SequelizeInvalidConnectionError/,
+        /SequelizeConnectionTimedOutError/,
+        /SequelizeConnectionAcquireTimeoutError/,
+        /Connection terminated unexpectedly/,
+      ],
+    },
     hooks: {
       beforeConnect: async (dbConfig: MutableConfig): Promise<void> => {
         if (config.get('database.useIam')) {

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -136,6 +136,21 @@ const createConnection = (): Sequelize => {
     logging: false,
     pool: config.get('database.poolOptions'),
     dialectOptions,
+    retry: {
+      max: 5,
+      backoffBase: 1000,
+      match: [
+        /ConnectionError/,
+        /SequelizeConnectionError/,
+        /SequelizeConnectionRefusedError/,
+        /SequelizeHostNotFoundError/,
+        /SequelizeHostNotReachableError/,
+        /SequelizeInvalidConnectionError/,
+        /SequelizeConnectionTimedOutError/,
+        /SequelizeConnectionAcquireTimeoutError/,
+        /Connection terminated unexpectedly/,
+      ],
+    },
     hooks: {
       beforeConnect: async (dbConfig: MutableConfig): Promise<void> => {
         if (config.get('database.useIam')) {

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -138,7 +138,6 @@ const createConnection = (): Sequelize => {
     dialectOptions,
     retry: {
       max: 5,
-      backoffBase: 1000,
       match: [
         /ConnectionError/,
         /SequelizeConnectionError/,


### PR DESCRIPTION
## Problem

When Aurora Postgres fails over the writer instance, connections are terminated unexpectly.

## Solution

Add a retry config to sequelize so that failed connections can be retried. 