### PR TITLE
test(backend): fix open handles caused by redis

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -20,4 +20,5 @@ module.exports = {
   globalTeardown: '<rootDir>/src/test-utils/global-teardown.ts',
   setupFiles: ['<rootDir>/src/test-utils/test-env.ts'],
   setupFilesAfterEnv: ['<rootDir>/src/test-utils/setup.ts'],
+  testTimeout: 10000,
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,8 +39,8 @@
         "rate-limit-redis": "^2.1.0",
         "redis": "^3.1.2",
         "reflect-metadata": "^0.1.13",
-        "sequelize": "^5.22.4",
-        "sequelize-typescript": "^1.1.0",
+        "sequelize": "^6.14.1",
+        "sequelize-typescript": "^2.1.2",
         "source-map-support": "^0.5.19",
         "starkbank-ecdsa": "^1.1.2",
         "swagger-jsdoc": "^5.0.1",
@@ -74,7 +74,7 @@
         "@types/nodemailer": "^6.4.0",
         "@types/papaparse": "^5.2.5",
         "@types/qs": "^6.9.4",
-        "@types/rate-limit-redis": "^1.7.1",
+        "@types/rate-limit-redis": "^1.7.4",
         "@types/redis": "^2.8.17",
         "@types/supertest": "^2.0.10",
         "@types/swagger-jsdoc": "^3.0.2",
@@ -97,7 +97,7 @@
         "supertest": "^6.0.1",
         "ts-jest": "^25.5.1",
         "tsc-watch": "^4.2.3",
-        "typescript": "^3.8.3",
+        "typescript": "^4.5.5",
         "umzug": "^2.3.0"
       }
     },
@@ -2453,7 +2453,8 @@
     "node_modules/@types/bluebird": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.30.tgz",
-      "integrity": "sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw=="
+      "integrity": "sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.1",
@@ -2530,6 +2531,14 @@
       "dev": true,
       "dependencies": {
         "@types/express": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/escape-html": {
@@ -2690,6 +2699,11 @@
       "dependencies": {
         "@types/express": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "13.9.3",
@@ -3543,11 +3557,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "node_modules/anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -4103,7 +4112,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
@@ -4593,15 +4603,6 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "dependencies": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
       }
     },
     "node_modules/cls-rtracer": {
@@ -7394,9 +7395,9 @@
       }
     },
     "node_modules/inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
+      "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw==",
       "engines": [
         "node >= 0.4.0"
       ]
@@ -7470,14 +7471,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
-    "node_modules/is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
@@ -12851,12 +12844,9 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
-      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
-      "dependencies": {
-        "any-promise": "^1.3.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
+      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -13179,29 +13169,60 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node_modules/sequelize": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.5.tgz",
-      "integrity": "sha512-ySIHof18sJbeVG4zjEvsDL490cd9S14/IhkCrZR/g0C/FPlZq1AzEJVeSAo++9/sgJH2eERltAIGqYQNgVqX/A==",
-      "deprecated": "Please update to v6 or higher! A migration guide can be found here: https://sequelize.org/v6/manual/upgrade-to-v6.html",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.15.0.tgz",
+      "integrity": "sha512-Ks2jSaKMfICZ8jMlhH401fLw5ikE8Vqt6slcR2peKOn4lA3H+LRfXdlnAl/CUDO1MflFl7PhifnzPxwhamciGQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
       "dependencies": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
-        "debug": "^4.1.1",
-        "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
-        "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.1",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.34",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^5.0.0",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
       }
     },
     "node_modules/sequelize-cli": {
@@ -13241,45 +13262,28 @@
       }
     },
     "node_modules/sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/sequelize-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.1.0.tgz",
-      "integrity": "sha512-FAPEQPeAhIaFQNLAcf9Q2IWcqWhNcvn5OZZ7BzGB0CJMtImIsGg4E/EAb7huMmPaPwDArxJUWGqk1KurphTNRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.2.tgz",
+      "integrity": "sha512-+vhugJk1LLq5EVeLWi/UrkpGLrJGVD0R3UpEGHYouf6qeLRBL1V7QCIZr0pHZA57+nJPoK4PPTD+sGHS11uvvw==",
       "dependencies": {
-        "glob": "7.1.2"
+        "glob": "7.2.0"
       },
       "engines": {
-        "node": ">=0.8.15"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "@types/bluebird": "*",
         "@types/node": "*",
         "@types/validator": "*",
         "reflect-metadata": "*",
-        "sequelize": "^5.1.0"
-      }
-    },
-    "node_modules/sequelize-typescript/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "sequelize": ">=6.8.0"
       }
     },
     "node_modules/sequelize/node_modules/debug": {
@@ -13298,17 +13302,34 @@
         }
       }
     },
+    "node_modules/sequelize/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sequelize/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/sequelize/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/sequelize/node_modules/uuid": {
@@ -13318,6 +13339,11 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/sequelize/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/serve-static": {
       "version": "1.14.1",
@@ -13397,11 +13423,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -14875,9 +14896,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -15424,9 +15445,9 @@
       }
     },
     "node_modules/wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -17656,7 +17677,8 @@
     "@types/bluebird": {
       "version": "3.5.30",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.30.tgz",
-      "integrity": "sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw=="
+      "integrity": "sha512-8LhzvcjIoqoi1TghEkRMkbbmM+jhHnBokPGkJWjclMK+Ks0MxEBow3/p2/iFTZ+OIbJHQDSfpgdZEb+af3gfVw==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.1",
@@ -17733,6 +17755,14 @@
       "dev": true,
       "requires": {
         "@types/express": "*"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
       }
     },
     "@types/escape-html": {
@@ -17895,6 +17925,11 @@
       "requires": {
         "@types/express": "*"
       }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "13.9.3",
@@ -18509,11 +18544,6 @@
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -18955,7 +18985,8 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -19362,15 +19393,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-    },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
-      }
     },
     "cls-rtracer": {
       "version": "2.4.0",
@@ -21554,9 +21576,9 @@
       "dev": true
     },
     "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.2.tgz",
+      "integrity": "sha512-cmZlljCRTBFouT8UzMzrGcVEvkv6D/wBdcdKG7J1QH5cXjtU75Dm+P27v9EKu/Y43UYyCJd1WC4zLebRrC8NBw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -21617,11 +21639,6 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
-    },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -25832,12 +25849,9 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-as-promised": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
-      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
-      "requires": {
-        "any-promise": "^1.3.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
+      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -26097,25 +26111,25 @@
       }
     },
     "sequelize": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.5.tgz",
-      "integrity": "sha512-ySIHof18sJbeVG4zjEvsDL490cd9S14/IhkCrZR/g0C/FPlZq1AzEJVeSAo++9/sgJH2eERltAIGqYQNgVqX/A==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.15.0.tgz",
+      "integrity": "sha512-Ks2jSaKMfICZ8jMlhH401fLw5ikE8Vqt6slcR2peKOn4lA3H+LRfXdlnAl/CUDO1MflFl7PhifnzPxwhamciGQ==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
-        "debug": "^4.1.1",
-        "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
-        "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.1",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.34",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^5.0.0",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -26126,20 +26140,36 @@
             "ms": "2.1.2"
           }
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -26172,31 +26202,16 @@
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg=="
     },
     "sequelize-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.1.0.tgz",
