### PR TITLE
chore: update rds backup event

### DIFF
--- a/serverless/database-backup/examples/event-rds-backup-complete.js
+++ b/serverless/database-backup/examples/event-rds-backup-complete.js
@@ -2,24 +2,26 @@
 
 // Example backup completed RDS event. See https://docs.amazonaws.cn/en_us/lambda/latest/dg/services-rds.html
 module.exports = {
-  "Records": [
-    {
-      "EventVersion": "1.0",
-      "EventSubscriptionArn": "arn:aws:sns:us-east-2:123456789012:rds-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
-      "EventSource": "aws:sns",
-      "Sns": {
-        "SignatureVersion": "1",
-        "Timestamp": "2019-01-02T12:45:07.000Z",
-        "Signature": "tcc6faL2yUC6dgZdmrwh1Y4cGa/ebXEkAi6RibDsvpi+tE/1+82j...65r==",
-        "SigningCertUrl": "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
-        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
-        "Message": "{\"Event Source\":\"db-instance\",\"Event Time\":\"2019-01-02 12:45:06.000\",\"Identifier Link\":\"https://console.aws.amazon.com/rds/home?region=eu-west-1#dbinstance:id=dbinstanceid\",\"Source ID\":\"dbinstanceid\",\"Event ID\":\"http://docs.amazonwebservices.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0002\",\"Event Message\":\"Finished DB Instance backup\"}",
-        "MessageAttributes": {},
-        "Type": "Notification",
-        "UnsubscribeUrl": "https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
-        "TopicArn":"arn:aws:sns:us-east-2:123456789012:sns-lambda",
-        "Subject": "RDS Notification Message",
-      }
-    }
+  "Records":[
+     {
+        "EventSource":"aws:sns",
+        "EventVersion":"1.0",
+        "EventSubscriptionArn":"arn:aws:sns:us-east-2:123456789012:db-rds-events:21be56ed-a058-49f5-8c98-aedd2564c486",
+        "Sns":{
+           "Type":"Notification",
+           "MessageId":"59aaab88-c2a3-554e-801b-f18ad03ba813",
+           "TopicArn":"arn:aws:sns:us-east-2:123456789012:db-rds-events",
+           "Subject":"RDS Notification Message",
+           "Message":"{\"Event Source\":\"db-cluster-snapshot\",\"Event Time\":\"2021-11-07 17:43:51.876\",\"Identifier Link\":\"https://console.aws.amazon.com/rds/home?region=us-east-2#snapshot:engine=aurora;id=db-instance-aurora\",\"Source ID\":\"db-instance-aurora\",\"Source ARN\":\"arn:aws:rds:us-east-2:123456789012:cluster-snapshot:db-instance-aurora\",\"Event ID\":\"http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html#RDS-EVENT-0169\",\"Event Message\":\"Automated cluster snapshot created\"}",
+           "Timestamp":"2021-11-07T17:43:52.348Z",
+           "SignatureVersion":"1",
+           "Signature":"be9Oihv5FuP3nX0V...Fg==",
+           "SigningCertUrl":"https://sns.us-east-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+           "UnsubscribeUrl":"https://sns.us-east-2.amazonaws.com/?Action=Unsubscribe&amp;SubscriptionArn=arn:aws-cn:sns:us-east-2:123456789012:test-lambda:21be56ed-a058-49f5-8c98-aedd2564c486",
+           "MessageAttributes":{
+              
+           }
+        }
+     }
   ]
 }

--- a/serverless/database-backup/src/utils/event.ts
+++ b/serverless/database-backup/src/utils/event.ts
@@ -1,7 +1,7 @@
 import { RdsEvent } from '../interfaces'
 
 export const RDS_EVENTS = {
-  BACKUP_COMPLETE: 'RDS-EVENT-0002',
+  BACKUP_COMPLETE: 'RDS-EVENT-0169',
 }
 
 export const parseRdsEvents = (event: any): Array<RdsEvent> => {


### PR DESCRIPTION
## Problem

After migrating to aurora, 
- the event subscription for running the backup lambda should be changed to:
![Screenshot 2021-11-08 at 2 00 22 AM](https://user-images.githubusercontent.com/33819199/140656286-9fb36a20-067c-46bf-b02b-72696037525e.png)

- the backup complete event code for aurora cluster is `RDS-EVENT-0169` (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_Events.Messages.html)
## Solution

Update the event subscription and event code.
