### PR TITLE
feat: sms cost calculator

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12282,6 +12282,11 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
+    },
     "graphql": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
@@ -22727,6 +22732,14 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
+      }
+    },
+    "sms-segments-calculator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/sms-segments-calculator/-/sms-segments-calculator-1.1.1.tgz",
+      "integrity": "sha512-Z2m3fF66q0DIvUeJxxmM3qmoqT6s71/fuxLmt3YH/Vernlx3T/5Bid0vv36Yd+OjWVV+JZqE7V87augZEY7WTw==",
+      "requires": {
+        "grapheme-splitter": "^1.0.4"
       }
     },
     "snapdragon": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^5.1.2",
     "react-textarea-autosize": "^7.1.2",
     "sass-burger": "^1.3.1",
+    "sms-segments-calculator": "^1.1.1",
     "spark-md5": "^3.0.1",
     "typescript": "^4.2.3",
     "uuidv4": "^6.1.1",


### PR DESCRIPTION
## Problem

Admin users do not have a good sense of how much each SMS will cost. One user had a shock when their bill was significantly higher than expected because they were using either Chinese or Tamil. As a result, the SMS was encoded using UCS-2 instead of GSM-7, and the number of message segments increased significantly.

## Solution

We can introduce a short SMS segment and cost estimate as such (content TBD - will discuss with Sam and Lisa before turning this into a PR). The cost per message segment was obtained from [Twilio's pricing page](https://www.twilio.com/sms/pricing/sg) and is accurate as of 5 Feb 2022.

#### Cost estimate for a GSM-7 SMS
<img width="1624" alt="Screenshot 2022-02-07 at 11 36 27 AM" src="https://user-images.githubusercontent.com/19917616/152720637-b64eab3e-d72a-497b-a34c-dc513bc46ca4.png">


#### Cost estimate for a UCS-2 SMS
<img width="1624" alt="Screenshot 2022-02-07 at 11 36 59 AM" src="https://user-images.githubusercontent.com/19917616/152720642-a2ae698b-6d13-42de-a442-0190e0ec2d5d.png">


## Before & After Screenshots

**BEFORE**:
<img width="1624" alt="Screenshot 2022-02-05 at 5 05 47 PM" src="https://user-images.githubusercontent.com/19917616/152635580-77a4d554-5793-4283-a060-5b025946d3db.png">


**AFTER**:
_Refer to Solution_

## Tests
_What tests should be run to confirm functionality?_
[TBD - will work on test suite after the UI is confirmed]

## Deploy Notes

**New dependencies**:

- `sms-segments-calculator` : library to calculate the number of SMS message segments and encoding type