-      "integrity": "sha512-FAPEQPeAhIaFQNLAcf9Q2IWcqWhNcvn5OZZ7BzGB0CJMtImIsGg4E/EAb7huMmPaPwDArxJUWGqk1KurphTNRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.2.tgz",
+      "integrity": "sha512-+vhugJk1LLq5EVeLWi/UrkpGLrJGVD0R3UpEGHYouf6qeLRBL1V7QCIZr0pHZA57+nJPoK4PPTD+sGHS11uvvw==",
       "requires": {
-        "glob": "7.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "glob": "7.2.0"
       }
     },
     "serve-static": {
@@ -26264,11 +26279,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -27424,9 +27434,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uid-safe": {
@@ -27875,9 +27885,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -48,8 +48,8 @@
     "rate-limit-redis": "^2.1.0",
     "redis": "^3.1.2",
     "reflect-metadata": "^0.1.13",
-    "sequelize": "^5.22.4",
-    "sequelize-typescript": "^1.1.0",
+    "sequelize": "^6.14.1",
+    "sequelize-typescript": "^2.1.2",
     "source-map-support": "^0.5.19",
     "starkbank-ecdsa": "^1.1.2",
     "swagger-jsdoc": "^5.0.1",
@@ -83,7 +83,7 @@
     "@types/nodemailer": "^6.4.0",
     "@types/papaparse": "^5.2.5",
     "@types/qs": "^6.9.4",
-    "@types/rate-limit-redis": "^1.7.1",
+    "@types/rate-limit-redis": "^1.7.4",
     "@types/redis": "^2.8.17",
     "@types/supertest": "^2.0.10",
     "@types/swagger-jsdoc": "^3.0.2",
@@ -106,7 +106,7 @@
     "supertest": "^6.0.1",
     "ts-jest": "^25.5.1",
     "tsc-watch": "^4.2.3",
-    "typescript": "^3.8.3",
+    "typescript": "^4.5.5",
     "umzug": "^2.3.0"
   },
   "_moduleAliases": {

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -1,6 +1,5 @@
 import cors from 'cors'
 import express, { Request, Response, NextFunction } from 'express'
-import bodyParser from 'body-parser'
 import { errors as celebrateErrorMiddleware } from 'celebrate'
 import morgan from 'morgan'
 import * as Sentry from '@sentry/node'
@@ -96,10 +95,10 @@ const expressApp = ({ app }: { app: express.Application }): void => {
   // This is to avoid stripping whitespace characters and messing with unicode encoding.
   // This route affects SES callbacks as well, so we'll need to parse the text as JSON
   // in the parseEvent() handle before parsing the SES event.
-  app.use('/v1/callback/email', bodyParser.text({ type: 'application/json' }))
+  app.use('/v1/callback/email', express.text({ type: 'application/json' }))
 
-  app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(express.json())
+  app.use(express.urlencoded({ extended: false }))
   // ref: https://expressjs.com/en/resources/middleware/cors.html#configuration-options
   // Default CORS setting:
   // {

--- a/backend/src/core/loaders/session.loader.ts
+++ b/backend/src/core/loaders/session.loader.ts
@@ -3,6 +3,7 @@ import session from 'express-session'
 import connectRedis from 'connect-redis'
 import config from '@core/config'
 import { RedisService } from '@core/services'
+import { RedisClient } from 'redis'
 
 /**
  * Initializes a session manager for logins
@@ -20,7 +21,7 @@ const sessionLoader = ({ app }: { app: express.Application }): void => {
     saveUninitialized: false,
     cookie: config.get('session.cookieSettings'),
     store: new sessionStore({
-      client: RedisService.sessionClient,
+      client: RedisService.sessionClient as RedisClient,
       logErrors: true,
     }),
   }

--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -24,7 +24,7 @@ const getOtp = async (req: Request, res: Response): Promise<Response> => {
       ...logMeta,
       error: e,
     })
-    return res.status(401).json({ message: e.message })
+    return res.status(401).json({ message: (e as Error).message })
   }
   try {
     const ipAddress = getRequestIp(req)

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -65,7 +65,7 @@ const verifyTemplate = async (
       error: err,
       action: 'verifyTemplate',
     })
-    return res.status(400).json({ message: err.message })
+    return res.status(400).json({ message: (err as Error).message })
   }
 }
 

--- a/backend/src/core/middlewares/settings.middleware.ts
+++ b/backend/src/core/middlewares/settings.middleware.ts
@@ -164,11 +164,12 @@ const getChannelSpecificCredentials = async (
     }
     return res.json(result)
   } catch (e) {
+    const errAsError = e as Error
     logger.error({
-      message: `${e.stack}`,
+      message: `${errAsError.stack}`,
       action: 'getChannelSpecificCredentials',
     })
-    return res.status(400).json({ message: `${e.message}` })
+    return res.status(400).json({ message: `${errAsError.message}` })
   }
 }
 

--- a/backend/src/core/middlewares/tests/campaign.middleware.test.ts
+++ b/backend/src/core/middlewares/tests/campaign.middleware.test.ts
@@ -2,9 +2,10 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, JobQueue, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
+// import { RedisService } from '@core/services'
 import { ChannelType, JobStatus } from '@core/constants'
 import { CampaignMiddleware } from '@core/middlewares/campaign.middleware'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 let mockRequest: Partial<Request>
@@ -20,7 +21,10 @@ beforeEach(() => {
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
 })
 
 afterEach(async () => {
@@ -31,7 +35,6 @@ afterEach(async () => {
 afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('canEditCampaign middleware', () => {
@@ -42,11 +45,11 @@ describe('canEditCampaign middleware', () => {
       type: ChannelType.SMS,
       valid: false,
       protect: false,
-    })
+    } as CreationAttributes<Campaign>)
     await JobQueue.create({
       campaignId: campaign.id,
       status: JobStatus.Sending,
-    })
+    } as CreationAttributes<JobQueue>)
 
     mockRequest = {
       params: { campaignId: String(campaign.id) },
@@ -68,7 +71,7 @@ describe('canEditCampaign middleware', () => {
       valid: false,
       protect: false,
       s3Object: { temp_filename: 'file' },
-    })
+    } as CreationAttributes<Campaign>)
 
     mockRequest = {
       params: { campaignId: String(campaign.id) },
@@ -89,7 +92,7 @@ describe('canEditCampaign middleware', () => {
       type: ChannelType.SMS,
       valid: false,
       protect: false,
-    })
+    } as CreationAttributes<Campaign>)
 
     mockRequest = {
       params: { campaignId: String(campaign.id) },

--- a/backend/src/core/models/user/tests/user.test.ts
+++ b/backend/src/core/models/user/tests/user.test.ts
@@ -2,8 +2,8 @@ import { Sequelize } from 'sequelize-typescript'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { User, Domain, Agency } from '@core/models'
 import { validateDomain } from '@core/utils/validate-domain'
-import { RedisService } from '@core/services'
 import config from '@core/config'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 
@@ -24,7 +24,6 @@ afterEach(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('BeforeCreate hook', () => {
@@ -35,7 +34,7 @@ describe('BeforeCreate hook', () => {
     await expect(
       User.create({
         email: INVALID_DOMAIN_EMAIL,
-      })
+      } as CreationAttributes<User>)
     ).rejects.toThrow(
       `User email ${INVALID_DOMAIN_EMAIL} does not end in a whitelisted domain`
     )
@@ -65,7 +64,7 @@ describe('BeforeCreate hook', () => {
     await expect(
       User.create({
         email: INVALID_DOMAIN_EMAIL,
-      })
+      } as CreationAttributes<User>)
     ).rejects.toThrow(
       `User email ${INVALID_DOMAIN_EMAIL} does not end in a whitelisted domain`
     )
@@ -88,7 +87,7 @@ describe('BeforeCreate hook', () => {
 
     const user = await User.create({
       email: VALID_DOMAIN_EMAIL,
-    })
+    } as CreationAttributes<User>)
     expect(user).not.toBeNull()
     expect(user).toMatchObject({
       email: VALID_DOMAIN_EMAIL,
@@ -116,7 +115,10 @@ describe('BeforeCreate hook', () => {
     // Create user (and trigger beforeCreate hook) with a single transaction,
     // to simulate behavior of auth service
     await sequelize.transaction(async (transaction) => {
-      await User.create({ email: NEW_DOMAIN_EMAIL }, { transaction })
+      await User.create(
+        { email: NEW_DOMAIN_EMAIL } as CreationAttributes<User>,
+        { transaction }
+      )
     })
 
     const user = await User.findOne({ where: { email: NEW_DOMAIN_EMAIL } })

--- a/backend/src/core/models/user/user.ts
+++ b/backend/src/core/models/user/user.ts
@@ -20,6 +20,7 @@ import { CreateOptions } from 'sequelize/types'
 import { Domain } from '../domain'
 import { Agency } from '../agency'
 import { loggerWithLabel } from '@core/logger'
+import { CreationAttributes } from 'sequelize/dist'
 
 const logger = loggerWithLabel(module)
 
@@ -120,7 +121,7 @@ export class User extends Model<User> {
         {
           domain: emailDomain,
           agencyId: defaultAgency.id,
-        },
+        } as CreationAttributes<Domain>,
         { transaction: options.transaction }
       )
     }

--- a/backend/src/core/routes/tests/auth.routes.test.ts
+++ b/backend/src/core/routes/tests/auth.routes.test.ts
@@ -5,6 +5,7 @@ import initialiseServer from '@test-utils/server'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { MailService, RedisService } from '@core/services'
 import { User } from '@core/models'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer()
 const appWithUserSession = initialiseServer(true)
@@ -20,7 +21,6 @@ afterEach(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('POST /auth/otp', () => {
@@ -77,7 +77,7 @@ describe('POST /auth/login', () => {
       createdAt: 123,
     })
     await new Promise((resolve) =>
-      RedisService.otpClient.set(email, otp, resolve)
+      RedisService.otpClient?.set(email, otp, resolve)
     )
 
     const res = await request(app)
@@ -86,7 +86,7 @@ describe('POST /auth/login', () => {
     expect(res.status).toBe(401)
 
     // OTP should be deleted after exceeding retries
-    RedisService.otpClient.get(email, (_err, value) => {
+    RedisService.otpClient?.get(email, (_err, value) => {
       expect(value).toBe(null)
     })
   })
@@ -99,7 +99,7 @@ describe('POST /auth/login', () => {
       createdAt: 123,
     })
     await new Promise((resolve) =>
-      RedisService.otpClient.set(email, otp, resolve)
+      RedisService.otpClient?.set(email, otp, resolve)
     )
 
     const res = await request(app)
@@ -117,7 +117,10 @@ describe('GET /auth/userinfo', () => {
   })
 
   test('Existing session found', async () => {
-    await User.create({ id: 1, email: 'user@agency.gov.sg' })
+    await User.create({
+      id: 1,
+      email: 'user@agency.gov.sg',
+    } as CreationAttributes<User>)
     const res = await request(appWithUserSession).get('/auth/userinfo')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ id: 1, email: 'user@agency.gov.sg' })

--- a/backend/src/core/routes/tests/campaign.routes.test.ts
+++ b/backend/src/core/routes/tests/campaign.routes.test.ts
@@ -3,15 +3,18 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Campaign, User, UserDemo } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
 })
 
 afterEach(async () => {
@@ -21,7 +24,6 @@ afterEach(async () => {
 afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('GET /campaigns', () => {
@@ -29,17 +31,17 @@ describe('GET /campaigns', () => {
     await Campaign.create({
       name: 'campaign-1',
       userId: 1,
-      type: 'SMS',
+      type: ChannelType.SMS,
       valid: false,
       protect: false,
-    })
+    } as CreationAttributes<Campaign>)
     await Campaign.create({
       name: 'campaign-2',
       userId: 1,
-      type: 'SMS',
+      type: ChannelType.SMS,
       valid: false,
       protect: false,
-    })
+    } as CreationAttributes<Campaign>)
 
     const res = await request(app).get('/campaigns')
     expect(res.status).toBe(200)
@@ -56,10 +58,10 @@ describe('GET /campaigns', () => {
       await Campaign.create({
         name: `campaign-${i}`,
         userId: 1,
-        type: 'SMS',
+        type: ChannelType.SMS,
         valid: false,
         protect: false,
-      })
+      } as CreationAttributes<Campaign>)
     }
 
     const res = await request(app)

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -34,7 +34,7 @@ const saveHashedOtp = (
   hashedOtp: HashedOtp
 ): Promise<boolean> => {
   return new Promise((resolve, reject) => {
-    RedisService.otpClient.set(
+    RedisService.otpClient?.set(
       email,
       JSON.stringify(hashedOtp),
       'EX',
@@ -59,10 +59,10 @@ const saveHashedOtp = (
  * Get the hashed otp that was saved against the user's email
  * @param email
  */
-const getHashedOtp = (email: string): Promise<HashedOtp> => {
+const getHashedOtp = async (email: string): Promise<HashedOtp> => {
   const logMeta = { email, action: 'getHashedOtp' }
   return new Promise((resolve, reject) => {
-    RedisService.otpClient.get(email, (error, value) => {
+    RedisService.otpClient?.get(email, (error, value) => {
       if (error) {
         logger.error({ message: 'Failed to get hashed otp', error, ...logMeta })
         reject(new Error('Internal server error - request for otp again'))
@@ -70,7 +70,7 @@ const getHashedOtp = (email: string): Promise<HashedOtp> => {
       if (value === null) {
         reject(new Error('OTP has expired. Please request for a new OTP.'))
       }
-      resolve(JSON.parse(value))
+      resolve(JSON.parse(value as string))
     })
   })
 }
@@ -81,7 +81,7 @@ const getHashedOtp = (email: string): Promise<HashedOtp> => {
  */
 const deleteHashedOtp = async (email: string): Promise<boolean> => {
   return new Promise((resolve, reject) => {
-    RedisService.otpClient.del(email, (error, response) => {
+    RedisService.otpClient?.del(email, (error, response) => {
       if (error || response !== 1) {
         logger.error({
           message: 'Failed to delete hashed otp',
@@ -277,7 +277,7 @@ const findOrCreateUser = async (email: string): Promise<User> => {
  * Helper method to find a user by their id
  * @param id
  */
-const findUser = (id: number): Promise<User> => {
+const findUser = (id: number): Promise<User | null> => {
   return User.findOne({
     where: { id },
   })

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -56,7 +56,7 @@ const createDemoCampaign = async ({
         valid: false,
         protect,
         demoMessageLimit,
-      },
+      } as Campaign,
       { transaction }
     )
     await userDemo?.decrement(numDemosColumn, { transaction })
@@ -104,7 +104,7 @@ const createCampaign = async ({
         userId,
         valid: false,
         protect,
-      },
+      } as Campaign,
       { transaction }
     )
   }
@@ -271,7 +271,7 @@ const getCampaignDetails = async (
     ],
   })
 
-  return campaignDetails?.get({ plain: true }) as CampaignDetails
+  return campaignDetails?.get({ plain: true }) as unknown as CampaignDetails
 }
 
 /**

--- a/backend/src/core/services/redis.service.ts
+++ b/backend/src/core/services/redis.service.ts
@@ -1,121 +1,122 @@
-import redis from 'redis'
+import redis, { RedisClient } from 'redis'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 
 const logger = loggerWithLabel(module)
 
-if (!config.get('redisOtpUri')) {
-  throw new Error('otpClient: redisOtpUri not found')
+export const RedisService: {
+  otpClient: RedisClient | undefined
+  sessionClient: RedisClient | undefined
+  rateLimitClient: RedisClient | undefined
+  credentialClient: RedisClient | undefined
+  init: () => void
+  shutdown: () => Promise<unknown[]>
+} = {
+  otpClient: undefined,
+  sessionClient: undefined,
+  rateLimitClient: undefined,
+  credentialClient: undefined,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  init: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  shutdown: (): Promise<unknown[]> => new Promise((resolve) => resolve([])),
 }
 
-/**
- * Client to redis cache for storing otps
- */
-const otpClient = redis
-  .createClient({ url: config.get('redisOtpUri') || undefined })
-  .on('connect', () => {
-    logger.info({
-      message: 'otpClient: Connected',
-      url: config.get('redisOtpUri'),
+RedisService.init = (): void => {
+  if (!config.get('redisOtpUri')) {
+    throw new Error('otpClient: redisOtpUri not found')
+  }
+  RedisService.otpClient = redis
+    .createClient({ url: config.get('redisOtpUri') || undefined })
+    .on('connect', () => {
+      logger.info({
+        message: 'otpClient: Connected',
+        url: config.get('redisOtpUri'),
+      })
     })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to otpClient',
-      url: config.get('redisOtpUri'),
-      error: String(err),
+    .on('error', (err: Error) => {
+      logger.error({
+        message: 'Failed to connect to otpClient',
+        url: config.get('redisOtpUri'),
+        error: String(err),
+      })
     })
-  })
-
-if (!config.get('redisSessionUri')) {
-  throw new Error('sessionClient: redisSessionUri not found')
+  if (!config.get('redisSessionUri')) {
+    throw new Error('sessionClient: redisSessionUri not found')
+  }
+  RedisService.sessionClient = redis
+    .createClient({ url: config.get('redisSessionUri') || undefined })
+    .on('connect', () => {
+      logger.info({
+        message: 'sessionClient: Connected',
+        url: config.get('redisSessionUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      logger.error({
+        message: 'Failed to connect to sessionClient',
+        url: config.get('redisSessionUri'),
+        error: String(err),
+      })
+    })
+  if (!config.get('redisRateLimitUri')) {
+    throw new Error('rateLimitClient: redisRateLimitUri not found')
+  }
+  RedisService.rateLimitClient = redis
+    .createClient({
+      enable_offline_queue: false,
+      url: config.get('redisRateLimitUri') || undefined,
+    })
+    .on('connect', () => {
+      logger.info({
+        message: 'rateLimitClient: Connected',
+        url: config.get('redisRateLimitUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      logger.error({
+        message: 'Failed to connect to rateLimitClient',
+        url: config.get('redisRateLimitUri'),
+        error: String(err),
+      })
+    })
+  if (!config.get('redisCredentialUri')) {
+    throw new Error('credentialClient: redisCredentialUri not found')
+  }
+  RedisService.credentialClient = redis
+    .createClient({
+      url: config.get('redisCredentialUri') || undefined,
+    })
+    .on('connect', () => {
+      logger.info({
+        message: 'credentialClient: Connected',
+        url: config.get('redisCredentialUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      logger.error({
+        message: 'Failed to connect to credentialClient',
+        url: config.get('redisCredentialUri'),
+        error: String(err),
+      })
+    })
 }
-
-/**
- * Client to redis cache for storing sessions
- */
-const sessionClient = redis
-  .createClient({ url: config.get('redisSessionUri') || undefined })
-  .on('connect', () => {
-    logger.info({
-      message: 'sessionClient: Connected',
-      url: config.get('redisSessionUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to sessionClient',
-      url: config.get('redisSessionUri'),
-      error: String(err),
-    })
-  })
-
-if (!config.get('redisRateLimitUri')) {
-  throw new Error('rateLimitClient: redisRateLimitUri not found')
-}
-
-/**
- * Client to redis cache for rate limiting transactional requests
- */
-const rateLimitClient = redis
-  .createClient({
-    enable_offline_queue: false,
-    url: config.get('redisRateLimitUri') || undefined,
-  })
-  .on('connect', () => {
-    logger.info({
-      message: 'rateLimitClient: Connected',
-      url: config.get('redisRateLimitUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to rateLimitClient',
-      url: config.get('redisRateLimitUri'),
-      error: String(err),
-    })
-  })
-
-if (!config.get('redisCredentialUri')) {
-  throw new Error('credentialClient: redisCredentialUri not found')
-}
-
-/**
- * Client to redis cache for storing credentials
- */
-const credentialClient = redis
-  .createClient({
-    url: config.get('redisCredentialUri') || undefined,
-  })
-  .on('connect', () => {
-    logger.info({
-      message: 'credentialClient: Connected',
-      url: config.get('redisCredentialUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to credentialClient',
-      url: config.get('redisCredentialUri'),
-      error: String(err),
-    })
-  })
 
 /**
  * Shutdown all redis clients
  */
-const shutdown = async (): Promise<void> => {
-  const clients = [otpClient, sessionClient, rateLimitClient, credentialClient]
-  await Promise.all(
-    clients.map((client) => new Promise((resolve) => client.quit(resolve)))
+RedisService.shutdown = async (): Promise<unknown[]> => {
+  const clients = [
+    RedisService.otpClient,
+    RedisService.sessionClient,
+    RedisService.rateLimitClient,
+    RedisService.credentialClient,
+  ]
+  return Promise.all(
+    clients.map((client) =>
+      client
+        ? new Promise((resolve) => client.flushall(() => client.quit(resolve)))
+        : new Promise((resolve) => resolve(null))
+    )
   )
-  await new Promise((resolve) => setImmediate(resolve))
-}
-
-export const RedisService = {
-  otpClient,
-  sessionClient,
-  rateLimitClient,
-  credentialClient,
-  shutdown,
 }

--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -60,7 +60,7 @@ const setNumRecipients = async (
       errored: 0,
       sent: 0,
       invalid: 0,
-    },
+    } as Statistic,
     {
       transaction,
     }

--- a/backend/src/core/utils/request.ts
+++ b/backend/src/core/utils/request.ts
@@ -8,12 +8,11 @@ export const getRequestIp: (req: Request) => string = (req: Request) => {
   return req.get('cf-connecting-ip') ?? req.ip
 }
 
-export const redirectTo = (path: string) => (
-  req: Request,
-  res: Response
-): void => {
-  const { baseUrl: campaignUrl, originalUrl } = req
-  const parsedUrl = new URL(originalUrl, 'https://base')
-  const redirectToPath = `${campaignUrl}${path}${parsedUrl.search}`
-  return res.redirect(307, redirectToPath)
-}
+export const redirectTo =
+  (path: string) =>
+  (req: Request, res: Response): void => {
+    const { baseUrl: campaignUrl, originalUrl } = req
+    const parsedUrl = new URL(originalUrl, 'https://base')
+    const redirectToPath = `${campaignUrl}${path}${parsedUrl.search}`
+    return res.redirect(307, redirectToPath)
+  }

--- a/backend/src/core/utils/tests/validate-domain.test.ts
+++ b/backend/src/core/utils/tests/validate-domain.test.ts
@@ -1,9 +1,9 @@
 import { Sequelize } from 'sequelize-typescript'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { Domain } from '@core/models'
 import { validateDomain } from '../validate-domain'
 import config from '@core/config'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 
@@ -17,14 +17,13 @@ afterEach(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('validateDomain', () => {
   it('should match exact domain in database', async () => {
     await Domain.create({
       domain: '@exactdomain.com',
-    })
+    } as CreationAttributes<Domain>)
 
     await expect(validateDomain('user@exactdomain.com')).resolves.toBe(true)
   })
@@ -32,7 +31,7 @@ describe('validateDomain', () => {
   it('should not match subdomains in database', async () => {
     await Domain.create({
       domain: '@school.edu.sg',
-    })
+    } as CreationAttributes<Domain>)
 
     await expect(validateDomain('teacher@school.edu.sg')).resolves.toBe(true)
     await expect(validateDomain('student@student.school.edu.sg')).resolves.toBe(

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -8,6 +8,7 @@ import { loggerWithLabel } from '@core/logger'
 import { TemplateError } from '@shared/templating'
 import { AuthService } from '@core/services'
 import { InvalidRecipientError } from '@core/errors'
+import { RedisClient } from 'redis'
 
 const logger = loggerWithLabel(module)
 
@@ -40,7 +41,7 @@ async function sendMessage(
 
     const BAD_REQUEST_ERRORS = [TemplateError, InvalidRecipientError]
     if (BAD_REQUEST_ERRORS.some((errType) => err instanceof errType)) {
-      res.status(400).json({ message: err.message })
+      res.status(400).json({ message: (err as Error).message })
       return
     }
     next(err)
@@ -50,7 +51,7 @@ async function sendMessage(
 const rateLimit = expressRateLimit({
   store: new RedisStore({
     prefix: 'transactionalEmail:',
-    client: RedisService.rateLimitClient,
+    client: RedisService.rateLimitClient as RedisClient,
     expiry: config.get('transactionalEmail.window'),
   }),
   keyGenerator: (req: Request) => req?.session?.user.id,

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -59,7 +59,7 @@ const validateAndStoreCredentials = async (
       error: err,
       ...logMeta,
     })
-    return res.status(400).json({ message: `${err.message}` })
+    return res.status(400).json({ message: `${(err as Error).message}` })
   }
   return res.json({ message: 'OK' })
 }
@@ -174,10 +174,8 @@ const isFromAddressAccepted = async (
     (await AuthService.findUser(req.session?.user?.id))?.email
 
   // Get default mail address for comparison
-  const {
-    fromName: defaultFromName,
-    fromAddress: defaultFromAddress,
-  } = parseFromAddress(config.get('mailFrom'))
+  const { fromName: defaultFromName, fromAddress: defaultFromAddress } =
+    parseFromAddress(config.get('mailFrom'))
 
   if (fromAddress !== userEmail && fromAddress !== defaultFromAddress) {
     logger.error({
@@ -223,7 +221,7 @@ const existsFromAddress = async (
       error: err,
       action: 'existsFromAddress',
     })
-    return res.status(400).json({ message: err.message })
+    return res.status(400).json({ message: (err as Error).message })
   }
   return next()
 }
@@ -251,7 +249,7 @@ const verifyFromAddress = async (
       error: err,
       action: 'verifyFromAddress',
     })
-    return res.status(400).json({ message: err.message })
+    return res.status(400).json({ message: (err as Error).message })
   }
   return next()
 }
@@ -324,7 +322,7 @@ const sendValidationMessage = async (
       error: err,
       action: 'sendValidationMessage',
     })
-    return res.status(400).json({ message: err.message })
+    return res.status(400).json({ message: (err as Error).message })
   }
   return next()
 }

--- a/backend/src/email/middlewares/tests/email.middleware.test.ts
+++ b/backend/src/email/middlewares/tests/email.middleware.test.ts
@@ -2,9 +2,9 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { EmailMiddleware } from '@email/middlewares/email.middleware'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 let campaignId: number
@@ -21,14 +21,17 @@ beforeEach(() => {
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
   const campaign = await Campaign.create({
     name: 'campaign-1',
     userId: 1,
     type: ChannelType.Email,
     valid: false,
     protect: false,
-  })
+  } as CreationAttributes<Campaign>)
   campaignId = campaign.id
 })
 
@@ -36,7 +39,6 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('isEmailCampaignOwnedByUser middleware', () => {

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -4,10 +4,10 @@ import initialiseServer from '@test-utils/server'
 import config from '@core/config'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { EmailFromAddress, EmailMessage } from '@email/models'
 import { CustomDomainService } from '@email/services'
 import { ChannelType } from '@core/constants'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
@@ -16,14 +16,17 @@ let protectedCampaignId: number
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
   const campaign = await Campaign.create({
     name: 'campaign-1',
     userId: 1,
     type: ChannelType.Email,
     valid: false,
     protect: false,
-  })
+  } as CreationAttributes<Campaign>)
   campaignId = campaign.id
   const protectedCampaign = await Campaign.create({
     name: 'campaign-2',
@@ -31,7 +34,7 @@ beforeAll(async () => {
     type: ChannelType.Email,
     valid: false,
     protect: true,
-  })
+  } as CreationAttributes<Campaign>)
   protectedCampaignId = protectedCampaign.id
 })
 
@@ -40,7 +43,6 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('PUT /campaign/{campaignId}/email/template', () => {
@@ -153,7 +155,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
     await EmailFromAddress.create({
       email: 'user@agency.gov.sg',
       name: 'Agency ABC',
-    })
+    } as CreationAttributes<EmailFromAddress>)
     const mockVerifyFromAddress = jest
       .spyOn(CustomDomainService, 'verifyFromAddress')
       .mockReturnValue(Promise.resolve())
@@ -205,7 +207,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
     await EmailFromAddress.create({
       email: 'user@agency.gov.sg',
       name: 'Agency ABC',
-    })
+    } as CreationAttributes<EmailFromAddress>)
     const mockVerifyFromAddress = jest
       .spyOn(CustomDomainService, 'verifyFromAddress')
       .mockReturnValue(Promise.resolve())
@@ -358,7 +360,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
       campaignId,
       recipient: 'user@agency.gov.sg',
       params: { recipient: 'user@agency.gov.sg' },
-    })
+    } as CreationAttributes<EmailMessage>)
     const testBody = await request(app)
       .put(`/campaign/${campaignId}/email/template`)
       .send({

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -7,6 +7,7 @@ import { EmailService } from '@email/services'
 
 import initialiseServer from '@test-utils/server'
 import sequelizeLoader from '@test-utils/sequelize-loader'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 let user: User
@@ -19,7 +20,7 @@ beforeEach(async () => {
   user = await User.create({
     id: userId,
     email: `user_${userId}@agency.gov.sg`,
-  })
+  } as CreationAttributes<User>)
   apiKey = await user.regenerateAndSaveApiKey()
   userId += 1
 })
@@ -27,7 +28,7 @@ beforeEach(async () => {
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
   // Flush the rate limit redis database
-  await new Promise((resolve) => RedisService.rateLimitClient.flushdb(resolve))
+  await new Promise((resolve) => RedisService.rateLimitClient?.flushdb(resolve))
 })
 
 afterEach(() => jest.resetAllMocks())
@@ -36,8 +37,7 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
 
-  await new Promise((resolve) => RedisService.rateLimitClient.flushdb(resolve))
-  await RedisService.shutdown()
+  await new Promise((resolve) => RedisService.rateLimitClient?.flushdb(resolve))
 })
 
 describe('POST /transactional/email/send', () => {

--- a/backend/src/email/services/custom-domain.service.ts
+++ b/backend/src/email/services/custom-domain.service.ts
@@ -7,6 +7,7 @@ import { EmailFromAddress } from '@email/models'
 import { MailService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
 import { formatFromAddress } from '@shared/utils/from-address'
+import { CreationAttributes } from 'sequelize/dist'
 
 const logger = loggerWithLabel(module)
 const [, region] = config.get('mailOptions.host').split('.')
@@ -108,9 +109,10 @@ const storeFromAddress = async (
 ): Promise<void> => {
   try {
     await EmailFromAddress.upsert({
-      name,
+      // ternary to fix type mismatch between <string | null> and <string | undefined>
+      name: name ? name : undefined,
       email,
-    })
+    } as CreationAttributes<EmailFromAddress>)
   } catch (err) {
     logger.error({
       message: 'Failed to store email address in EmailFromAddress table',

--- a/backend/src/email/services/email-template.service.ts
+++ b/backend/src/email/services/email-template.service.ts
@@ -14,6 +14,7 @@ import {
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@email/interfaces'
 import { parseFromAddress, formatFromAddress } from '@shared/utils/from-address'
+import { CreationAttributes } from 'sequelize/dist'
 
 const client = new TemplateClient({ xssOptions: XSS_EMAIL_OPTION })
 
@@ -39,24 +40,23 @@ const upsertEmailTemplate = async ({
       })) !== null
     ) {
       // .update is actually a bulkUpdate
-      const updatedTemplate: [
-        number,
-        EmailTemplate[]
-      ] = await EmailTemplate.update(
-        {
-          subject,
-          body,
-          replyTo,
-          from,
-          showLogo,
-        },
-        {
-          where: { campaignId },
-          individualHooks: true, // required so that BeforeUpdate hook runs
-          returning: true,
-          transaction,
-        }
-      )
+      const updatedTemplate: [number, EmailTemplate[]] =
+        await EmailTemplate.update(
+          {
+            subject,
+            body,
+            // ternary to fix type mismatch between <string | null> and <string | undefined>
+            replyTo: replyTo ? replyTo : undefined,
+            from,
+            showLogo,
+          },
+          {
+            where: { campaignId },
+            individualHooks: true, // required so that BeforeUpdate hook runs
+            returning: true,
+            transaction,
+          }
+        )
 
       transaction?.commit()
       return updatedTemplate[1][0]
@@ -67,10 +67,11 @@ const upsertEmailTemplate = async ({
         campaignId,
         body,
         subject,
-        replyTo,
+        // ternary to fix type mismatch between <string | null> and <string | undefined>
+        replyTo: replyTo ? replyTo : undefined,
         from,
         showLogo,
-      },
+      } as CreationAttributes<EmailTemplate>,
       {
         transaction,
       }
@@ -182,10 +183,8 @@ const storeTemplate = async ({
   }
 
   // Append via to sender name if it is not the default from name
-  const {
-    fromName: defaultFromName,
-    fromAddress: defaultFromAddress,
-  } = parseFromAddress(config.get('mailFrom'))
+  const { fromName: defaultFromName, fromAddress: defaultFromAddress } =
+    parseFromAddress(config.get('mailFrom'))
   const { fromName, fromAddress } = parseFromAddress(from)
 
   let expectedFromName: string | null

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -25,9 +25,8 @@ async function sendMessage({
   recipient: string
   replyTo?: string
 }): Promise<void> {
-  const sanitizedSubject = EmailTemplateService.client.replaceNewLinesAndSanitize(
-    subject
-  )
+  const sanitizedSubject =
+    EmailTemplateService.client.replaceNewLinesAndSanitize(subject)
   const sanitizedBody = EmailTemplateService.client.filterXSS(body)
   if (!sanitizedSubject || !sanitizedBody) {
     throw new TemplateError(

--- a/backend/src/email/utils/callback/query.ts
+++ b/backend/src/email/utils/callback/query.ts
@@ -7,6 +7,7 @@ import { EmailBlacklist, EmailMessage } from '@email/models'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { Campaign } from '@core/models'
+import { MessageStatus } from '@core/constants'
 
 const logger = loggerWithLabel(module)
 
@@ -43,8 +44,8 @@ export const updateMessageWithError = async (
     {
       errorCode: errorCode,
       errorSubType,
-      receivedAt: timestamp,
-      status: 'INVALID_RECIPIENT',
+      receivedAt: new Date(timestamp),
+      status: 'INVALID_RECIPIENT' as MessageStatus,
     },
     {
       where: {
@@ -81,8 +82,8 @@ export const updateMessageWithSuccess = async (
   // Should not overwrite a READ status for the message
   const [, result] = await EmailMessage.update(
     {
-      receivedAt: timestamp,
-      status: 'SUCCESS',
+      receivedAt: new Date(timestamp),
+      status: 'SUCCESS' as MessageStatus,
     },
     {
       where: {
@@ -120,8 +121,8 @@ export const updateMessageWithRead = async (
   // Since open event supercedes error or success notification types, overwrite any previous status
   const [, result] = await EmailMessage.update(
     {
-      receivedAt: timestamp,
-      status: 'READ',
+      receivedAt: new Date(timestamp),
+      status: 'READ' as MessageStatus,
     },
     {
       where: { id },

--- a/backend/src/setup.ts
+++ b/backend/src/setup.ts
@@ -1,6 +1,9 @@
+/* eslint-disable  @typescript-eslint/no-var-requires */
 require('dotenv').config()
 require('module-alias/register')
 
 import config from '@core/config'
+import { RedisService } from '@core/services'
 // Validate to make sure all the required env vars have been set
 config.validate()
+RedisService.init()

--- a/backend/src/sms/middlewares/sms-template.middleware.ts
+++ b/backend/src/sms/middlewares/sms-template.middleware.ts
@@ -40,14 +40,11 @@ const storeTemplate = async (
   const logMeta = { campaignId, action: 'storeTemplate' }
   try {
     // extract params from template, save to db (this will be done with hook)
-    const {
-      check,
-      valid,
-      updatedTemplate,
-    }: StoreTemplateOutput = await SmsTemplateService.storeTemplate({
-      campaignId: +campaignId,
-      body,
-    })
+    const { check, valid, updatedTemplate }: StoreTemplateOutput =
+      await SmsTemplateService.storeTemplate({
+        campaignId: +campaignId,
+        body,
+      })
 
     if (check?.reupload) {
       logger.info({
@@ -167,6 +164,7 @@ const uploadCompleteHandler = async (
         })
       }, RETRY_CONFIG)
     } catch (err) {
+      const errAsError = err as Error
       // Do not return any response since it has already been sent
       logger.error({
         message: 'Error storing messages for campaign',
@@ -176,13 +174,13 @@ const uploadCompleteHandler = async (
       })
 
       // Precondition failure is caused by ETag mismatch. Convert to a more user-friendly error message.
-      if (err.code === 'PreconditionFailed') {
-        err.message =
+      if ((err as any).code === 'PreconditionFailed') {
+        errAsError.message =
           'Please try again. Error processing the recipient list. Please contact the Postman team if this problem persists.'
       }
 
       // Store error to return on poll
-      UploadService.storeS3Error(+campaignId, err.message)
+      UploadService.storeS3Error(+campaignId, errAsError.message)
     }
   } catch (err) {
     logger.error({
@@ -198,7 +196,7 @@ const uploadCompleteHandler = async (
     ]
 
     if (userErrors.some((errType) => err instanceof errType)) {
-      return res.status(400).json({ message: err.message })
+      return res.status(400).json({ message: (err as Error).message })
     }
     return next(err)
   }
@@ -214,12 +212,8 @@ const pollCsvStatusHandler = async (
 ): Promise<Response | void> => {
   try {
     const { campaignId } = req.params
-    const {
-      isCsvProcessing,
-      filename,
-      tempFilename,
-      error,
-    } = await UploadService.getCsvStatus(+campaignId)
+    const { isCsvProcessing, filename, tempFilename, error } =
+      await UploadService.getCsvStatus(+campaignId)
 
     // If done processing, returns num recipients and preview msg
     let numRecipients, preview

--- a/backend/src/sms/middlewares/sms-transactional.middleware.ts
+++ b/backend/src/sms/middlewares/sms-transactional.middleware.ts
@@ -33,7 +33,7 @@ async function sendMessage(
 
     const BAD_REQUEST_ERRORS = [TemplateError, InvalidRecipientError]
     if (BAD_REQUEST_ERRORS.some((errType) => err instanceof errType)) {
-      res.status(400).json({ message: err.message })
+      res.status(400).json({ message: (err as Error).message })
       return
     }
 

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -50,7 +50,7 @@ const disabledForDemoCampaign = async (
       +req.params.campaignId,
       userId
     )
-    if (campaign.demoMessageLimit) {
+    if (campaign?.demoMessageLimit) {
       return res.status(400).json({
         message: `Action not allowed for demo campaign`,
       })
@@ -156,11 +156,12 @@ const getCredentialsFromLabel = async (
     res.locals.credentialName = credentialName
     return next()
   } catch (err) {
+    const errAsError = err as Error
     logger.error({
       ...logMeta,
-      message: `${err.stack}`,
+      message: `${errAsError.stack}`,
     })
-    return res.status(400).json({ message: `${err.message}` })
+    return res.status(400).json({ message: `${errAsError.message}` })
   }
 }
 
@@ -228,7 +229,7 @@ const validateAndStoreCredentials = async (
       error: err,
       ...logMeta,
     })
-    return res.status(400).json({ message: `${err.message}` })
+    return res.status(400).json({ message: `${(err as Error).message}` })
   }
 }
 

--- a/backend/src/sms/middlewares/tests/sms.middleware.test.ts
+++ b/backend/src/sms/middlewares/tests/sms.middleware.test.ts
@@ -2,9 +2,9 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { SmsMiddleware } from '@sms/middlewares/sms.middleware'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 let campaignId: number
@@ -21,14 +21,17 @@ beforeEach(() => {
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
   const campaign = await Campaign.create({
     name: 'campaign-1',
     userId: 1,
     type: ChannelType.SMS,
     valid: false,
     protect: false,
-  })
+  } as CreationAttributes<Campaign>)
   campaignId = campaign.id
 })
 
@@ -36,7 +39,6 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('isSmsCampaignOwnedByUser middleware', () => {

--- a/backend/src/sms/routes/tests/sms-settings.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-settings.routes.test.ts
@@ -3,17 +3,20 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Credential, UserCredential, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { mockSecretsManager } from '@mocks/aws-sdk'
 import { SmsService } from '@sms/services'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
 })
 
 afterAll(async () => {
@@ -21,7 +24,6 @@ afterAll(async () => {
   await Credential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('POST /settings/sms/credentials', () => {

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -28,10 +28,8 @@ const isAuthenticated = (
 
 const parseEvent = async (req: Request): Promise<void> => {
   const { messageId, campaignId } = req.params
-  const {
-    MessageStatus: twilioMessageStatus,
-    ErrorCode: twilioErrorCode,
-  } = req.body
+  const { MessageStatus: twilioMessageStatus, ErrorCode: twilioErrorCode } =
+    req.body
   // Do not process message if it's not of a finalized delivery status
   if (FINALIZED_STATUS.indexOf(twilioMessageStatus as string) === -1) {
     return
@@ -47,7 +45,7 @@ const parseEvent = async (req: Request): Promise<void> => {
       {
         errorCode: twilioErrorCode,
         status: 'ERROR',
-      },
+      } as SmsMessage,
       {
         where: {
           id: messageId,
@@ -63,7 +61,7 @@ const parseEvent = async (req: Request): Promise<void> => {
       {
         receivedAt: new Date(),
         status: 'SUCCESS',
-      },
+      } as SmsMessage,
       {
         where: {
           id: messageId,

--- a/backend/src/sms/services/sms-template.service.ts
+++ b/backend/src/sms/services/sms-template.service.ts
@@ -11,6 +11,7 @@ import {
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@sms/interfaces'
+import { CreationAttributes } from 'sequelize/dist'
 
 const client = new TemplateClient({ xssOptions: XSS_SMS_OPTION })
 
@@ -55,7 +56,7 @@ const upsertSmsTemplate = async ({
       {
         campaignId,
         body,
-      },
+      } as CreationAttributes<SmsTemplate>,
       {
         transaction,
       }

--- a/backend/src/sms/services/sms-transactional.service.ts
+++ b/backend/src/sms/services/sms-transactional.service.ts
@@ -19,9 +19,8 @@ async function sendMessage({
   body: string
   recipient: string
 }): Promise<void> {
-  const sanitizedBody = SmsTemplateService.client.replaceNewLinesAndSanitize(
-    body
-  )
+  const sanitizedBody =
+    SmsTemplateService.client.replaceNewLinesAndSanitize(body)
   if (!sanitizedBody) {
     throw new TemplateError(
       'Message is invalid as it only contains invalid HTML tags.'

--- a/backend/src/sms/services/twilio-client.class.ts
+++ b/backend/src/sms/services/twilio-client.class.ts
@@ -42,7 +42,9 @@ export default class TwilioClient {
     } catch (error) {
       // Handle +65802 errors by forcing delivery once
       if (
-        /\+65802\d+ is not a valid phone number/.test(error.message) &&
+        /\+65802\d+ is not a valid phone number/.test(
+          (error as Error).message
+        ) &&
         !forceDelivery
       ) {
         return this.send(recipient, message, true)
@@ -50,11 +52,11 @@ export default class TwilioClient {
 
       // 20429 - REST API rate limit exceeded
       // 21611 - Message queue limit exceeded
-      if ([20429, 21611].includes(error.code)) {
+      if ([20429, 21611].includes((error as any).code)) {
         throw new RateLimitError()
       }
 
-      if (error.code === 21211) {
+      if ((error as any).code === 21211) {
         throw new InvalidRecipientError('Invalid phone number')
       }
 

--- a/backend/src/telegram/middlewares/telegram-template.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-template.middleware.ts
@@ -40,14 +40,11 @@ const storeTemplate = async (
   const { body } = req.body
   const logMeta = { campaignId, action: 'storeTemplate' }
   try {
-    const {
-      check,
-      valid,
-      updatedTemplate,
-    } = await TelegramTemplateService.storeTemplate({
-      campaignId: +campaignId,
-      body,
-    })
+    const { check, valid, updatedTemplate } =
+      await TelegramTemplateService.storeTemplate({
+        campaignId: +campaignId,
+        body,
+      })
 
     if (check?.reupload) {
       logger.info({
@@ -156,6 +153,7 @@ const uploadCompleteHandler = async (
         })
       }, RETRY_CONFIG)
     } catch (err) {
+      const errAsError = err as Error
       // Do not return any response since it has already been sent
       logger.error({
         message: 'Error storing messages for campaign',
@@ -165,13 +163,13 @@ const uploadCompleteHandler = async (
       })
 
       // Precondition failure is caused by ETag mismatch. Convert to a more user-friendly error message.
-      if (err.code === 'PreconditionFailed') {
-        err.message =
+      if ((err as any).code === 'PreconditionFailed') {
+        errAsError.message =
           'Please try again. Error processing the recipient list. Please contact the Postman team if this problem persists.'
       }
 
       // Store error to return on poll
-      UploadService.storeS3Error(+campaignId, err.message)
+      UploadService.storeS3Error(+campaignId, errAsError.message)
     }
   } catch (err) {
     logger.error({
@@ -187,7 +185,7 @@ const uploadCompleteHandler = async (
     ]
 
     if (userErrors.some((errType) => err instanceof errType)) {
-      return res.status(400).json({ message: err.message })
+      return res.status(400).json({ message: (err as Error).message })
     }
     return next(err)
   }
@@ -203,12 +201,8 @@ const pollCsvStatusHandler = async (
 ): Promise<Response | void> => {
   try {
     const { campaignId } = req.params
-    const {
-      isCsvProcessing,
-      filename,
-      tempFilename,
-      error,
-    } = await UploadService.getCsvStatus(+campaignId)
+    const { isCsvProcessing, filename, tempFilename, error } =
+      await UploadService.getCsvStatus(+campaignId)
 
     // If done processing, returns num recipients and preview msg
     let numRecipients, preview

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -4,6 +4,7 @@ import { CredentialService } from '@core/services'
 import { TelegramService } from '@telegram/services'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
+import { Campaign } from '@core/models'
 
 const logger = loggerWithLabel(module)
 
@@ -27,7 +28,7 @@ const disabledForDemoCampaign = async (
       +req.params.campaignId,
       userId
     )
-    if (campaign.demoMessageLimit) {
+    if (campaign?.demoMessageLimit) {
       return res.status(400).json({
         message: `Action disabled for demo campaign`,
       })
@@ -122,11 +123,12 @@ const getCredentialsFromLabel = async (
     res.locals.credentialName = botId(telegramBotToken)
     return next()
   } catch (err) {
+    const errAsError = err as Error
     logger.error({
       ...logMeta,
-      message: `${err.stack}`,
+      message: `${errAsError.stack}`,
     })
-    return res.status(400).json({ message: `${err.message}` })
+    return res.status(400).json({ message: `${errAsError.message}` })
   }
 }
 
@@ -145,7 +147,7 @@ const getCampaignCredential = async (
   const userId = req.session?.user?.id
   const campaign = await TelegramService.findCampaign(+campaignId, userId)
 
-  const { credName } = campaign
+  const { credName } = campaign as Campaign
   if (!credName) {
     logger.error({
       message: 'Credential not found for this campaign',
@@ -255,7 +257,7 @@ const sendValidationMessage = async (
       error: err,
       ...logMeta,
     })
-    return res.status(400).json({ message: `${err.message}` })
+    return res.status(400).json({ message: `${(err as Error).message}` })
   }
 }
 

--- a/backend/src/telegram/middlewares/tests/telegram.middleware.test.ts
+++ b/backend/src/telegram/middlewares/tests/telegram.middleware.test.ts
@@ -2,9 +2,9 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { TelegramMiddleware } from '@telegram/middlewares/telegram.middleware'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 let campaignId: number
@@ -21,14 +21,17 @@ beforeEach(() => {
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
   const campaign = await Campaign.create({
     name: 'campaign-1',
     userId: 1,
     type: ChannelType.Telegram,
     valid: false,
     protect: false,
-  })
+  } as CreationAttributes<Campaign>)
   campaignId = campaign.id
 })
 
@@ -36,7 +39,6 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('isTelegramCampaignOwnedByUser middleware', () => {

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -3,13 +3,13 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Campaign, User, Credential } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { DefaultCredentialName } from '@core/constants'
 import { formatDefaultCredentialName } from '@core/utils'
 import { TelegramMessage } from '@telegram/models'
 import { ChannelType } from '@core/constants'
 import { mockSecretsManager } from '@mocks/aws-sdk'
 import { mockTelegram, Telegram } from '@mocks/telegraf'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
@@ -20,19 +20,26 @@ const createCampaign = async ({
   isDemo,
 }: {
   isDemo: boolean
-}): Promise<Campaign> =>
-  await Campaign.create({
+}): Promise<Campaign> => {
+  const campaign = {
     name: 'test-campaign',
     userId: 1,
     type: ChannelType.Telegram,
     protect: false,
     valid: false,
-    demoMessageLimit: isDemo ? 20 : null,
-  })
+  } as Campaign
+  if (isDemo) {
+    campaign.demoMessageLimit = 20
+  }
+  return Campaign.create(campaign as CreationAttributes<Campaign>)
+}
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
   const campaign = await createCampaign({ isDemo: false })
   campaignId = campaign.id
 })
@@ -43,7 +50,6 @@ afterAll(async () => {
   await Credential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('POST /campaign/{campaignId}/telegram/credentials', () => {
@@ -240,7 +246,7 @@ describe('PUT /campaign/{campaignId}/telegram/template', () => {
       campaignId,
       recipient: 'user@agency.gov.sg',
       params: { recipient: 'user@agency.gov.sg' },
-    })
+    } as CreationAttributes<TelegramMessage>)
     const res = await request(app)
       .put(`/campaign/${campaignId}/telegram/template`)
       .send({

--- a/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
@@ -3,24 +3,26 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Credential, UserCredential, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { mockTelegram } from '@mocks/telegraf'
 import { mockSecretsManager } from '@mocks/aws-sdk'
+import { CreationAttributes } from 'sequelize/dist'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
 
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
-  await User.create({ id: 1, email: 'user@agency.gov.sg' })
+  await User.create({
+    id: 1,
+    email: 'user@agency.gov.sg',
+  } as CreationAttributes<User>)
 })
 
 afterAll(async () => {
   await UserCredential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('POST /settings/telegram/credentials', () => {

--- a/backend/src/telegram/services/telegram-template.service.ts
+++ b/backend/src/telegram/services/telegram-template.service.ts
@@ -14,6 +14,7 @@ import {
 import { TelegramMessage, TelegramTemplate } from '@telegram/models'
 import { StoreTemplateInput, StoreTemplateOutput } from '@telegram/interfaces'
 import { MessageBulkInsertInterface } from '@core/interfaces/message.interface'
+import { CreationAttributes } from 'sequelize/dist'
 const client = new TemplateClient({
   xssOptions: XSS_TELEGRAM_OPTION,
   lineBreak: '\n',

--- a/backend/src/telegram/utils/callback/handlers/contact.ts
+++ b/backend/src/telegram/utils/callback/handlers/contact.ts
@@ -1,6 +1,6 @@
 import { TelegrafContext } from 'telegraf/typings/context'
 import { Message, ExtraReplyMessage } from 'telegraf/typings/telegram-types'
-import { QueryTypes } from 'sequelize'
+import { CreationAttributes, QueryTypes } from 'sequelize'
 
 import { loggerWithLabel } from '@core/logger'
 import { PostmanTelegramError } from '../PostmanTelegramError'
@@ -56,7 +56,7 @@ const upsertTelegramSubscriber = async (
       const updatedCount = result?.[1]
       if (!updatedCount) {
         await TelegramSubscriber.create(
-          { telegramId, phoneNumber },
+          { telegramId, phoneNumber } as CreationAttributes<TelegramSubscriber>,
           { transaction }
         )
       }
@@ -95,56 +95,56 @@ const addBotSubscriber = async (
 /**
  * Handles updates with contacts.
  */
-export const contactMessageHandler = (botId: string) => async (
-  ctx: TelegrafContext
-): Promise<Message> => {
-  logger.info({
-    from: ctx.from,
-    contact: ctx.message?.contact,
-    botId,
-    action: 'contactMessageHandler',
-  })
+export const contactMessageHandler =
+  (botId: string) =>
+  async (ctx: TelegrafContext): Promise<Message> => {
+    logger.info({
+      from: ctx.from,
+      contact: ctx.message?.contact,
+      botId,
+      action: 'contactMessageHandler',
+    })
 
-  // Parse contact data
-  const contact = ctx.message?.contact
-  if (!contact) {
-    throw new PostmanTelegramError('Contact not defined')
+    // Parse contact data
+    const contact = ctx.message?.contact
+    if (!contact) {
+      throw new PostmanTelegramError('Contact not defined')
+    }
+
+    const { phone_number: phoneNumber, user_id: telegramId } = contact
+    if (!(phoneNumber && telegramId)) {
+      throw new PostmanTelegramError('Invalid contact information')
+    }
+
+    const senderTelegramId = ctx.from?.id
+    if (!senderTelegramId || telegramId !== senderTelegramId) {
+      throw new PostmanTelegramError('Sender and contact mismatch')
+    }
+
+    // Upsert and add subscriptions
+    const upserted = await upsertTelegramSubscriber(phoneNumber, telegramId)
+    const didAddBotSubscriber = await addBotSubscriber(botId, telegramId)
+
+    // Respond
+    const replyOptions: ExtraReplyMessage = {
+      reply_markup: {
+        remove_keyboard: true,
+      },
+    }
+
+    // Configure bot reply based on what actually happened
+    let reply
+    if (didAddBotSubscriber) {
+      reply = 'You are now subscribed.'
+    } else {
+      reply = 'You were already subscribed.'
+    }
+
+    if (upserted) {
+      reply += ' Your phone number and Telegram ID have been updated.'
+    } else {
+      reply += ' An internal failure has occurred.'
+    }
+
+    return ctx.reply(reply, replyOptions)
   }
-
-  const { phone_number: phoneNumber, user_id: telegramId } = contact
-  if (!(phoneNumber && telegramId)) {
-    throw new PostmanTelegramError('Invalid contact information')
-  }
-
-  const senderTelegramId = ctx.from?.id
-  if (!senderTelegramId || telegramId !== senderTelegramId) {
-    throw new PostmanTelegramError('Sender and contact mismatch')
-  }
-
-  // Upsert and add subscriptions
-  const upserted = await upsertTelegramSubscriber(phoneNumber, telegramId)
-  const didAddBotSubscriber = await addBotSubscriber(botId, telegramId)
-
-  // Respond
-  const replyOptions: ExtraReplyMessage = {
-    reply_markup: {
-      remove_keyboard: true,
-    },
-  }
-
-  // Configure bot reply based on what actually happened
-  let reply
-  if (didAddBotSubscriber) {
-    reply = 'You are now subscribed.'
-  } else {
-    reply = 'You were already subscribed.'
-  }
-
-  if (upserted) {
-    reply += ' Your phone number and Telegram ID have been updated.'
-  } else {
-    reply += ' An internal failure has occurred.'
-  }
-
-  return ctx.reply(reply, replyOptions)
-}

--- a/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
+++ b/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
@@ -1,9 +1,9 @@
 import { Sequelize } from 'sequelize-typescript'
 import { TelegrafContext } from 'telegraf/typings/context'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { BotSubscriber, TelegramSubscriber } from '@telegram/models'
 import { contactMessageHandler } from '../contact'
+import { CreationAttributes } from 'sequelize/dist'
 
 let sequelize: Sequelize
 beforeAll(async () => {
@@ -12,7 +12,6 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('contactMessageHandler', () => {
@@ -47,11 +46,11 @@ describe('contactMessageHandler', () => {
     await TelegramSubscriber.create({
       phoneNumber,
       telegramId,
-    })
+    } as CreationAttributes<TelegramSubscriber>)
     await BotSubscriber.create({
       botId,
       telegramId,
-    })
+    } as CreationAttributes<BotSubscriber>)
   }
 
   afterEach(async () => {
@@ -74,9 +73,7 @@ describe('contactMessageHandler', () => {
     })
     expect(botSubscriber).not.toBeNull()
 
-    expect(
-      ctx.reply
-    ).toBeCalledWith(
+    expect(ctx.reply).toBeCalledWith(
       'You are now subscribed. Your phone number and Telegram ID have been updated.',
       { reply_markup: { remove_keyboard: true } }
     )
@@ -99,9 +96,7 @@ describe('contactMessageHandler', () => {
     })
     expect(botSubscriber).not.toBeNull()
 
-    expect(
-      ctx.reply
-    ).toBeCalledWith(
+    expect(ctx.reply).toBeCalledWith(
       'You were already subscribed. Your phone number and Telegram ID have been updated.',
       { reply_markup: { remove_keyboard: true } }
     )
@@ -124,9 +119,7 @@ describe('contactMessageHandler', () => {
     })
     expect(botSubscriber).not.toBeNull()
 
-    expect(
-      ctx.reply
-    ).toBeCalledWith(
+    expect(ctx.reply).toBeCalledWith(
       'You were already subscribed. Your phone number and Telegram ID have been updated.',
       { reply_markup: { remove_keyboard: true } }
     )

--- a/backend/src/test-utils/global-teardown.ts
+++ b/backend/src/test-utils/global-teardown.ts
@@ -1,3 +1,7 @@
-module.exports = async function () {
+require('module-alias/register')
+import { RedisService } from '@core/services'
+
+module.exports = async function (): Promise<void> {
   await global.sequelize.close()
+  await RedisService.shutdown()
 }

--- a/backend/src/test-utils/server.ts
+++ b/backend/src/test-utils/server.ts
@@ -1,14 +1,13 @@
 import express, { Request, Response, NextFunction } from 'express'
 import { errors as celebrateErrorMiddleware } from 'celebrate'
-import bodyParser from 'body-parser'
 import sessionLoader from '@core/loaders/session.loader'
 import routes from '@core/routes'
 
 const initialiseServer = (session?: boolean): express.Application => {
   const app: express.Application = express()
   sessionLoader({ app })
-  app.use(bodyParser.json())
-  app.use(bodyParser.urlencoded({ extended: false }))
+  app.use(express.json())
+  app.use(express.urlencoded({ extended: false }))
 
   app.use((req: Request, _res: Response, next: NextFunction): void => {
     if (session && req.session) {

--- a/backend/src/test-utils/setup.ts
+++ b/backend/src/test-utils/setup.ts
@@ -1,3 +1,5 @@
+import { RedisService } from '@core/services'
+
 /* eslint-disable no-console */
 global.console = {
   ...global.console,
@@ -10,3 +12,4 @@ global.console = {
 
 // Mock services
 jest.mock('@core/services/mail-client.class')
+RedisService.init()

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -10,6 +10,8 @@
     "./src/__mocks__"
   ],
   "references": [
-    { "path": "../shared/tsconfig.build.json" }
+    {
+      "path": "../shared/tsconfig.build.json"
+    }
   ]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,9 @@
     "./src/server.ts"
   ],
   "references": [
-    { "path": "../shared/tsconfig.build.json" }
+    {
+      "path": "../shared/tsconfig.build.json"
+    }
   ],
   "compileOnSave": true,
   "compilerOptions": {
@@ -35,17 +37,33 @@
     "moduleResolution": "node",
     "baseUrl": "./src",
     "paths": {
-      "@core/*": ["core/*"],
-      "@sms/*": ["sms/*"],
-      "@email/*": ["email/*"],
-      "@telegram/*": ["telegram/*"],
-      "@shared/*": ["../../shared/src/*"],
-      "@test-utils/*": ["test-utils/*"],
-      "@database/*": ["database/*"],
-      "@mocks/*": ["__mocks__/*"],
+      "@core/*": [
+        "core/*"
+      ],
+      "@sms/*": [
+        "sms/*"
+      ],
+      "@email/*": [
+        "email/*"
+      ],
+      "@telegram/*": [
+        "telegram/*"
+      ],
+      "@shared/*": [
+        "../../shared/src/*"
+      ],
+      "@test-utils/*": [
+        "test-utils/*"
+      ],
+      "@database/*": [
+        "database/*"
+      ],
+      "@mocks/*": [
+        "__mocks__/*"
+      ],
     },
     "esModuleInterop": true,
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": true
   }
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:11-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postmangovsg_test
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:6-alpine
+    ports:
+      - "6379:6379"
+  localstack:
+    image: localstack/localstack:0.11.6
+    ports:
+      - "4566-4599:4566-4599"
+    environment:
+      - DEBUG=1
+      - DATA_DIR=/tmp/localstack/data
+      - FILE_STORAGE_BUCKET_NAME=${FILE_STORAGE_BUCKET_NAME:-localstack-upload}
+      - BACKUP_BUCKET_NAME=${BACKUP_BUCKET_NAME:-localstack-backup}
+      - AWS_LOG_GROUP_NAME=${AWS_LOG_GROUP_NAME:-postmangovsg-beanstalk-localstack}

--- a/shared/src/templating/template-client.ts
+++ b/shared/src/templating/template-client.ts
@@ -117,15 +117,16 @@ export class TemplateClient {
         tokens,
       }
     } catch (err) {
-      console.error({ message: `${err.stack}` })
-      if (err.message.includes('Unclosed tag'))
+      const errAsError = err as Error
+      console.error({ message: `${errAsError.stack}` })
+      if (errAsError.message.includes('Unclosed tag'))
         throw new TemplateError(
           'Check that all the keywords have double curly brackets around them.\nA correct example is {{ keyword }}, and incorrect ones are {{ keyword } or {{ keyword . '
         )
       // reserved chars in mustache are '^' and '#' and '/'
       if (
-        err.message.includes('Unclosed section') ||
-        err.message.includes('Unopened section')
+        errAsError.message.includes('Unclosed section') ||
+        errAsError.message.includes('Unopened section')
       )
         throw new TemplateError(
           "Check that the keywords only contain letters, numbers and underscore.\nKeywords like {{ Person's Name }} are not allowed, but {{ Person_Name }} is allowed."


### PR DESCRIPTION
**Note**: pending #1360 to be merged first

- problem: currently we're initializing redis clients in the main
program of redis.service, which hoist the variables in the global
scope through importing. As a result, the file handle opened by
`createClient` function call doesn't get closed when the application
scope exits

- solution: have a dedicated init function inside redis.service so
we will initialize redis clients in the application scope specifically

- some misc changes:
  - update of sequelize version to latest
  - deprecate body-parser in favor of native express middlewares
