### PR TITLE
test(backend): fix redis client open handles

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2021-06-25T08:45:30Z",
+  "version": "1.0.3",
   "plugins_used": [
     {
-      "name": "AWSKeyDetector"
+      "name": "ArtifactoryDetector"
     },
     {
-      "name": "ArtifactoryDetector"
+      "name": "AWSKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -49,16 +49,44 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json|^.secrets.baseline$|backend/src/test-utils/*"
+      ]
+    }
+  ],
   "results": {
-    "backend/src/test-utils/test-env.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "backend/src/test-utils/test-env.ts",
-        "hashed_secret": "c237a19676ad55d8904be354990dd54f92f9572c",
-        "is_verified": false,
-        "line_number": 8
-      }
-    ],
     "frontend/.env-example": [
       {
         "type": "Basic Auth Credentials",
@@ -69,38 +97,5 @@
       }
     ]
   },
-  "version": "1.0.3",
-  "filters_used": [
-    {
-      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "package-lock.json|^.secrets.baseline$"
-      ]
-    }
-  ]
+  "generated_at": "2022-03-17T05:38:17Z"
 }

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   roots: ['<rootDir>'],
   testMatch: ['**/tests/**/*.(spec|test).+(ts|tsx|js)'],
+  // testMatch: ['**/tests/**/auth.routes.(spec|test).+(ts|tsx|js)'],
   testPathIgnorePatterns: ['<rootDir>/build/', '<rootDir>/node_modules/'],
   moduleNameMapper: {
     '@core/(.*)': '<rootDir>/src/core/$1',

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "start": "node build/server",
     "copy-assets": "copyfiles -u 1 src/assets/* src/**/*.sql build",
     "pretest": "tsc --build",
-    "test": "jest --maxWorkers=2",
+    "test": "jest --runInBand --detectOpenHandles",
     "precommit": "lint-staged"
   },
   "author": "",

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/node'
 import requestTracer from 'cls-rtracer'
 
 import config from '@core/config'
-import v1Router from '@core/routes'
+import { InitV1Route } from '@core/routes'
 import { getStream, loggerWithLabel } from '@core/logger'
 import { clientIp, userId } from '@core/utils/morgan'
 
@@ -128,7 +128,7 @@ const expressApp = ({ app }: { app: express.Application }): void => {
 
   app.use(sentrySessionMiddleware)
 
-  app.use('/v1', v1Router)
+  app.use('/v1', InitV1Route(app))
   app.use(celebrateErrorMiddleware())
   app.use(Sentry.Handlers.errorHandler())
 

--- a/backend/src/core/loaders/index.ts
+++ b/backend/src/core/loaders/index.ts
@@ -6,15 +6,27 @@ import sessionLoader from './session.loader'
 import sequelizeLoader from './sequelize.loader'
 import cloudwatchLoader from './cloudwatch.loader'
 import uploadQueueLoader from './upload-queue.loader'
+import {
+  InitAuthService,
+  InitCredentialService,
+  RedisService,
+} from '@core/services'
 
 const loaders = async ({ app }: { app: Application }): Promise<void> => {
+  const redisService = new RedisService()
+  ;(app as any).redisService = redisService
+  ;(app as any).authService = InitAuthService(redisService)
+  ;(app as any).credentialService = InitCredentialService(redisService)
   securityHeadersLoader({ app })
   await cloudwatchLoader()
   await sequelizeLoader()
-  sessionLoader({ app })
-  expressLoader({ app })
-  swaggerLoader({ app })
+  await sessionLoader({ app })
+  await expressLoader({ app })
+  await swaggerLoader({ app })
   await uploadQueueLoader()
+  ;(app as any).cleanup = async function (): Promise<void> {
+    await (app as any).redisService.shutdown()
+  }
 }
 
 export { loaders }

--- a/backend/src/core/loaders/session.loader.ts
+++ b/backend/src/core/loaders/session.loader.ts
@@ -2,7 +2,6 @@ import express from 'express'
 import session from 'express-session'
 import connectRedis from 'connect-redis'
 import config from '@core/config'
-import { RedisService } from '@core/services'
 
 /**
  * Initializes a session manager for logins
@@ -20,7 +19,7 @@ const sessionLoader = ({ app }: { app: express.Application }): void => {
     saveUninitialized: false,
     cookie: config.get('session.cookieSettings'),
     store: new sessionStore({
-      client: RedisService.sessionClient,
+      client: (app as any).redisService.sessionClient,
       logErrors: true,
     }),
   }

--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -1,169 +1,185 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { AuthService } from '@core/services'
 import { getRequestIp } from '@core/utils/request'
 
-const logger = loggerWithLabel(module)
-
-/**
- *  Determines if an email is whitelisted / enough time has elapsed since the last otp request,
- *  and sends an otp to that email if allowed
- * @param req
- * @param res
- */
-const getOtp = async (req: Request, res: Response): Promise<Response> => {
-  const email = req.body.email
-  const logMeta = { email, action: 'getOTP' }
-
-  try {
-    await AuthService.canSendOtp(email)
-  } catch (e) {
-    logger.error({
-      message: 'Not allowed to send OTP',
-      ...logMeta,
-      error: e,
-    })
-    return res.status(401).json({ message: e.message })
-  }
-  try {
-    const ipAddress = getRequestIp(req)
-    await AuthService.sendOtp(email, ipAddress)
-  } catch (e) {
-    logger.error({
-      message: 'Error sending OTP',
-      ...logMeta,
-      error: e,
-    })
-    return res.sendStatus(500)
-  }
-  return res.sendStatus(200)
+export interface AuthMiddleware {
+  getOtp: Handler
+  verifyOtp: Handler
+  getUser: Handler
+  isCookieOrApiKeyAuthenticated: Handler
+  logout: Handler
 }
 
-/**
- * Verifies that user input matches otp stored in redis
- * @param req
- * @param res
- * @param next
- */
-const verifyOtp = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { email, otp } = req.body
-  const logMeta = { email, action: 'verifyOTP' }
-  const authorized = await AuthService.verifyOtp({ email, otp })
-  if (!authorized) {
-    logger.error({ message: 'Failed to verify OTP for email', ...logMeta })
-    return res.sendStatus(401)
-  }
-  try {
-    if (req.session) {
-      const user = await AuthService.findOrCreateUser(email)
-      req.session.user = {
-        id: user.id,
-        createdAt: user.createdAt,
-        updatedAt: user.updatedAt,
-        email: user.email,
-      }
-      return res.sendStatus(200)
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const InitAuthMiddleware = (authService: AuthService) => {
+  const logger = loggerWithLabel(module)
+
+  /**
+   *  Determines if an email is whitelisted / enough time has elapsed since the last otp request,
+   *  and sends an otp to that email if allowed
+   * @param req
+   * @param res
+   */
+  const getOtp = async (req: Request, res: Response): Promise<Response> => {
+    const email = req.body.email
+    const logMeta = { email, action: 'getOTP' }
+
+    try {
+      await authService.canSendOtp(email)
+    } catch (e) {
+      logger.error({
+        message: 'Not allowed to send OTP',
+        ...logMeta,
+        error: e,
+      })
+      return res.status(401).json({ message: e.message })
     }
-    logger.error({ message: 'Session object not found!', ...logMeta })
-    return res.sendStatus(401)
-  } catch (err) {
-    return next(err)
+    try {
+      const ipAddress = getRequestIp(req)
+      await authService.sendOtp(email, ipAddress)
+    } catch (e) {
+      logger.error({
+        message: 'Error sending OTP',
+        ...logMeta,
+        error: e,
+      })
+      return res.sendStatus(500)
+    }
+    return res.sendStatus(200)
   }
-}
 
-/**
- * Checks if user is logged in, and returns their email if they are
- * @param req
- * @param res
- */
-const getUser = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  if (req?.session?.user?.id) {
-    const user = await AuthService.findUser(req?.session?.user?.id)
+  /**
+   * Verifies that user input matches otp stored in redis
+   * @param req
+   * @param res
+   * @param next
+   */
+  const verifyOtp = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { email, otp } = req.body
+    const logMeta = { email, action: 'verifyOTP' }
+    const authorized = await authService.verifyOtp({ email, otp })
+    if (!authorized) {
+      logger.error({ message: 'Failed to verify OTP for email', ...logMeta })
+      return res.sendStatus(401)
+    }
+    try {
+      if (req.session) {
+        const user = await authService.findOrCreateUser(email)
+        req.session.user = {
+          id: user.id,
+          createdAt: user.createdAt,
+          updatedAt: user.updatedAt,
+          email: user.email,
+        }
+        return res.sendStatus(200)
+      }
+      logger.error({ message: 'Session object not found!', ...logMeta })
+      return res.sendStatus(401)
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Checks if user is logged in, and returns their email if they are
+   * @param req
+   * @param res
+   */
+  const getUser = async (
+    req: Request,
+    res: Response
+  ): Promise<Response | void> => {
+    if (req?.session?.user?.id) {
+      const user = await authService.findUser(req?.session?.user?.id)
+      logger.info({
+        message: 'Existing user session found',
+        action: 'getUser',
+      })
+      return res.json({ email: user?.email, id: user?.id })
+    }
     logger.info({
-      message: 'Existing user session found',
+      message: 'No existing user session found!',
       action: 'getUser',
     })
-    return res.json({ email: user?.email, id: user?.id })
+    return res.json({})
   }
-  logger.info({ message: 'No existing user session found!', action: 'getUser' })
-  return res.json({})
-}
 
-/**
- * Checks that request has a valid cookie (based on session), or a valid Authorization header
- * @param req
- * @param res
- * @param next
- */
-const isCookieOrApiKeyAuthenticated = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    if (AuthService.checkCookie(req)) {
-      return next()
-    }
-
-    const user = await AuthService.getUserForApiKey(req)
-    if (user !== null && req.session) {
-      // Ideally, we store the user id in res.locals for api key, because theoretically, no session was created.
-      // Practically, we have to check multiple places for the user id when we want to retrieve the id
-      // To avoid these checks, we assign the user id to the session property instead so that downstream middlewares can use it
-      req.session.user = user
-      req.session.apiKey = true
-      logger.info({
-        message: 'User authenticated by API key',
-        action: 'isCookieOrApiKeyAuthenticated',
-      })
-      return next()
-    }
-
-    return res.sendStatus(401)
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Destroys user's session
- * @param req
- * @param res
- * @param next
- */
-const logout = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  return new Promise<Response | void>((resolve, reject) => {
-    req.session?.destroy((err) => {
-      res.cookie(config.get('session.cookieName'), '', { expires: new Date() }) // Makes cookie expire immediately
-      if (!err) {
-        return resolve(res.sendStatus(200))
+  /**
+   * Checks that request has a valid cookie (based on session), or a valid Authorization header
+   * @param req
+   * @param res
+   * @param next
+   */
+  const isCookieOrApiKeyAuthenticated = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      if (authService.checkCookie(req)) {
+        return next()
       }
-      logger.error({
-        message: 'Failed to destroy session',
-        error: err,
-        action: 'logout',
-      })
-      reject(err)
-    })
-  }).catch((err) => next(err))
-}
 
-export const AuthMiddleware = {
-  getOtp,
-  verifyOtp,
-  getUser,
-  isCookieOrApiKeyAuthenticated,
-  logout,
+      const user = await authService.getUserForApiKey(req)
+      if (user !== null && req.session) {
+        // Ideally, we store the user id in res.locals for api key, because theoretically, no session was created.
+        // Practically, we have to check multiple places for the user id when we want to retrieve the id
+        // To avoid these checks, we assign the user id to the session property instead so that downstream middlewares can use it
+        req.session.user = user
+        req.session.apiKey = true
+        logger.info({
+          message: 'User authenticated by API key',
+          action: 'isCookieOrApiKeyAuthenticated',
+        })
+        return next()
+      }
+
+      return res.sendStatus(401)
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Destroys user's session
+   * @param req
+   * @param res
+   * @param next
+   */
+  const logout = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    return new Promise<Response | void>((resolve, reject) => {
+      req.session?.destroy((err) => {
+        res.cookie(config.get('session.cookieName'), '', {
+          expires: new Date(),
+        }) // Makes cookie expire immediately
+        if (!err) {
+          return resolve(res.sendStatus(200))
+        }
+        logger.error({
+          message: 'Failed to destroy session',
+          error: err,
+          action: 'logout',
+        })
+        reject(err)
+      })
+    }).catch((err) => next(err))
+  }
+
+  return {
+    getOtp,
+    verifyOtp,
+    getUser,
+    isCookieOrApiKeyAuthenticated,
+    logout,
+  }
 }

--- a/backend/src/core/middlewares/settings.middleware.ts
+++ b/backend/src/core/middlewares/settings.middleware.ts
@@ -1,278 +1,294 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import { ChannelType } from '@core/constants'
 import { CredentialService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
 
-const logger = loggerWithLabel(module)
-
-/*
- * Retrieves API key and stored credentials of the user
- */
-const getUserSettings = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void | Response> => {
-  try {
-    const userId = req.session?.user?.id
-    const userSettings = await CredentialService.getUserSettings(userId)
-    if (!userSettings) {
-      throw new Error('User not found')
-    }
-    return res.json({
-      has_api_key: userSettings.hasApiKey,
-      creds: userSettings.creds,
-      demo: {
-        num_demos_sms: userSettings.demo?.numDemosSms,
-        num_demos_telegram: userSettings.demo?.numDemosTelegram,
-        is_displayed: userSettings.demo?.isDisplayed,
-      },
-      announcement_version: userSettings.userFeature?.announcementVersion,
-    })
-  } catch (err) {
-    next(err)
-  }
+export interface SettingsMiddleware {
+  getUserSettings: Handler
+  checkUserCredentialLabel: Handler
+  storeUserCredential: Handler
+  checkAndStoreLabelIfExists: Handler
+  getChannelSpecificCredentials: Handler
+  deleteUserCredential: Handler
+  regenerateApiKey: Handler
+  updateDemoDisplayed: Handler
+  updateAnnouncementVersion: Handler
 }
 
-/**
- * Checks if label already used for that user
- * @param req
- * @param res
- * @param next
- */
-const checkUserCredentialLabel = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const userId = req.session?.user?.id
+export const InitSettingsMiddleware = (
+  credentialService: CredentialService
+): SettingsMiddleware => {
+  const logger = loggerWithLabel(module)
+
+  /*
+   * Retrieves API key and stored credentials of the user
+   */
+  const getUserSettings = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
+    try {
+      const userId = req.session?.user?.id
+      const userSettings = await credentialService.getUserSettings(userId)
+      if (!userSettings) {
+        throw new Error('User not found')
+      }
+      return res.json({
+        has_api_key: userSettings.hasApiKey,
+        creds: userSettings.creds,
+        demo: {
+          num_demos_sms: userSettings.demo?.numDemosSms,
+          num_demos_telegram: userSettings.demo?.numDemosTelegram,
+          is_displayed: userSettings.demo?.isDisplayed,
+        },
+        announcement_version: userSettings.userFeature?.announcementVersion,
+      })
+    } catch (err) {
+      next(err)
+    }
+  }
+
+  /**
+   * Checks if label already used for that user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const checkUserCredentialLabel = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const { label } = req.body
+      const result = await credentialService.getUserCredential(userId, label)
+      const errorMessage = 'User credential with the same label already exists.'
+      if (result) {
+        logger.error({
+          message: errorMessage,
+          label,
+          action: 'checkUserCredentialLabel',
+        })
+        return res.status(400).json({ message: errorMessage })
+      }
+      next()
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
+   * Associate credential to user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const storeUserCredential = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
     const { label } = req.body
-    const result = await CredentialService.getUserCredential(userId, label)
-    const errorMessage = 'User credential with the same label already exists.'
-    if (result) {
-      logger.error({
-        message: errorMessage,
+    const userId = req.session?.user?.id
+    const { credentialName, channelType } = res.locals
+    const logMeta = {
+      action: 'storeUserCredential',
+      credentialName,
+      channelType,
+    }
+    try {
+      if (!credentialName || !channelType) {
+        const errorMessage = 'Credential or credential type does not exist'
+        throw new Error(errorMessage)
+      }
+      await credentialService.createUserCredential(
         label,
-        action: 'checkUserCredentialLabel',
-      })
-      return res.status(400).json({ message: errorMessage })
-    }
-    next()
-  } catch (e) {
-    next(e)
-  }
-}
-
-/**
- * Associate credential to user
- * @param req
- * @param res
- * @param next
- */
-const storeUserCredential = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { label } = req.body
-  const userId = req.session?.user?.id
-  const { credentialName, channelType } = res.locals
-  const logMeta = {
-    action: 'storeUserCredential',
-    credentialName,
-    channelType,
-  }
-  try {
-    if (!credentialName || !channelType) {
-      const errorMessage = 'Credential or credential type does not exist'
-      throw new Error(errorMessage)
-    }
-    await CredentialService.createUserCredential(
-      label,
-      channelType,
-      credentialName,
-      +userId
-    )
-    logger.info({ message: 'Stored user credential', ...logMeta })
-    return res.json({ message: 'OK' })
-  } catch (e) {
-    next(e)
-  }
-}
-
-const checkAndStoreLabelIfExists = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { label } = req.body
-  if (!label) {
-    return next()
-  }
-  const userId = req.session?.user?.id
-  const { credentialName, channelType } = res.locals
-
-  try {
-    const result = await CredentialService.getUserCredential(userId, label)
-    if (result) {
-      return res.status(400).json({
-        message: 'User credential with the same label already exists.',
-      })
-    }
-    if (!credentialName || !channelType) {
-      throw new Error('Credential or credential type does not exist')
-    }
-    await CredentialService.createUserCredential(
-      label,
-      channelType,
-      credentialName,
-      +userId
-    )
-    next()
-  } catch (e) {
-    next(e)
-  }
-}
-
-/**
- * Get only labels for SMS and Telegram credentials for that user
- * @param req
- * @param res
- * @param next
- */
-const getChannelSpecificCredentials = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  try {
-    const { channelType } = req.params
-    const userId = req.session?.user?.id
-
-    let result
-    switch (channelType) {
-      case ChannelType.SMS:
-        result = await CredentialService.getSmsUserCredentialLabels(+userId)
-        break
-      case ChannelType.Telegram:
-        result = await CredentialService.getTelegramUserCredentialLabels(
-          +userId
-        )
-        break
-      default:
-        throw new Error('Unsupported channel type')
-    }
-    return res.json(result)
-  } catch (e) {
-    logger.error({
-      message: `${e.stack}`,
-      action: 'getChannelSpecificCredentials',
-    })
-    return res.status(400).json({ message: `${e.message}` })
-  }
-}
-
-/**
- * Delete a credential label for that user
- * @param req
- * @param res
- * @param next
- */
-const deleteUserCredential = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { label } = req.body
-    const userId = req.session?.user?.id
-    const count = await CredentialService.deleteUserCredential(+userId, label)
-    const logMeta = { label, action: 'deleteUserCredential' }
-    if (count) {
-      logger.info({ message: 'User credential deleted', ...logMeta })
+        channelType,
+        credentialName,
+        +userId
+      )
+      logger.info({ message: 'Stored user credential', ...logMeta })
       return res.json({ message: 'OK' })
-    } else {
-      logger.error({ message: 'Credential not found', ...logMeta })
-      res.status(400).json({ message: 'Credential not found' })
+    } catch (e) {
+      next(e)
     }
-  } catch (e) {
-    next(e)
   }
-}
 
-/**
- * Generate and associate an api key with that user
- * @param req
- * @param res
- * @param next
- */
-const regenerateApiKey = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+  const checkAndStoreLabelIfExists = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { label } = req.body
+    if (!label) {
+      return next()
+    }
     const userId = req.session?.user?.id
-    const apiKey = await CredentialService.regenerateApiKey(+userId)
-    return res.json({ api_key: apiKey })
-  } catch (e) {
-    next(e)
-  }
-}
+    const { credentialName, channelType } = res.locals
 
-/**
- * Update whether demos should be displayed for user
- * @param req
- * @param res
- * @param next
- */
-const updateDemoDisplayed = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const userId = req.session?.user?.id
-    const { is_displayed: isDisplayed } = req.body
-    await CredentialService.updateDemoDisplayed(+userId, isDisplayed)
-    return res.sendStatus(200)
-  } catch (e) {
-    next(e)
+    try {
+      const result = await credentialService.getUserCredential(userId, label)
+      if (result) {
+        return res.status(400).json({
+          message: 'User credential with the same label already exists.',
+        })
+      }
+      if (!credentialName || !channelType) {
+        throw new Error('Credential or credential type does not exist')
+      }
+      await credentialService.createUserCredential(
+        label,
+        channelType,
+        credentialName,
+        +userId
+      )
+      next()
+    } catch (e) {
+      next(e)
+    }
   }
-}
 
-/**
- * Update the announcement version for user
- * @param req
- * @param res
- * @param next
- */
-const updateAnnouncementVersion = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const userId = req.session?.user?.id
-    const { announcement_version: announcementVersion } = req.body
-    await CredentialService.updateAnnouncementVersion(
-      +userId,
-      announcementVersion
-    )
-    return res.sendStatus(200)
-  } catch (e) {
-    next(e)
+  /**
+   * Get only labels for SMS and Telegram credentials for that user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getChannelSpecificCredentials = async (
+    req: Request,
+    res: Response
+  ): Promise<Response | void> => {
+    try {
+      const { channelType } = req.params
+      const userId = req.session?.user?.id
+
+      let result
+      switch (channelType) {
+        case ChannelType.SMS:
+          result = await credentialService.getSmsUserCredentialLabels(+userId)
+          break
+        case ChannelType.Telegram:
+          result = await credentialService.getTelegramUserCredentialLabels(
+            +userId
+          )
+          break
+        default:
+          throw new Error('Unsupported channel type')
+      }
+      return res.json(result)
+    } catch (e) {
+      logger.error({
+        message: `${e.stack}`,
+        action: 'getChannelSpecificCredentials',
+      })
+      return res.status(400).json({ message: `${e.message}` })
+    }
   }
-}
 
-export const SettingsMiddleware = {
-  getUserSettings,
-  checkUserCredentialLabel,
-  storeUserCredential,
-  checkAndStoreLabelIfExists,
-  getChannelSpecificCredentials,
-  deleteUserCredential,
-  regenerateApiKey,
-  updateDemoDisplayed,
-  updateAnnouncementVersion,
+  /**
+   * Delete a credential label for that user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const deleteUserCredential = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { label } = req.body
+      const userId = req.session?.user?.id
+      const count = await credentialService.deleteUserCredential(+userId, label)
+      const logMeta = { label, action: 'deleteUserCredential' }
+      if (count) {
+        logger.info({ message: 'User credential deleted', ...logMeta })
+        return res.json({ message: 'OK' })
+      } else {
+        logger.error({ message: 'Credential not found', ...logMeta })
+        res.status(400).json({ message: 'Credential not found' })
+      }
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
+   * Generate and associate an api key with that user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const regenerateApiKey = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const apiKey = await credentialService.regenerateApiKey(+userId)
+      return res.json({ api_key: apiKey })
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
+   * Update whether demos should be displayed for user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const updateDemoDisplayed = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const { is_displayed: isDisplayed } = req.body
+      await credentialService.updateDemoDisplayed(+userId, isDisplayed)
+      return res.sendStatus(200)
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  /**
+   * Update the announcement version for user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const updateAnnouncementVersion = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const { announcement_version: announcementVersion } = req.body
+      await credentialService.updateAnnouncementVersion(
+        +userId,
+        announcementVersion
+      )
+      return res.sendStatus(200)
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  return {
+    getUserSettings,
+    checkUserCredentialLabel,
+    storeUserCredential,
+    checkAndStoreLabelIfExists,
+    getChannelSpecificCredentials,
+    deleteUserCredential,
+    regenerateApiKey,
+    updateDemoDisplayed,
+    updateAnnouncementVersion,
+  }
 }

--- a/backend/src/core/middlewares/tests/campaign.middleware.test.ts
+++ b/backend/src/core/middlewares/tests/campaign.middleware.test.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, JobQueue, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType, JobStatus } from '@core/constants'
 import { CampaignMiddleware } from '@core/middlewares/campaign.middleware'
 
@@ -31,7 +30,6 @@ afterEach(async () => {
 afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('canEditCampaign middleware', () => {

--- a/backend/src/core/models/user/tests/user.test.ts
+++ b/backend/src/core/models/user/tests/user.test.ts
@@ -2,7 +2,6 @@ import { Sequelize } from 'sequelize-typescript'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { User, Domain, Agency } from '@core/models'
 import { validateDomain } from '@core/utils/validate-domain'
-import { RedisService } from '@core/services'
 import config from '@core/config'
 
 let sequelize: Sequelize
@@ -24,7 +23,6 @@ afterEach(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('BeforeCreate hook', () => {

--- a/backend/src/core/routes/auth.routes.ts
+++ b/backend/src/core/routes/auth.routes.ts
@@ -2,145 +2,147 @@ import { Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { AuthMiddleware } from '@core/middlewares'
 
-const router = Router()
+export const InitAuthRoutes = (authMiddleware: AuthMiddleware): Router => {
+  const router = Router()
 
-// validators
-const getOtpValidator = {
-  [Segments.BODY]: Joi.object({
-    email: Joi.string()
-      .email()
-      .options({ convert: true }) // Converts email to lowercase if it isn't
-      .lowercase()
-      .required(), // validation for email ending in whitelisted domains was removed as we want to support other manually whitelisted emails
-  }),
+  // validators
+  const getOtpValidator = {
+    [Segments.BODY]: Joi.object({
+      email: Joi.string()
+        .email()
+        .options({ convert: true }) // Converts email to lowercase if it isn't
+        .lowercase()
+        .required(), // validation for email ending in whitelisted domains was removed as we want to support other manually whitelisted emails
+    }),
+  }
+
+  const verifyOtpValidator = {
+    [Segments.BODY]: Joi.object({
+      email: Joi.string()
+        .email()
+        .options({ convert: true }) // Converts email to lowercase if it isn't
+        .lowercase()
+        .required(),
+      otp: Joi.string()
+        .length(6)
+        .pattern(/^\d+$/, { name: 'numbers' })
+        .required(),
+    }),
+  }
+
+  // actual routes here
+
+  /**
+   * @swagger
+   * paths:
+   *  /auth/otp:
+   *    post:
+   *      tags:
+   *        - Authentication
+   *      summary: Get otp for user
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                email:
+   *                  type: string
+   *              required:
+   *              - email
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/otp', celebrate(getOtpValidator), authMiddleware.getOtp)
+
+  /**
+   * @swagger
+   * paths:
+   *  /auth/login:
+   *    post:
+   *      summary: Verify user otp
+   *      tags:
+   *        - Authentication
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                email:
+   *                  type: string
+   *                otp:
+   *                   type: string
+   *              required:
+   *              - email
+   *              - otp
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "401":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/login', celebrate(verifyOtpValidator), authMiddleware.verifyOtp)
+
+  /**
+   * @swagger
+   * paths:
+   *  /auth/userinfo:
+   *    get:
+   *      summary: get logged in user info
+   *      tags:
+   *        - Authentication
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  email:
+   *                    type: string
+   *
+   */
+  router.get('/userinfo', authMiddleware.getUser)
+
+  /**
+   * @swagger
+   * paths:
+   *  /auth/logout:
+   *    get:
+   *      summary: logs user out
+   *      tags:
+   *        - Authentication
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/logout', authMiddleware.logout)
+
+  return router
 }
-
-const verifyOtpValidator = {
-  [Segments.BODY]: Joi.object({
-    email: Joi.string()
-      .email()
-      .options({ convert: true }) // Converts email to lowercase if it isn't
-      .lowercase()
-      .required(),
-    otp: Joi.string()
-      .length(6)
-      .pattern(/^\d+$/, { name: 'numbers' })
-      .required(),
-  }),
-}
-
-// actual routes here
-
-/**
- * @swagger
- * paths:
- *  /auth/otp:
- *    post:
- *      tags:
- *        - Authentication
- *      summary: Get otp for user
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                email:
- *                  type: string
- *              required:
- *              - email
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/otp', celebrate(getOtpValidator), AuthMiddleware.getOtp)
-
-/**
- * @swagger
- * paths:
- *  /auth/login:
- *    post:
- *      summary: Verify user otp
- *      tags:
- *        - Authentication
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                email:
- *                  type: string
- *                otp:
- *                   type: string
- *              required:
- *              - email
- *              - otp
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "401":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/login', celebrate(verifyOtpValidator), AuthMiddleware.verifyOtp)
-
-/**
- * @swagger
- * paths:
- *  /auth/userinfo:
- *    get:
- *      summary: get logged in user info
- *      tags:
- *        - Authentication
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  email:
- *                    type: string
- *
- */
-router.get('/userinfo', AuthMiddleware.getUser)
-
-/**
- * @swagger
- * paths:
- *  /auth/logout:
- *    get:
- *      summary: logs user out
- *      tags:
- *        - Authentication
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/logout', AuthMiddleware.logout)
-
-export default router

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -1,182 +1,235 @@
-import { Router, Request, Response, NextFunction } from 'express'
+import { Router, Request, Response, NextFunction, Application } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { ChannelType } from '@core/constants'
 import { Campaign } from '@core/models'
-import { AuthMiddleware } from '@core/middlewares'
+import { InitAuthMiddleware, InitSettingsMiddleware } from '@core/middlewares'
 import { loggerWithLabel } from '@core/logger'
 
 // Core routes
-import authenticationRoutes from './auth.routes'
+import { InitAuthRoutes } from './auth.routes'
 import protectedMailRoutes from './protected.routes'
 import campaignRoutes from './campaign.routes'
-import settingsRoutes from './settings.routes'
+import { InitSettingsRoute } from './settings.routes'
 import statsRoutes from './stats.routes'
 import unsubscriberRoutes from './unsubscriber.routes'
 
 // Import channel-specific routes
 import {
-  smsCampaignRoutes,
-  smsSettingsRoutes,
   smsCallbackRoutes,
-  smsTransactionalRoutes,
+  InitSmsCampaignRoute,
+  InitSmsSettingsRoute,
+  InitSmsTransactionalRoute,
 } from '@sms/routes'
 import {
-  emailCampaignRoutes,
-  emailSettingsRoutes,
   emailCallbackRoutes,
-  emailTransactionalRoutes,
+  InitEmailCampaignRoute,
+  InitEmailSettingsRoute,
+  InitEmailTransactionalRoute,
 } from '@email/routes'
 import {
-  telegramCampaignRoutes,
-  telegramSettingsRoutes,
   telegramCallbackRoutes,
+  InitTelegramCampaignMiddleware,
+  InitTelegramSettingsRoute,
 } from '@telegram/routes'
+import { InitSmsMiddleware } from '@sms/middlewares'
+import {
+  InitEmailMiddleware,
+  InitEmailTemplateMiddleware,
+  InitEmailTransactionalMiddleware,
+} from '@email/middlewares'
+import { InitTelegramMiddleware } from '@telegram/middlewares'
 
-const logger = loggerWithLabel(module)
+export const InitV1Route = (app: Application): Router => {
+  const logger = loggerWithLabel(module)
+  const authMiddleware = InitAuthMiddleware((app as any).authService)
+  const authenticationRoutes = InitAuthRoutes(authMiddleware)
+  const settingsMiddleware = InitSettingsMiddleware(
+    (app as any).credentialService
+  )
+  const settingsRoutes = InitSettingsRoute(settingsMiddleware)
+  const smsMiddleware = InitSmsMiddleware((app as any).credentialService)
+  const smsCampaignRoutes = InitSmsCampaignRoute(
+    smsMiddleware,
+    settingsMiddleware
+  )
+  const smsSettingsRoutes = InitSmsSettingsRoute(
+    smsMiddleware,
+    settingsMiddleware
+  )
+  const smsTransactionalRoutes = InitSmsTransactionalRoute(smsMiddleware)
+  const emailTemplateMiddleware = InitEmailTemplateMiddleware(
+    (app as any).authService
+  )
+  const emailMiddleware = InitEmailMiddleware((app as any).authService)
+  const emailCampaignRoutes = InitEmailCampaignRoute(
+    emailTemplateMiddleware,
+    emailMiddleware
+  )
+  const emailTransactionalMiddleware = InitEmailTransactionalMiddleware(
+    (app as any).redisService,
+    (app as any).authService
+  )
+  const emailTransactionalRoutes = InitEmailTransactionalRoute(
+    emailTransactionalMiddleware,
+    emailMiddleware
+  )
+  const emailSettingsRoutes = InitEmailSettingsRoute(emailMiddleware)
+  const telegramMiddleware = InitTelegramMiddleware(
+    (app as any).credentialService
+  )
+  const telegramCampaignRoutes = InitTelegramCampaignMiddleware(
+    settingsMiddleware,
+    telegramMiddleware
+  )
+  const telegramSettingsRoutes = InitTelegramSettingsRoute(
+    telegramMiddleware,
+    settingsMiddleware
+  )
 
-const CHANNEL_ROUTES = Object.values(ChannelType).map(
-  (route) => `/${route.toLowerCase()}`
-)
+  const CHANNEL_ROUTES = Object.values(ChannelType).map(
+    (route) => `/${route.toLowerCase()}`
+  )
 
-const campaignIdValidator = {
-  [Segments.PARAMS]: Joi.object({
-    campaignId: Joi.number().integer().positive().required(),
-  }),
-}
+  const campaignIdValidator = {
+    [Segments.PARAMS]: Joi.object({
+      campaignId: Joi.number().integer().positive().required(),
+    }),
+  }
 
-/**
- *  Redirects /campaign/:campaignId to the routes specific to the channel for that campaign
- * @param req
- * @param res
- */
-const redirectToChannelRoute = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  const { baseUrl: campaignUrl, originalUrl } = req
-  const resource = originalUrl.substring(campaignUrl.length) // Anything after /campaign/:campaignId
-  if (CHANNEL_ROUTES.some((route) => resource.startsWith(route))) {
-    // Fall through from missing channel route, which means that the route doesn't exist
-    logger.error({
-      message: 'Channel does not exist',
-      originalUrl,
-      action: 'redirectToChannelRoute',
+  /**
+   *  Redirects /campaign/:campaignId to the routes specific to the channel for that campaign
+   * @param req
+   * @param res
+   */
+  const redirectToChannelRoute = async (
+    req: Request,
+    res: Response
+  ): Promise<Response | void> => {
+    const { baseUrl: campaignUrl, originalUrl } = req
+    const resource = originalUrl.substring(campaignUrl.length) // Anything after /campaign/:campaignId
+    if (CHANNEL_ROUTES.some((route) => resource.startsWith(route))) {
+      // Fall through from missing channel route, which means that the route doesn't exist
+      logger.error({
+        message: 'Channel does not exist',
+        originalUrl,
+        action: 'redirectToChannelRoute',
+      })
+      return res.sendStatus(404)
+    }
+
+    const { campaignId } = req.params
+
+    const campaign = await Campaign.findOne({
+      where: { id: +campaignId },
+      attributes: ['type'],
     })
-    return res.sendStatus(404)
+    if (!campaign) {
+      // This campaign doesn't exist
+      logger.error({
+        message: 'Campaign does not exist',
+        campaignId,
+        action: 'redirectToChannelRoute',
+      })
+      return res.sendStatus(404)
+    }
+
+    const redirectTo = `${campaignUrl}/${campaign?.type.toLowerCase()}${resource}`
+    return res.redirect(307, redirectTo)
   }
 
-  const { campaignId } = req.params
-
-  const campaign = await Campaign.findOne({
-    where: { id: +campaignId },
-    attributes: ['type'],
-  })
-  if (!campaign) {
-    // This campaign doesn't exist
-    logger.error({
-      message: 'Campaign does not exist',
-      campaignId,
-      action: 'redirectToChannelRoute',
-    })
-    return res.sendStatus(404)
+  /**
+   * Healthcheck endpoint that connects to the db
+   * @param _req
+   * @param res
+   * @param next
+   */
+  const ping = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      await Campaign.sequelize?.query('SELECT 1+1;')
+      return res.sendStatus(200)
+    } catch (err) {
+      return next(err)
+    }
   }
 
-  const redirectTo = `${campaignUrl}/${campaign?.type.toLowerCase()}${resource}`
-  return res.redirect(307, redirectTo)
+  const router = Router()
+  router.use('/ping', ping)
+  router.use('/auth', authenticationRoutes)
+  router.use('/stats', statsRoutes)
+  router.use('/protect', protectedMailRoutes)
+  router.use('/unsubscribe', unsubscriberRoutes)
+
+  router.use(
+    '/campaigns',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    campaignRoutes
+  )
+  router.use(
+    '/campaign/:campaignId/sms',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    celebrate(campaignIdValidator),
+    smsCampaignRoutes
+  )
+  router.use(
+    '/campaign/:campaignId/email',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    celebrate(campaignIdValidator),
+    emailCampaignRoutes
+  )
+  router.use(
+    '/campaign/:campaignId/telegram',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    celebrate(campaignIdValidator),
+    telegramCampaignRoutes
+  )
+  router.use(
+    '/campaign/:campaignId',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    celebrate(campaignIdValidator),
+    redirectToChannelRoute
+  )
+
+  router.use(
+    '/settings/email',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    emailSettingsRoutes
+  )
+  router.use(
+    '/settings/sms',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    smsSettingsRoutes
+  )
+  router.use(
+    '/settings/telegram',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    telegramSettingsRoutes
+  )
+  router.use(
+    '/settings',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    settingsRoutes
+  )
+
+  router.use(
+    '/transactional/sms',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    smsTransactionalRoutes
+  )
+
+  router.use(
+    '/transactional/email',
+    authMiddleware.isCookieOrApiKeyAuthenticated,
+    emailTransactionalRoutes
+  )
+
+  router.use('/callback/email', emailCallbackRoutes)
+
+  router.use('/callback/sms', smsCallbackRoutes)
+
+  router.use('/callback/telegram', telegramCallbackRoutes)
+  return router
 }
-
-/**
- * Healthcheck endpoint that connects to the db
- * @param _req
- * @param res
- * @param next
- */
-const ping = async (
-  _req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    await Campaign.sequelize?.query('SELECT 1+1;')
-    return res.sendStatus(200)
-  } catch (err) {
-    return next(err)
-  }
-}
-
-const router = Router()
-router.use('/ping', ping)
-router.use('/auth', authenticationRoutes)
-router.use('/stats', statsRoutes)
-router.use('/protect', protectedMailRoutes)
-router.use('/unsubscribe', unsubscriberRoutes)
-
-router.use(
-  '/campaigns',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  campaignRoutes
-)
-router.use(
-  '/campaign/:campaignId/sms',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  celebrate(campaignIdValidator),
-  smsCampaignRoutes
-)
-router.use(
-  '/campaign/:campaignId/email',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  celebrate(campaignIdValidator),
-  emailCampaignRoutes
-)
-router.use(
-  '/campaign/:campaignId/telegram',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  celebrate(campaignIdValidator),
-  telegramCampaignRoutes
-)
-router.use(
-  '/campaign/:campaignId',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  celebrate(campaignIdValidator),
-  redirectToChannelRoute
-)
-
-router.use(
-  '/settings/email',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  emailSettingsRoutes
-)
-router.use(
-  '/settings/sms',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  smsSettingsRoutes
-)
-router.use(
-  '/settings/telegram',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  telegramSettingsRoutes
-)
-router.use(
-  '/settings',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  settingsRoutes
-)
-
-router.use(
-  '/transactional/sms',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  smsTransactionalRoutes
-)
-
-router.use(
-  '/transactional/email',
-  AuthMiddleware.isCookieOrApiKeyAuthenticated,
-  emailTransactionalRoutes
-)
-
-router.use('/callback/email', emailCallbackRoutes)
-
-router.use('/callback/sms', smsCallbackRoutes)
-
-router.use('/callback/telegram', telegramCallbackRoutes)
-export default router

--- a/backend/src/core/routes/settings.routes.ts
+++ b/backend/src/core/routes/settings.routes.ts
@@ -4,231 +4,235 @@ import { celebrate, Joi, Segments } from 'celebrate'
 
 import { SettingsMiddleware } from '@core/middlewares'
 
-const router = Router()
+export const InitSettingsRoute = (
+  settingsMiddleware: SettingsMiddleware
+): Router => {
+  const router = Router()
 
-const deleteCredentialValidator = {
-  [Segments.BODY]: Joi.object({
-    label: Joi.string().required(),
-  }),
+  const deleteCredentialValidator = {
+    [Segments.BODY]: Joi.object({
+      label: Joi.string().required(),
+    }),
+  }
+
+  const getCredentialsValidator = {
+    [Segments.PARAMS]: Joi.object({
+      channelType: Joi.string()
+        .uppercase()
+        .valid(ChannelType.SMS, ChannelType.Telegram)
+        .required(),
+    }),
+  }
+
+  const demoDisplayedValidator = {
+    [Segments.BODY]: Joi.object({
+      is_displayed: Joi.boolean().required(),
+    }),
+  }
+
+  // The version has to be a SHA-256 hash written in base64.
+  const updateAnnouncementVersionValidator = {
+    [Segments.BODY]: Joi.object({
+      announcement_version: Joi.string().base64().length(44).required(),
+    }),
+  }
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings:
+   *    get:
+   *      summary: Retrieve stored settings for user
+   *      tags:
+   *        - Settings
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  has_api_key:
+   *                    type: boolean
+   *                  creds:
+   *                    type: array
+   *                    items:
+   *                      type: object
+   *                      properties:
+   *                        label:
+   *                          type: string
+   *                        type:
+   *                          $ref: '#/components/schemas/ChannelType'
+   *
+   */
+  router.get('/', settingsMiddleware.getUserSettings)
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/regen:
+   *    post:
+   *      summary: Regenerates api key
+   *      tags:
+   *        - Settings
+   *
+   *      responses:
+   *        200:
+   *          description: Success
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   api_key:
+   *                     type: string
+   *
+   */
+  router.post('/regen', settingsMiddleware.regenerateApiKey)
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/credentials:
+   *    delete:
+   *      summary: Deletes stored credential for user
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                label:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request
+   *
+   */
+  router.delete(
+    '/credentials',
+    celebrate(deleteCredentialValidator),
+    settingsMiddleware.deleteUserCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/{channelType}/credentials:
+   *    get:
+   *      summary: Retrieve channel specific credentials for user
+   *      tags:
+   *        - Settings
+   *      parameters:
+   *        - name: channelType
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *            enum: [SMS, TELEGRAM]
+   *
+   *      responses:
+   *        "200":
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: array
+   *                items:
+   *                  type: string
+   *
+   */
+  router.get(
+    '/:channelType/credentials',
+    celebrate(getCredentialsValidator),
+    settingsMiddleware.getChannelSpecificCredentials
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/demo:
+   *    put:
+   *       tags:
+   *         - Settings
+   *       summary: Update whether to display demos
+   *       requestBody:
+   *         required: true
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 is_displayed:
+   *                   type: boolean
+   *       responses:
+   *         "200":
+   *           description: Success
+   *           content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  is_displayed:
+   *                    type: boolean
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.put(
+    '/demo',
+    celebrate(demoDisplayedValidator),
+    settingsMiddleware.updateDemoDisplayed
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/announcement-version:
+   *    put:
+   *       tags:
+   *         - Settings
+   *       summary: Update announcement version for this user
+   *       requestBody:
+   *         required: true
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 announcement_version:
+   *                   type: string
+   *       responses:
+   *         "200":
+   *           description: Success
+   *           content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  announcement_version:
+   *                    type: number
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.put(
+    '/announcement-version',
+    celebrate(updateAnnouncementVersionValidator),
+    settingsMiddleware.updateAnnouncementVersion
+  )
+
+  return router
 }
-
-const getCredentialsValidator = {
-  [Segments.PARAMS]: Joi.object({
-    channelType: Joi.string()
-      .uppercase()
-      .valid(ChannelType.SMS, ChannelType.Telegram)
-      .required(),
-  }),
-}
-
-const demoDisplayedValidator = {
-  [Segments.BODY]: Joi.object({
-    is_displayed: Joi.boolean().required(),
-  }),
-}
-
-// The version has to be a SHA-256 hash written in base64.
-const updateAnnouncementVersionValidator = {
-  [Segments.BODY]: Joi.object({
-    announcement_version: Joi.string().base64().length(44).required(),
-  }),
-}
-
-/**
- * @swagger
- * paths:
- *  /settings:
- *    get:
- *      summary: Retrieve stored settings for user
- *      tags:
- *        - Settings
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  has_api_key:
- *                    type: boolean
- *                  creds:
- *                    type: array
- *                    items:
- *                      type: object
- *                      properties:
- *                        label:
- *                          type: string
- *                        type:
- *                          $ref: '#/components/schemas/ChannelType'
- *
- */
-router.get('/', SettingsMiddleware.getUserSettings)
-
-/**
- * @swagger
- * paths:
- *  /settings/regen:
- *    post:
- *      summary: Regenerates api key
- *      tags:
- *        - Settings
- *
- *      responses:
- *        200:
- *          description: Success
- *          content:
- *             application/json:
- *               schema:
- *                 type: object
- *                 properties:
- *                   api_key:
- *                     type: string
- *
- */
-router.post('/regen', SettingsMiddleware.regenerateApiKey)
-
-/**
- * @swagger
- * paths:
- *  /settings/credentials:
- *    delete:
- *      summary: Deletes stored credential for user
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                label:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request
- *
- */
-router.delete(
-  '/credentials',
-  celebrate(deleteCredentialValidator),
-  SettingsMiddleware.deleteUserCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/{channelType}/credentials:
- *    get:
- *      summary: Retrieve channel specific credentials for user
- *      tags:
- *        - Settings
- *      parameters:
- *        - name: channelType
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *            enum: [SMS, TELEGRAM]
- *
- *      responses:
- *        "200":
- *          content:
- *            application/json:
- *              schema:
- *                type: array
- *                items:
- *                  type: string
- *
- */
-router.get(
-  '/:channelType/credentials',
-  celebrate(getCredentialsValidator),
-  SettingsMiddleware.getChannelSpecificCredentials
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/demo:
- *    put:
- *       tags:
- *         - Settings
- *       summary: Update whether to display demos
- *       requestBody:
- *         required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 is_displayed:
- *                   type: boolean
- *       responses:
- *         "200":
- *           description: Success
- *           content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  is_displayed:
- *                    type: boolean
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "500":
- *           description: Internal Server Error
- */
-router.put(
-  '/demo',
-  celebrate(demoDisplayedValidator),
-  SettingsMiddleware.updateDemoDisplayed
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/announcement-version:
- *    put:
- *       tags:
- *         - Settings
- *       summary: Update announcement version for this user
- *       requestBody:
- *         required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 announcement_version:
- *                   type: string
- *       responses:
- *         "200":
- *           description: Success
- *           content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  announcement_version:
- *                    type: number
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "500":
- *           description: Internal Server Error
- */
-router.put(
-  '/announcement-version',
-  celebrate(updateAnnouncementVersionValidator),
-  SettingsMiddleware.updateAnnouncementVersion
-)
-
-export default router

--- a/backend/src/core/routes/tests/campaign.routes.test.ts
+++ b/backend/src/core/routes/tests/campaign.routes.test.ts
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Campaign, User, UserDemo } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 import { ChannelType } from '@core/constants'
 
 const app = initialiseServer(true)
@@ -22,8 +22,7 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
   await UploadService.destroyUploadQueue()
-  RedisService.otpClient.quit()
-  RedisService.sessionClient.quit()
+  await (app as any).cleanup()
 })
 
 describe('GET /campaigns', () => {

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -9,286 +9,307 @@ import { RedisService, ApiKeyService, MailService } from '@core/services'
 import { HashedOtp, VerifyOtpInput } from '@core/interfaces'
 import { Transaction } from 'sequelize/types'
 
-const logger = loggerWithLabel(module)
-const SALT_ROUNDS = 10 // bcrypt default
-const {
-  retries: OTP_RETRIES,
-  expiry: OTP_EXPIRY,
-  resendTimeout: OTP_RESEND_TIMEOUT,
-} = config.get('otp')
-
-/**
- * Generate a six digit otp
- */
-const generateOtp = (): string => {
-  return authenticator.generate(authenticator.generateSecret())
+export interface AuthService {
+  canSendOtp(email: string): Promise<void>
+  sendOtp(email: string, ipAddress: string): Promise<string | void>
+  verifyOtp(input: VerifyOtpInput): Promise<boolean>
+  findOrCreateUser(email: string): Promise<User>
+  findUser(id: number): Promise<User>
+  checkCookie(req: Request): boolean
+  getUserForApiKey(req: Request): Promise<User | null>
 }
 
-/**
- * Save hashed otp against the user's email
- * @param email
- * @param hashedOtp
- */
-const saveHashedOtp = (
-  email: string,
-  hashedOtp: HashedOtp
-): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    RedisService.otpClient.set(
-      email,
-      JSON.stringify(hashedOtp),
-      'EX',
-      OTP_EXPIRY,
-      (error) => {
+export const InitAuthService = (redisService: RedisService): AuthService => {
+  const logger = loggerWithLabel(module)
+  const SALT_ROUNDS = 10 // bcrypt default
+  const {
+    retries: OTP_RETRIES,
+    expiry: OTP_EXPIRY,
+    resendTimeout: OTP_RESEND_TIMEOUT,
+  } = config.get('otp')
+
+  /**
+   * Generate a six digit otp
+   */
+  const generateOtp = (): string => {
+    return authenticator.generate(authenticator.generateSecret())
+  }
+
+  /**
+   * Save hashed otp against the user's email
+   * @param email
+   * @param hashedOtp
+   */
+  const saveHashedOtp = (
+    email: string,
+    hashedOtp: HashedOtp
+  ): Promise<boolean> => {
+    return new Promise((resolve, reject) => {
+      redisService.otpClient.set(
+        email,
+        JSON.stringify(hashedOtp),
+        'EX',
+        OTP_EXPIRY,
+        (error) => {
+          if (error) {
+            logger.error({
+              message: 'Failed to save hashed otp',
+              email,
+              error,
+              action: 'saveHashedOtp',
+            })
+            reject(error)
+          }
+          resolve(true)
+        }
+      )
+    })
+  }
+
+  /**
+   * Get the hashed otp that was saved against the user's email
+   * @param email
+   */
+  const getHashedOtp = (email: string): Promise<HashedOtp> => {
+    const logMeta = { email, action: 'getHashedOtp' }
+    return new Promise((resolve, reject) => {
+      redisService.otpClient.get(email, (error, value) => {
         if (error) {
           logger.error({
-            message: 'Failed to save hashed otp',
+            message: 'Failed to get hashed otp',
+            error,
+            ...logMeta,
+          })
+          reject(new Error('Internal server error - request for otp again'))
+        }
+        if (value === null) {
+          reject(new Error('OTP has expired. Please request for a new OTP.'))
+        }
+        resolve(JSON.parse(value))
+      })
+    })
+  }
+
+  /**
+   * Delete the hashed otp that was saved against the user's email
+   * @param email
+   */
+  const deleteHashedOtp = async (email: string): Promise<boolean> => {
+    return new Promise((resolve, reject) => {
+      redisService.otpClient.del(email, (error, response) => {
+        if (error || response !== 1) {
+          logger.error({
+            message: 'Failed to delete hashed otp',
             email,
             error,
-            action: 'saveHashedOtp',
+            response,
+            action: 'deleteHashedOtp',
           })
           reject(error)
         }
         resolve(true)
+      })
+    })
+  }
+
+  /**
+   * Checks that sufficient time has elapsed since the last send of an otp for that email
+   * @param email
+   */
+  const hasWaitTimeElapsed = async (email: string): Promise<void> => {
+    const existingHash: HashedOtp | null = await getHashedOtp(email).catch(
+      () => {
+        // If there is no hash, just proceed
+        return null
       }
     )
-  })
-}
 
-/**
- * Get the hashed otp that was saved against the user's email
- * @param email
- */
-const getHashedOtp = (email: string): Promise<HashedOtp> => {
-  const logMeta = { email, action: 'getHashedOtp' }
-  return new Promise((resolve, reject) => {
-    RedisService.otpClient.get(email, (error, value) => {
-      if (error) {
-        logger.error({ message: 'Failed to get hashed otp', error, ...logMeta })
-        reject(new Error('Internal server error - request for otp again'))
-      }
-      if (value === null) {
-        reject(new Error('OTP has expired. Please request for a new OTP.'))
-      }
-      resolve(JSON.parse(value))
-    })
-  })
-}
-
-/**
- * Delete the hashed otp that was saved against the user's email
- * @param email
- */
-const deleteHashedOtp = async (email: string): Promise<boolean> => {
-  return new Promise((resolve, reject) => {
-    RedisService.otpClient.del(email, (error, response) => {
-      if (error || response !== 1) {
-        logger.error({
-          message: 'Failed to delete hashed otp',
-          email,
-          error,
-          response,
-          action: 'deleteHashedOtp',
-        })
-        reject(error)
-      }
-      resolve(true)
-    })
-  })
-}
-
-/**
- * Checks that sufficient time has elapsed since the last send of an otp for that email
- * @param email
- */
-const hasWaitTimeElapsed = async (email: string): Promise<void> => {
-  const existingHash: HashedOtp | null = await getHashedOtp(email).catch(() => {
-    // If there is no hash, just proceed
-    return null
-  })
-
-  // Check that at least WAIT_IN_SECONDS has elapsed before allowing the resend of a new otp
-  if (existingHash) {
-    const remainingTime = Math.ceil(
-      (existingHash.createdAt +
-        OTP_RESEND_TIMEOUT * 1000 -
-        new Date().getTime()) /
-        1000
-    )
-    if (remainingTime > 0)
-      throw new Error(
-        `Wait for ${remainingTime} seconds before requesting for a new otp`
+    // Check that at least WAIT_IN_SECONDS has elapsed before allowing the resend of a new otp
+    if (existingHash) {
+      const remainingTime = Math.ceil(
+        (existingHash.createdAt +
+          OTP_RESEND_TIMEOUT * 1000 -
+          new Date().getTime()) /
+          1000
       )
+      if (remainingTime > 0)
+        throw new Error(
+          `Wait for ${remainingTime} seconds before requesting for a new otp`
+        )
+    }
   }
-}
 
-/**
- * Checks that email belongs to a whitelisted domain, or has been inserted manually in the database
- * @param email
- */
-const isWhitelistedEmail = async (email: string): Promise<boolean> => {
-  const endsInWhitelistedDomain = await validateDomain(email)
-  if (!endsInWhitelistedDomain) {
-    // If the email does not end in a whitelisted domain, check that it was  whitelisted by us manually
-    const user = await User.findOne({ where: { email: email } })
-    if (user === null) throw new Error('User is not authorized')
+  /**
+   * Checks that email belongs to a whitelisted domain, or has been inserted manually in the database
+   * @param email
+   */
+  const isWhitelistedEmail = async (email: string): Promise<boolean> => {
+    const endsInWhitelistedDomain = await validateDomain(email)
+    if (!endsInWhitelistedDomain) {
+      // If the email does not end in a whitelisted domain, check that it was  whitelisted by us manually
+      const user = await User.findOne({ where: { email: email } })
+      if (user === null) throw new Error('User is not authorized')
+    }
+    return true
   }
-  return true
-}
 
-/**
- * Extracts api key from Authorization bearer token
- * @param req
- */
-const getApiKey = (req: Request): string | null => {
-  const headerKey = 'Bearer'
-  const authHeader = req.get('authorization')
-  if (!authHeader) return null
+  /**
+   * Extracts api key from Authorization bearer token
+   * @param req
+   */
+  const getApiKey = (req: Request): string | null => {
+    const headerKey = 'Bearer'
+    const authHeader = req.get('authorization')
+    if (!authHeader) return null
 
-  const [header, apiKey] = authHeader.split(' ')
-  if (headerKey !== header) return null
+    const [header, apiKey] = authHeader.split(' ')
+    if (headerKey !== header) return null
 
-  const [name, version, key] = apiKey.split('_')
-  if (!name || !version || !key) return null
+    const [name, version, key] = apiKey.split('_')
+    if (!name || !version || !key) return null
 
-  return apiKey
-}
-
-/**
- * Finds if the supplied api key is associated with a user
- * @param req
- */
-const getUserForApiKey = async (req: Request): Promise<User | null> => {
-  const apiKey = getApiKey(req)
-  if (apiKey !== null) {
-    const hash = await ApiKeyService.getApiKeyHash(apiKey)
-    const user = await User.findOne({
-      where: { apiKey: hash },
-      attributes: ['id', 'email'],
-    })
-    return user
+    return apiKey
   }
-  return null
-}
 
-/**
- * Checks that a valid cookie has been sent with  the request
- * @param req
- */
-const checkCookie = (req: Request): boolean => {
-  return req.session?.user?.id !== undefined
-}
-
-/**
- * Checks whether to send an otp to the email
- * @param email
- * @throws error if email is not whitelisted, or user has to wait for some time before requesting an otp
- */
-const canSendOtp = async (email: string): Promise<void> => {
-  await isWhitelistedEmail(email)
-  await hasWaitTimeElapsed(email)
-}
-
-/**
- * Sends an email containing the otp to the user
- * @param email
- * @param ipAddress originating IP address that requests for OTP.
- */
-const sendOtp = async (
-  email: string,
-  ipAddress: string
-): Promise<string | void> => {
-  const otp = generateOtp()
-  const hashValue = await bcrypt.hash(otp, SALT_ROUNDS)
-  const hashedOtp: HashedOtp = {
-    hash: hashValue,
-    retries: OTP_RETRIES,
-    createdAt: Date.now(),
+  /**
+   * Finds if the supplied api key is associated with a user
+   * @param req
+   */
+  const getUserForApiKey = async (req: Request): Promise<User | null> => {
+    const apiKey = getApiKey(req)
+    if (apiKey !== null) {
+      const hash = await ApiKeyService.getApiKeyHash(apiKey)
+      const user = await User.findOne({
+        where: { apiKey: hash },
+        attributes: ['id', 'email'],
+      })
+      return user
+    }
+    return null
   }
-  await saveHashedOtp(email, hashedOtp)
 
-  const appName = config.get('APP_NAME')
-  return MailService.mailClient.sendMail({
-    from: config.get('mailFrom'),
-    recipients: [email],
-    subject: `One-Time Password (OTP) for ${appName}`,
-    body: `Your OTP is <b>${otp}</b>. It will expire in ${Math.floor(
-      OTP_EXPIRY / 60
-    )} minutes.
+  /**
+   * Checks that a valid cookie has been sent with  the request
+   * @param req
+   */
+  const checkCookie = (req: Request): boolean => {
+    return req.session?.user?.id !== undefined
+  }
+
+  /**
+   * Checks whether to send an otp to the email
+   * @param email
+   * @throws error if email is not whitelisted, or user has to wait for some time before requesting an otp
+   */
+  const canSendOtp = async (email: string): Promise<void> => {
+    await isWhitelistedEmail(email)
+    await hasWaitTimeElapsed(email)
+  }
+
+  /**
+   * Sends an email containing the otp to the user
+   * @param email
+   * @param ipAddress originating IP address that requests for OTP.
+   */
+  const sendOtp = async (
+    email: string,
+    ipAddress: string
+  ): Promise<string | void> => {
+    const otp = generateOtp()
+    const hashValue = await bcrypt.hash(otp, SALT_ROUNDS)
+    const hashedOtp: HashedOtp = {
+      hash: hashValue,
+      retries: OTP_RETRIES,
+      createdAt: Date.now(),
+    }
+    await saveHashedOtp(email, hashedOtp)
+
+    const appName = config.get('APP_NAME')
+    return MailService.mailClient.sendMail({
+      from: config.get('mailFrom'),
+      recipients: [email],
+      subject: `One-Time Password (OTP) for ${appName}`,
+      body: `Your OTP is <b>${otp}</b>. It will expire in ${Math.floor(
+        OTP_EXPIRY / 60
+      )} minutes.
     Please use this to login to your ${appName} account. <p>If your OTP does not work, please request for a new OTP.</p>
     <p>This login attempt was made from the IP: ${ipAddress}. If you did not attempt to log in to ${appName}, you may choose to investigate this IP address further.</p>
     <p>The ${appName} Support Team</p>`,
-  })
-}
+    })
+  }
 
-/**
- *  Checks that user's otp input is correct, and authorizes them if so.
- * @param input
- */
-const verifyOtp = async (input: VerifyOtpInput): Promise<boolean> => {
-  const logMeta = { email: input.email, action: 'verifyOtp' }
-  try {
-    const hashedOtp: HashedOtp = await getHashedOtp(input.email)
-    const authorized: boolean = await bcrypt.compare(input.otp, hashedOtp.hash)
-    if (authorized) {
-      await deleteHashedOtp(input.email)
-      return true
-    }
-    hashedOtp.retries -= 1
-    // if there is at least 1 retry, save the hashedOtp
-    if (hashedOtp.retries > 0) {
-      await saveHashedOtp(input.email, hashedOtp)
-    } else {
-      await deleteHashedOtp(input.email)
-      logger.info({
-        message: 'No otp retries left, deleting otp',
+  /**
+   *  Checks that user's otp input is correct, and authorizes them if so.
+   * @param input
+   */
+  const verifyOtp = async (input: VerifyOtpInput): Promise<boolean> => {
+    const logMeta = { email: input.email, action: 'verifyOtp' }
+    try {
+      const hashedOtp: HashedOtp = await getHashedOtp(input.email)
+      const authorized: boolean = await bcrypt.compare(
+        input.otp,
+        hashedOtp.hash
+      )
+      if (authorized) {
+        await deleteHashedOtp(input.email)
+        return true
+      }
+      hashedOtp.retries -= 1
+      // if there is at least 1 retry, save the hashedOtp
+      if (hashedOtp.retries > 0) {
+        await saveHashedOtp(input.email, hashedOtp)
+      } else {
+        await deleteHashedOtp(input.email)
+        logger.info({
+          message: 'No otp retries left, deleting otp',
+          ...logMeta,
+        })
+      }
+      return false
+    } catch (e) {
+      logger.error({
+        message: 'Error occured while verifying otp',
+        error: e,
         ...logMeta,
       })
+      return false
     }
-    return false
-  } catch (e) {
-    logger.error({
-      message: 'Error occured while verifying otp',
-      error: e,
-      ...logMeta,
-    })
-    return false
   }
-}
 
-/**
- * Helper method to find or create a user by their email
- * @param email
- */
-const findOrCreateUser = async (email: string): Promise<User> => {
-  const result = await User.sequelize?.transaction(async (t: Transaction) => {
-    const [user] = await User.findOrCreate({
-      where: { email: email },
-      transaction: t,
+  /**
+   * Helper method to find or create a user by their email
+   * @param email
+   */
+  const findOrCreateUser = async (email: string): Promise<User> => {
+    const result = await User.sequelize?.transaction(async (t: Transaction) => {
+      const [user] = await User.findOrCreate({
+        where: { email: email },
+        transaction: t,
+      })
+      return user
     })
-    return user
-  })
-  if (!result) throw new Error('Unable to find or create user')
+    if (!result) throw new Error('Unable to find or create user')
 
-  return result
-}
+    return result
+  }
 
-/**
- * Helper method to find a user by their id
- * @param id
- */
-const findUser = (id: number): Promise<User> => {
-  return User.findOne({
-    where: { id },
-  })
-}
+  /**
+   * Helper method to find a user by their id
+   * @param id
+   */
+  const findUser = (id: number): Promise<User> => {
+    return User.findOne({
+      where: { id },
+    })
+  }
 
-export const AuthService = {
-  canSendOtp,
-  sendOtp,
-  verifyOtp,
-  findOrCreateUser,
-  findUser,
-  checkCookie,
-  getUserForApiKey,
+  return {
+    canSendOtp,
+    sendOtp,
+    verifyOtp,
+    findOrCreateUser,
+    findUser,
+    checkCookie,
+    getUserForApiKey,
+  }
 }

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -12,367 +12,406 @@ import {
 } from '@core/models'
 import { configureEndpoint } from '@core/utils/aws-endpoint'
 import { loggerWithLabel } from '@core/logger'
-import { RedisService } from '@core/services'
 import { TwilioCredentials } from '@sms/interfaces'
 import { UserSettings } from '@core/interfaces'
+import { RedisService } from './redis.service'
 
-const secretsManager = new AWS.SecretsManager(configureEndpoint(config))
-const logger = loggerWithLabel(module)
+export interface CredentialService {
+  // Credentials (cred_name)
+  storeCredential(
+    name: string,
+    secret: string,
+    restrictEnvironment: boolean
+  ): Promise<void>
+  getTwilioCredentials(name: string): Promise<TwilioCredentials>
+  getTelegramCredential(name: string): Promise<string>
+  // User credentials (user - label - cred_name)
+  createUserCredential(
+    label: string,
+    type: ChannelType,
+    credName: string,
+    userId: number
+  ): Promise<UserCredential>
+  deleteUserCredential(userId: number, label: string): Promise<number>
+  getUserCredential(userId: number, label: string): Promise<UserCredential>
+  getSmsUserCredentialLabels(userId: number): Promise<string[]>
+  getTelegramUserCredentialLabels(userId: number): Promise<string[]>
+  getUserSettings(userId: number): Promise<UserSettings | null>
+  // Api Key
+  regenerateApiKey(userId: number): Promise<string>
+  // User metadata
+  updateDemoDisplayed(
+    userId: number,
+    isDisplayed: boolean
+  ): Promise<{ isDisplayed: boolean }>
+  updateAnnouncementVersion(
+    userId: number,
+    announcementVersion: string
+  ): Promise<{ announcementVersion: string }>
+}
 
-/**
- * Upserts credential into AWS SecretsManager
- * @param name
- * @param secret
- * @param restrictEnvironment
- * @throws error if update fails
- */
-const upsertCredential = async (
-  name: string,
-  secret: string,
-  restrictEnvironment: boolean
-): Promise<void> => {
-  const logMeta = { name, action: 'upsertCredential' }
-  // If credential doesn't exist, upload credential to secret manager
-  try {
-    await secretsManager
-      .createSecret({
-        Name: name,
-        SecretString: secret,
-        ...(restrictEnvironment
-          ? { Tags: [{ Key: 'environment', Value: config.get('env') }] }
-          : {}),
-      })
-      .promise()
-    logger.info({
-      message: 'Successfully stored credential in AWS secrets manager',
-      ...logMeta,
-    })
-  } catch (err) {
-    if (err.name === 'ResourceExistsException') {
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const InitCredentialService = (redisService: RedisService) => {
+  const secretsManager = new AWS.SecretsManager(configureEndpoint(config))
+  const logger = loggerWithLabel(module)
+
+  /**
+   * Upserts credential into AWS SecretsManager
+   * @param name
+   * @param secret
+   * @param restrictEnvironment
+   * @throws error if update fails
+   */
+  const upsertCredential = async (
+    name: string,
+    secret: string,
+    restrictEnvironment: boolean
+  ): Promise<void> => {
+    const logMeta = { name, action: 'upsertCredential' }
+    // If credential doesn't exist, upload credential to secret manager
+    try {
       await secretsManager
-        .putSecretValue({
-          SecretId: name,
+        .createSecret({
+          Name: name,
           SecretString: secret,
+          ...(restrictEnvironment
+            ? { Tags: [{ Key: 'environment', Value: config.get('env') }] }
+            : {}),
         })
         .promise()
       logger.info({
-        message: 'Successfully updated credential in AWS secrets manager',
-        error: err,
+        message: 'Successfully stored credential in AWS secrets manager',
         ...logMeta,
       })
-    } else {
-      logger.error({
-        message: 'Failed to store credential in AWS secrets manager',
-        error: err,
-        ...logMeta,
-      })
-      throw err
-    }
-  }
-  return
-}
-
-/**
- * Save a credential into secrets manager and the credential table
- * @param name
- * @param secret
- * @param restrictEnvironment
- */
-const storeCredential = async (
-  name: string,
-  secret: string,
-  restrictEnvironment = false
-): Promise<void> => {
-  const logMeta = { name, action: 'storeCredential' }
-  // If adding a credential to secrets manager throws an error, db will not be updated
-  // If adding a credential to secrets manager succeeds, but the db call fails, it is ok because the credential will not be associated with a campaign
-  // It results in orphan secrets manager credentials, which is acceptable.
-  await upsertCredential(name, secret, restrictEnvironment)
-  await Credential.findCreateFind({
-    where: { name },
-  })
-  logger.info({ message: 'Successfully stored credential in DB', ...logMeta })
-}
-
-/**
- * Retrieve a credential from secrets manager
- * @param name
- */
-const getTwilioCredentials = (name: string): Promise<TwilioCredentials> => {
-  const logMeta = { name, action: 'getTwilioCredentials' }
-
-  return new Promise((resolve, reject) => {
-    RedisService.credentialClient.get(name, async (error, value) => {
-      if (error || value === null) {
-        const data = await secretsManager
-          .getSecretValue({ SecretId: name })
+    } catch (err) {
+      if (err.name === 'ResourceExistsException') {
+        await secretsManager
+          .putSecretValue({
+            SecretId: name,
+            SecretString: secret,
+          })
           .promise()
         logger.info({
-          message: 'Retrieved secret from AWS secrets manager.',
+          message: 'Successfully updated credential in AWS secrets manager',
+          error: err,
           ...logMeta,
         })
-
-        if (!data?.SecretString) {
-          reject(new Error('Missing secret string from AWS secrets manager.'))
-          return
-        }
-        value = data?.SecretString
-
-        RedisService.credentialClient.set(
-          name,
-          value,
-          'PX',
-          config.get('twilioCredentialCache.maxAge'),
-          (error) => {
-            if (error) {
-              logger.error({
-                message: 'Failed to save Twilio credential',
-                error,
-                ...logMeta,
-              })
-            }
-          }
-        )
+      } else {
+        logger.error({
+          message: 'Failed to store credential in AWS secrets manager',
+          error: err,
+          ...logMeta,
+        })
+        throw err
       }
-      resolve(JSON.parse(value))
-    })
-  })
-}
-
-/**
- * Retrieve Telegram credentials from secrets manager
- * @param name
- */
-const getTelegramCredential = async (name: string): Promise<string> => {
-  const logMeta = { name, action: 'getTelegramCredential' }
-  const data = await secretsManager.getSecretValue({ SecretId: name }).promise()
-  logger.info({
-    message: 'Retrieved secret from AWS secrets manager.',
-    ...logMeta,
-  })
-  const secretString = get(data, 'SecretString', '')
-  if (!secretString) {
-    throw new Error('Missing secret string from AWS secrets manager.')
+    }
+    return
   }
-  return secretString
-}
 
-/**
- * Creates a label for the credential, associated with a user
- * @param label
- * @param type
- * @param credName
- * @param userId
- */
-const createUserCredential = (
-  label: string,
-  type: ChannelType,
-  credName: string,
-  userId: number
-): Promise<UserCredential> => {
-  return UserCredential.create({
-    label,
-    type,
-    credName,
-    userId,
-  })
-}
+  /**
+   * Save a credential into secrets manager and the credential table
+   * @param name
+   * @param secret
+   * @param restrictEnvironment
+   */
+  const storeCredential = async (
+    name: string,
+    secret: string,
+    restrictEnvironment = false
+  ): Promise<void> => {
+    const logMeta = { name, action: 'storeCredential' }
+    // If adding a credential to secrets manager throws an error, db will not be updated
+    // If adding a credential to secrets manager succeeds, but the db call fails, it is ok because the credential will not be associated with a campaign
+    // It results in orphan secrets manager credentials, which is acceptable.
+    await upsertCredential(name, secret, restrictEnvironment)
+    await Credential.findCreateFind({
+      where: { name },
+    })
+    logger.info({ message: 'Successfully stored credential in DB', ...logMeta })
+  }
 
-/**
- * Deletes the credential label for a user
- * @param userId
- * @param label
- */
-const deleteUserCredential = (
-  userId: number,
-  label: string
-): Promise<number> => {
-  return UserCredential.destroy({
-    where: {
-      userId,
+  /**
+   * Retrieve a credential from secrets manager
+   * @param name
+   */
+  const getTwilioCredentials = (name: string): Promise<TwilioCredentials> => {
+    const logMeta = { name, action: 'getTwilioCredentials' }
+
+    return new Promise((resolve, reject) => {
+      redisService.credentialClient.get(name, async (error, value) => {
+        if (error || value === null) {
+          const data = await secretsManager
+            .getSecretValue({ SecretId: name })
+            .promise()
+          logger.info({
+            message: 'Retrieved secret from AWS secrets manager.',
+            ...logMeta,
+          })
+
+          if (!data?.SecretString) {
+            reject(new Error('Missing secret string from AWS secrets manager.'))
+            return
+          }
+          value = data?.SecretString
+
+          redisService.credentialClient.set(
+            name,
+            value,
+            'PX',
+            config.get('twilioCredentialCache.maxAge'),
+            (error) => {
+              if (error) {
+                logger.error({
+                  message: 'Failed to save Twilio credential',
+                  error,
+                  ...logMeta,
+                })
+              }
+            }
+          )
+        }
+        resolve(JSON.parse(value))
+      })
+    })
+  }
+
+  /**
+   * Retrieve Telegram credentials from secrets manager
+   * @param name
+   */
+  const getTelegramCredential = async (name: string): Promise<string> => {
+    const logMeta = { name, action: 'getTelegramCredential' }
+    const data = await secretsManager
+      .getSecretValue({ SecretId: name })
+      .promise()
+    logger.info({
+      message: 'Retrieved secret from AWS secrets manager.',
+      ...logMeta,
+    })
+    const secretString = get(data, 'SecretString', '')
+    if (!secretString) {
+      throw new Error('Missing secret string from AWS secrets manager.')
+    }
+    return secretString
+  }
+
+  /**
+   * Creates a label for the credential, associated with a user
+   * @param label
+   * @param type
+   * @param credName
+   * @param userId
+   */
+  const createUserCredential = (
+    label: string,
+    type: ChannelType,
+    credName: string,
+    userId: number
+  ): Promise<UserCredential> => {
+    return UserCredential.create({
       label,
-    },
-  })
-}
-
-/**
- * Checks if a user already has this credential label associated with them
- * @param userId
- * @param label
- */
-const getUserCredential = (
-  userId: number,
-  label: string
-): Promise<UserCredential> => {
-  return UserCredential.findOne({
-    where: {
+      type,
+      credName,
       userId,
-      label,
-    },
-    attributes: ['credName'],
-  })
-}
+    })
+  }
 
-/**
- * Gets only the sms credential labels for that user
- * @param userId
- */
-const getSmsUserCredentialLabels = async (
-  userId: number
-): Promise<string[]> => {
-  const creds = await UserCredential.findAll({
-    where: {
-      type: ChannelType.SMS,
-      userId: userId,
-    },
-    attributes: ['label'],
-  })
-  return creds.map((c) => c.label)
-}
+  /**
+   * Deletes the credential label for a user
+   * @param userId
+   * @param label
+   */
+  const deleteUserCredential = (
+    userId: number,
+    label: string
+  ): Promise<number> => {
+    return UserCredential.destroy({
+      where: {
+        userId,
+        label,
+      },
+    })
+  }
 
-/**
- * Gets only the telegram credential labels for that user
- * @param userId
- */
-const getTelegramUserCredentialLabels = async (
-  userId: number
-): Promise<string[]> => {
-  const creds = await UserCredential.findAll({
-    where: {
-      type: ChannelType.Telegram,
-      userId: userId,
-    },
-    attributes: ['label'],
-  })
-  return creds.map((c) => c.label)
-}
+  /**
+   * Checks if a user already has this credential label associated with them
+   * @param userId
+   * @param label
+   */
+  const getUserCredential = (
+    userId: number,
+    label: string
+  ): Promise<UserCredential> => {
+    return UserCredential.findOne({
+      where: {
+        userId,
+        label,
+      },
+      attributes: ['credName'],
+    })
+  }
 
-/**
- * Gets api keys and credential labels for that user
- * @param userId
- */
-// TODO: refactor demo and announcement version features out
-const getUserSettings = async (
-  userId: number
-): Promise<UserSettings | null> => {
-  const user = await User.findOne({
-    where: {
-      id: userId,
-    },
-    attributes: ['apiKey'],
-    // include as 'creds'
-    include: [
-      {
-        model: UserCredential,
-        attributes: ['label', 'type'],
+  /**
+   * Gets only the sms credential labels for that user
+   * @param userId
+   */
+  const getSmsUserCredentialLabels = async (
+    userId: number
+  ): Promise<string[]> => {
+    const creds = await UserCredential.findAll({
+      where: {
+        type: ChannelType.SMS,
+        userId: userId,
       },
-      {
-        model: UserDemo,
-        attributes: [
-          ['num_demos_sms', 'numDemosSms'],
-          ['num_demos_telegram', 'numDemosTelegram'],
-          ['is_displayed', 'isDisplayed'],
-        ],
+      attributes: ['label'],
+    })
+    return creds.map((c) => c.label)
+  }
+
+  /**
+   * Gets only the telegram credential labels for that user
+   * @param userId
+   */
+  const getTelegramUserCredentialLabels = async (
+    userId: number
+  ): Promise<string[]> => {
+    const creds = await UserCredential.findAll({
+      where: {
+        type: ChannelType.Telegram,
+        userId: userId,
       },
-      {
-        model: UserFeature,
-        attributes: [['announcement_version', 'announcementVersion']],
+      attributes: ['label'],
+    })
+    return creds.map((c) => c.label)
+  }
+
+  /**
+   * Gets api keys and credential labels for that user
+   * @param userId
+   */
+  // TODO: refactor demo and announcement version features out
+  const getUserSettings = async (
+    userId: number
+  ): Promise<UserSettings | null> => {
+    const user = await User.findOne({
+      where: {
+        id: userId,
       },
-    ],
-    plain: true,
-  })
-  if (user) {
+      attributes: ['apiKey'],
+      // include as 'creds'
+      include: [
+        {
+          model: UserCredential,
+          attributes: ['label', 'type'],
+        },
+        {
+          model: UserDemo,
+          attributes: [
+            ['num_demos_sms', 'numDemosSms'],
+            ['num_demos_telegram', 'numDemosTelegram'],
+            ['is_displayed', 'isDisplayed'],
+          ],
+        },
+        {
+          model: UserFeature,
+          attributes: [['announcement_version', 'announcementVersion']],
+        },
+      ],
+      plain: true,
+    })
+    if (user) {
+      return {
+        hasApiKey: !!user.apiKey,
+        creds: user.creds,
+        demo: user.demo,
+        userFeature: user.userFeature,
+      }
+    } else {
+      return null
+    }
+  }
+
+  /**
+   * Gnerates an api key for the specified user
+   * @param userId
+   * @throws Error if user is not found
+   */
+  const regenerateApiKey = async (userId: number): Promise<string> => {
+    const user = await User.findByPk(userId)
+    if (!user) {
+      throw new Error('User not found')
+    }
+    return user.regenerateAndSaveApiKey()
+  }
+
+  const updateDemoDisplayed = async (
+    userId: number,
+    isDisplayed: boolean
+  ): Promise<{ isDisplayed: boolean }> => {
+    const [numUpdated, userDemo] = await UserDemo.update(
+      { isDisplayed },
+      {
+        where: { userId },
+        returning: true,
+      }
+    )
+    if (numUpdated !== 1) {
+      logger.error({
+        message: 'Incorrect number of records updated',
+        numUpdated,
+        action: 'updateDemoDisplayed',
+      })
+      throw new Error('Could not update demo displayed')
+    }
     return {
-      hasApiKey: !!user.apiKey,
-      creds: user.creds,
-      demo: user.demo,
-      userFeature: user.userFeature,
+      isDisplayed: userDemo[0].isDisplayed,
     }
-  } else {
-    return null
   }
-}
 
-/**
- * Gnerates an api key for the specified user
- * @param userId
- * @throws Error if user is not found
- */
-const regenerateApiKey = async (userId: number): Promise<string> => {
-  const user = await User.findByPk(userId)
-  if (!user) {
-    throw new Error('User not found')
-  }
-  return user.regenerateAndSaveApiKey()
-}
+  /**
+   * Updates the announcement version for the specified user
+   * @param userId
+   * @param announcementVersion
+   * @throws Error if user is not found
+   */
+  const updateAnnouncementVersion = async (
+    userId: number,
+    announcementVersion: string
+  ): Promise<{ announcementVersion: string }> => {
+    const [rowUpserted] = await UserFeature.upsert(
+      { userId: userId, announcementVersion: announcementVersion },
+      { returning: true }
+    )
 
-const updateDemoDisplayed = async (
-  userId: number,
-  isDisplayed: boolean
-): Promise<{ isDisplayed: boolean }> => {
-  const [numUpdated, userDemo] = await UserDemo.update(
-    { isDisplayed },
-    {
-      where: { userId },
-      returning: true,
+    if (!rowUpserted) {
+      logger.error({
+        message: 'No upserted row returned',
+        action: 'updateAnnouncementVersion',
+      })
+      throw new Error('Could not update announcement version')
     }
-  )
-  if (numUpdated !== 1) {
-    logger.error({
-      message: 'Incorrect number of records updated',
-      numUpdated,
-      action: 'updateDemoDisplayed',
-    })
-    throw new Error('Could not update demo displayed')
-  }
-  return {
-    isDisplayed: userDemo[0].isDisplayed,
-  }
-}
 
-/**
- * Updates the announcement version for the specified user
- * @param userId
- * @param announcementVersion
- * @throws Error if user is not found
- */
-const updateAnnouncementVersion = async (
-  userId: number,
-  announcementVersion: string
-): Promise<{ announcementVersion: string }> => {
-  const [rowUpserted] = await UserFeature.upsert(
-    { userId: userId, announcementVersion: announcementVersion },
-    { returning: true }
-  )
-
-  if (!rowUpserted) {
-    logger.error({
-      message: 'No upserted row returned',
-      action: 'updateAnnouncementVersion',
-    })
-    throw new Error('Could not update announcement version')
+    return {
+      announcementVersion: rowUpserted.announcementVersion,
+    }
   }
 
   return {
-    announcementVersion: rowUpserted.announcementVersion,
+    // Credentials (cred_name)
+    storeCredential,
+    getTwilioCredentials,
+    getTelegramCredential,
+    // User credentials (user - label - cred_name)
+    createUserCredential,
+    deleteUserCredential,
+    getUserCredential,
+    getSmsUserCredentialLabels,
+    getTelegramUserCredentialLabels,
+    getUserSettings,
+    // Api Key
+    regenerateApiKey,
+    // User metadata
+    updateDemoDisplayed,
+    updateAnnouncementVersion,
   }
-}
-
-export const CredentialService = {
-  // Credentials (cred_name)
-  storeCredential,
-  getTwilioCredentials,
-  getTelegramCredential,
-  // User credentials (user - label - cred_name)
-  createUserCredential,
-  deleteUserCredential,
-  getUserCredential,
-  getSmsUserCredentialLabels,
-  getTelegramUserCredentialLabels,
-  getUserSettings,
-  // Api Key
-  regenerateApiKey,
-  // User metadata
-  updateDemoDisplayed,
-  updateAnnouncementVersion,
 }

--- a/backend/src/core/services/redis.service.ts
+++ b/backend/src/core/services/redis.service.ts
@@ -1,121 +1,115 @@
-import redis from 'redis'
+import redis, { RedisClient } from 'redis'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
-
-const logger = loggerWithLabel(module)
 
 if (!config.get('redisOtpUri')) {
   throw new Error('otpClient: redisOtpUri not found')
 }
-
-/**
- * Client to redis cache for storing otps
- */
-const otpClient = redis
-  .createClient({ url: config.get('redisOtpUri') || undefined })
-  .on('connect', () => {
-    logger.info({
-      message: 'otpClient: Connected',
-      url: config.get('redisOtpUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to otpClient',
-      url: config.get('redisOtpUri'),
-      error: String(err),
-    })
-  })
-
 if (!config.get('redisSessionUri')) {
   throw new Error('sessionClient: redisSessionUri not found')
 }
-
-/**
- * Client to redis cache for storing sessions
- */
-const sessionClient = redis
-  .createClient({ url: config.get('redisSessionUri') || undefined })
-  .on('connect', () => {
-    logger.info({
-      message: 'sessionClient: Connected',
-      url: config.get('redisSessionUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to sessionClient',
-      url: config.get('redisSessionUri'),
-      error: String(err),
-    })
-  })
-
 if (!config.get('redisRateLimitUri')) {
   throw new Error('rateLimitClient: redisRateLimitUri not found')
 }
-
-/**
- * Client to redis cache for rate limiting transactional requests
- */
-const rateLimitClient = redis
-  .createClient({
-    enable_offline_queue: false,
-    url: config.get('redisRateLimitUri') || undefined,
-  })
-  .on('connect', () => {
-    logger.info({
-      message: 'rateLimitClient: Connected',
-      url: config.get('redisRateLimitUri'),
-    })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to rateLimitClient',
-      url: config.get('redisRateLimitUri'),
-      error: String(err),
-    })
-  })
-
 if (!config.get('redisCredentialUri')) {
   throw new Error('credentialClient: redisCredentialUri not found')
 }
 
-/**
- * Client to redis cache for storing credentials
- */
-const credentialClient = redis
-  .createClient({
-    url: config.get('redisCredentialUri') || undefined,
-  })
-  .on('connect', () => {
-    logger.info({
-      message: 'credentialClient: Connected',
-      url: config.get('redisCredentialUri'),
+export class RedisService {
+  private logger = loggerWithLabel(module)
+  /**
+   * Client to redis cache for storing otps
+   */
+  public otpClient: RedisClient = redis
+    .createClient({ url: config.get('redisOtpUri') || undefined })
+    .on('connect', () => {
+      this.logger.info({
+        message: 'otpClient: Connected',
+        url: config.get('redisOtpUri'),
+      })
     })
-  })
-  .on('error', (err: Error) => {
-    logger.error({
-      message: 'Failed to connect to credentialClient',
-      url: config.get('redisCredentialUri'),
-      error: String(err),
+    .on('error', (err: Error) => {
+      this.logger.error({
+        message: 'Failed to connect to otpClient',
+        url: config.get('redisOtpUri'),
+        error: String(err),
+      })
     })
-  })
 
-/**
- * Shutdown all redis clients
- */
-const shutdown = async (): Promise<void> => {
-  const clients = [otpClient, sessionClient, rateLimitClient, credentialClient]
-  await Promise.all(
-    clients.map((client) => new Promise((resolve) => client.quit(resolve)))
-  )
-  await new Promise((resolve) => setImmediate(resolve))
-}
+  /**
+   * Client to redis cache for storing sessions
+   */
+  public sessionClient = redis
+    .createClient({ url: config.get('redisSessionUri') || undefined })
+    .on('connect', () => {
+      this.logger.info({
+        message: 'sessionClient: Connected',
+        url: config.get('redisSessionUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      this.logger.error({
+        message: 'Failed to connect to sessionClient',
+        url: config.get('redisSessionUri'),
+        error: String(err),
+      })
+    })
 
-export const RedisService = {
-  otpClient,
-  sessionClient,
-  rateLimitClient,
-  credentialClient,
-  shutdown,
+  /**
+   * Client to redis cache for rate limiting transactional requests
+   */
+  public rateLimitClient = redis
+    .createClient({
+      enable_offline_queue: false,
+      url: config.get('redisRateLimitUri') || undefined,
+    })
+    .on('connect', () => {
+      this.logger.info({
+        message: 'rateLimitClient: Connected',
+        url: config.get('redisRateLimitUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      this.logger.error({
+        message: 'Failed to connect to rateLimitClient',
+        url: config.get('redisRateLimitUri'),
+        error: String(err),
+      })
+    })
+
+  /**
+   * Client to redis cache for storing credentials
+   */
+  public credentialClient = redis
+    .createClient({
+      url: config.get('redisCredentialUri') || undefined,
+    })
+    .on('connect', () => {
+      this.logger.info({
+        message: 'credentialClient: Connected',
+        url: config.get('redisCredentialUri'),
+      })
+    })
+    .on('error', (err: Error) => {
+      this.logger.error({
+        message: 'Failed to connect to credentialClient',
+        url: config.get('redisCredentialUri'),
+        error: String(err),
+      })
+    })
+  /**
+   * Shutdown all redis clients
+   */
+  public async shutdown(): Promise<void> {
+    const clients = [
+      this.otpClient,
+      this.sessionClient,
+      this.rateLimitClient,
+      this.credentialClient,
+    ]
+    await Promise.all(
+      clients.map((client) => new Promise((resolve) => client.quit(resolve)))
+    )
+    await new Promise((resolve) => setImmediate(resolve))
+  }
 }

--- a/backend/src/core/utils/tests/validate-domain.test.ts
+++ b/backend/src/core/utils/tests/validate-domain.test.ts
@@ -1,6 +1,5 @@
 import { Sequelize } from 'sequelize-typescript'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { Domain } from '@core/models'
 import { validateDomain } from '../validate-domain'
 import config from '@core/config'
@@ -17,7 +16,6 @@ afterEach(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('validateDomain', () => {

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import {
   MissingTemplateKeysError,
   HydrationError,
@@ -18,291 +18,305 @@ import { StoreTemplateOutput } from '@email/interfaces'
 import { loggerWithLabel } from '@core/logger'
 import { ThemeClient } from '@shared/theme'
 
-const logger = loggerWithLabel(module)
-
-/**
- * Store template subject and body in email template table.
- * If an existing csv has been uploaded for this campaign but whose columns do not match the attributes provided in the new template,
- * delete the old csv, and prompt user to upload a new csv.
- * @param req
- * @param res
- * @param next
- */
-const storeTemplate = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { campaignId } = req.params
-  const {
-    subject,
-    body,
-    reply_to: replyTo,
-    from,
-    show_logo: showLogo,
-  } = req.body
-  const logMeta = { campaignId, action: 'storeTemplate' }
-  try {
-    const { check, valid, updatedTemplate }: StoreTemplateOutput =
-      await EmailTemplateService.storeTemplate({
-        campaignId: +campaignId,
-        subject,
-        body,
-        replyTo:
-          replyTo || (await AuthService.findUser(req.session?.user?.id))?.email,
-        from,
-        showLogo,
-      })
-
-    const template = {
-      body: updatedTemplate?.body,
-      subject: updatedTemplate?.subject,
-      params: updatedTemplate?.params,
-      reply_to: updatedTemplate?.replyTo,
-      from: updatedTemplate?.from,
-      show_logo: updatedTemplate?.showLogo,
-    }
-
-    if (check?.reupload) {
-      logger.info({
-        message:
-          'Email template has changed, required to re-upload recipient list',
-        ...logMeta,
-      })
-      return res.json({
-        message:
-          'Please re-upload your recipient list as template has changed.',
-        extra_keys: check.extraKeys,
-        num_recipients: 0,
-        valid: false,
-        template,
-      })
-    } else {
-      const numRecipients = await StatsService.getNumRecipients(+campaignId)
-      return res.json({
-        message: `Template for campaign ${campaignId} updated`,
-        valid: valid,
-        num_recipients: numRecipients,
-        template,
-      })
-    }
-  } catch (err) {
-    if (err instanceof HydrationError || err instanceof TemplateError) {
-      logger.error({
-        message: 'Failed to store template',
-        error: err,
-        ...logMeta,
-      })
-      return res.status(400).json({ message: err.message })
-    }
-    return next(err)
-  }
+export interface EmailTemplateMiddleware {
+  storeTemplate: Handler
+  uploadCompleteHandler: Handler
+  pollCsvStatusHandler: Handler
+  deleteCsvErrorHandler: Handler
+  uploadProtectedCompleteHandler: Handler
 }
 
-/**
- * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
- * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
- * If the template and csv do not match, prompt the user to upload a new file.
- * @param req
- * @param res
- * @param next
- */
-const uploadCompleteHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { campaignId } = req.params
-  // extract s3Key from transactionId
-  const { transaction_id: transactionId, filename, etag } = req.body
-  const logMeta = { campaignId, action: 'uploadCompleteHandler' }
-
-  try {
-    const { s3Key } = UploadService.extractParamsFromJwt(transactionId)
-
-    // check if template exists
-    const template = await EmailTemplateService.getFilledTemplate(+campaignId)
-    if (template === null) {
-      throw new Error(
-        'Error: No message template found. Please create a message template before uploading a recipient file.'
-      )
-    }
-
-    // Store temp filename
-    await UploadService.storeS3TempFilename(+campaignId, filename)
-
-    // Enqueue upload job to be processed
-    await EmailTemplateService.enqueueUpload({
-      campaignId: +campaignId,
-      template,
-      s3Key,
-      etag,
-      filename,
-    })
-
-    // Return early because bulk insert is slow
-    res.sendStatus(202)
-  } catch (err) {
-    logger.error({
-      message: 'Failed to complete upload to s3',
-      error: err,
-      ...logMeta,
-    })
-    const userErrors = [
-      UserError,
-      RecipientColumnMissing,
-      MissingTemplateKeysError,
-      InvalidRecipientError,
-    ]
-    if (userErrors.some((errType) => err instanceof errType)) {
-      return res.status(400).json({ message: err.message })
-    }
-    return next(err)
-  }
-}
-
-/*
- * Returns status of csv processing
- */
-const pollCsvStatusHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+export const InitEmailTemplateMiddleware = (
+  authService: AuthService
+): EmailTemplateMiddleware => {
+  const logger = loggerWithLabel(module)
+  /**
+   * Store template subject and body in email template table.
+   * If an existing csv has been uploaded for this campaign but whose columns do not match the attributes provided in the new template,
+   * delete the old csv, and prompt user to upload a new csv.
+   * @param req
+   * @param res
+   * @param next
+   */
+  const storeTemplate = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
     const { campaignId } = req.params
-    const { isCsvProcessing, filename, tempFilename, error } =
-      await UploadService.getCsvStatus(+campaignId)
-
-    // If done processing, returns num recipients and preview msg
-    let numRecipients, preview, themedBody
-
-    if (!isCsvProcessing) {
-      ;[numRecipients, preview] = await Promise.all([
-        StatsService.getNumRecipients(+campaignId),
-        EmailService.getHydratedMessage(+campaignId),
-      ])
-
-      if (preview !== undefined) {
-        const { body, agencyName, agencyLogoURI, showMasthead } = preview
-        themedBody = await ThemeClient.generateThemedBody({
+    const {
+      subject,
+      body,
+      reply_to: replyTo,
+      from,
+      show_logo: showLogo,
+    } = req.body
+    const logMeta = { campaignId, action: 'storeTemplate' }
+    try {
+      const { check, valid, updatedTemplate }: StoreTemplateOutput =
+        await EmailTemplateService.storeTemplate({
+          campaignId: +campaignId,
+          subject,
           body,
-          unsubLink: UnsubscriberService.generateTestUnsubLink(),
-          agencyName,
-          agencyLogoURI,
-          showMasthead,
+          replyTo:
+            replyTo ||
+            (
+              await authService.findUser(req.session?.user?.id)
+            )?.email,
+          from,
+          showLogo,
+        })
+
+      const template = {
+        body: updatedTemplate?.body,
+        subject: updatedTemplate?.subject,
+        params: updatedTemplate?.params,
+        reply_to: updatedTemplate?.replyTo,
+        from: updatedTemplate?.from,
+        show_logo: updatedTemplate?.showLogo,
+      }
+
+      if (check?.reupload) {
+        logger.info({
+          message:
+            'Email template has changed, required to re-upload recipient list',
+          ...logMeta,
+        })
+        return res.json({
+          message:
+            'Please re-upload your recipient list as template has changed.',
+          extra_keys: check.extraKeys,
+          num_recipients: 0,
+          valid: false,
+          template,
+        })
+      } else {
+        const numRecipients = await StatsService.getNumRecipients(+campaignId)
+        return res.json({
+          message: `Template for campaign ${campaignId} updated`,
+          valid: valid,
+          num_recipients: numRecipients,
+          template,
         })
       }
+    } catch (err) {
+      if (err instanceof HydrationError || err instanceof TemplateError) {
+        logger.error({
+          message: 'Failed to store template',
+          error: err,
+          ...logMeta,
+        })
+        return res.status(400).json({ message: err.message })
+      }
+      return next(err)
     }
-
-    res.json({
-      is_csv_processing: isCsvProcessing,
-      csv_filename: filename,
-      temp_csv_filename: tempFilename,
-      csv_error: error,
-      num_recipients: numRecipients,
-      preview: {
-        ...preview,
-        themedBody,
-      },
-    })
-  } catch (err) {
-    next(err)
   }
-}
 
-/*
- * Deletes csv error and temp csv name from db
- */
-const deleteCsvErrorHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+  /**
+   * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
+   * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
+   * If the template and csv do not match, prompt the user to upload a new file.
+   * @param req
+   * @param res
+   * @param next
+   */
+  const uploadCompleteHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
     const { campaignId } = req.params
-    await UploadService.deleteS3TempKeys(+campaignId)
-    res.sendStatus(200)
-  } catch (e) {
-    next(e)
-  }
-}
+    // extract s3Key from transactionId
+    const { transaction_id: transactionId, filename, etag } = req.body
+    const logMeta = { campaignId, action: 'uploadCompleteHandler' }
 
-// TODO: refactor this handler with uploadCompleteHandler to share the same function
-/**
- * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
- * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
- * If the template and csv do not match, prompt the user to upload a new file.
- * @param req
- * @param res
- * @param next
- */
-const uploadProtectedCompleteHandler = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { campaignId } = req.params
-  // extract s3Key from transactionId
-  const { transaction_id: transactionId, filename } = req.body
-  const logMeta = { campaignId, action: 'uploadProtectedCompleteHandler' }
+    try {
+      const { s3Key } = UploadService.extractParamsFromJwt(transactionId)
 
-  try {
-    const { s3Key } = UploadService.extractParamsFromJwt(transactionId) as {
-      s3Key: string
-      uploadId: string
-    }
+      // check if template exists
+      const template = await EmailTemplateService.getFilledTemplate(+campaignId)
+      if (template === null) {
+        throw new Error(
+          'Error: No message template found. Please create a message template before uploading a recipient file.'
+        )
+      }
 
-    // check if template exists
-    const template = await EmailTemplateService.getFilledTemplate(+campaignId)
-    if (template === null) {
-      throw new Error(
-        'Error: No message template found. Please create a message template before uploading a recipient file.'
-      )
-    }
+      // Store temp filename
+      await UploadService.storeS3TempFilename(+campaignId, filename)
 
-    // Store temp filename
-    await UploadService.storeS3TempFilename(+campaignId, filename)
-
-    // Enqueue upload job to be processed
-    const { etag } = res.locals
-    await EmailTemplateService.enqueueUpload(
-      {
+      // Enqueue upload job to be processed
+      await EmailTemplateService.enqueueUpload({
         campaignId: +campaignId,
         template,
         s3Key,
         etag,
         filename,
-      },
-      true
-    )
+      })
 
-    // Return early because bulk insert is slow
-    res.sendStatus(202)
-  } catch (err) {
-    logger.error({
-      message: 'Failed to complete upload to s3',
-      error: err,
-      ...logMeta,
-    })
-    const userErrors = [
-      RecipientColumnMissing,
-      MissingTemplateKeysError,
-      InvalidRecipientError,
-      UserError,
-    ]
-
-    if (userErrors.some((errType) => err instanceof errType)) {
-      return res.status(400).json({ message: err.message })
+      // Return early because bulk insert is slow
+      res.sendStatus(202)
+    } catch (err) {
+      logger.error({
+        message: 'Failed to complete upload to s3',
+        error: err,
+        ...logMeta,
+      })
+      const userErrors = [
+        UserError,
+        RecipientColumnMissing,
+        MissingTemplateKeysError,
+        InvalidRecipientError,
+      ]
+      if (userErrors.some((errType) => err instanceof errType)) {
+        return res.status(400).json({ message: err.message })
+      }
+      return next(err)
     }
-    return next(err)
   }
-}
 
-export const EmailTemplateMiddleware = {
-  storeTemplate,
-  uploadCompleteHandler,
-  pollCsvStatusHandler,
-  deleteCsvErrorHandler,
-  uploadProtectedCompleteHandler,
+  /*
+   * Returns status of csv processing
+   */
+  const pollCsvStatusHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { isCsvProcessing, filename, tempFilename, error } =
+        await UploadService.getCsvStatus(+campaignId)
+
+      // If done processing, returns num recipients and preview msg
+      let numRecipients, preview, themedBody
+
+      if (!isCsvProcessing) {
+        ;[numRecipients, preview] = await Promise.all([
+          StatsService.getNumRecipients(+campaignId),
+          EmailService.getHydratedMessage(+campaignId),
+        ])
+
+        if (preview !== undefined) {
+          const { body, agencyName, agencyLogoURI, showMasthead } = preview
+          themedBody = await ThemeClient.generateThemedBody({
+            body,
+            unsubLink: UnsubscriberService.generateTestUnsubLink(),
+            agencyName,
+            agencyLogoURI,
+            showMasthead,
+          })
+        }
+      }
+
+      res.json({
+        is_csv_processing: isCsvProcessing,
+        csv_filename: filename,
+        temp_csv_filename: tempFilename,
+        csv_error: error,
+        num_recipients: numRecipients,
+        preview: {
+          ...preview,
+          themedBody,
+        },
+      })
+    } catch (err) {
+      next(err)
+    }
+  }
+
+  /*
+   * Deletes csv error and temp csv name from db
+   */
+  const deleteCsvErrorHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      await UploadService.deleteS3TempKeys(+campaignId)
+      res.sendStatus(200)
+    } catch (e) {
+      next(e)
+    }
+  }
+
+  // TODO: refactor this handler with uploadCompleteHandler to share the same function
+  /**
+   * Downloads the file from s3 and checks that its columns match the attributes provided in the template.
+   * If a template has not yet been uploaded, do not write to the message logs, but prompt the user to upload a template first.
+   * If the template and csv do not match, prompt the user to upload a new file.
+   * @param req
+   * @param res
+   * @param next
+   */
+  const uploadProtectedCompleteHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { campaignId } = req.params
+    // extract s3Key from transactionId
+    const { transaction_id: transactionId, filename } = req.body
+    const logMeta = { campaignId, action: 'uploadProtectedCompleteHandler' }
+
+    try {
+      const { s3Key } = UploadService.extractParamsFromJwt(transactionId) as {
+        s3Key: string
+        uploadId: string
+      }
+
+      // check if template exists
+      const template = await EmailTemplateService.getFilledTemplate(+campaignId)
+      if (template === null) {
+        throw new Error(
+          'Error: No message template found. Please create a message template before uploading a recipient file.'
+        )
+      }
+
+      // Store temp filename
+      await UploadService.storeS3TempFilename(+campaignId, filename)
+
+      // Enqueue upload job to be processed
+      const { etag } = res.locals
+      await EmailTemplateService.enqueueUpload(
+        {
+          campaignId: +campaignId,
+          template,
+          s3Key,
+          etag,
+          filename,
+        },
+        true
+      )
+
+      // Return early because bulk insert is slow
+      res.sendStatus(202)
+    } catch (err) {
+      logger.error({
+        message: 'Failed to complete upload to s3',
+        error: err,
+        ...logMeta,
+      })
+      const userErrors = [
+        RecipientColumnMissing,
+        MissingTemplateKeysError,
+        InvalidRecipientError,
+        UserError,
+      ]
+
+      if (userErrors.some((errType) => err instanceof errType)) {
+        return res.status(400).json({ message: err.message })
+      }
+      return next(err)
+    }
+  }
+
+  return {
+    storeTemplate,
+    uploadCompleteHandler,
+    pollCsvStatusHandler,
+    deleteCsvErrorHandler,
+    uploadProtectedCompleteHandler,
+  }
 }

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Request, Response, NextFunction, Handler } from 'express'
 import expressRateLimit from 'express-rate-limit'
 import RedisStore from 'rate-limit-redis'
 import { RedisService } from '@core/services'
@@ -6,71 +6,81 @@ import { EmailTransactionalService } from '@email/services'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { TemplateError } from '@shared/templating'
-import { AuthService } from '@core/services'
+import { AuthService } from '@core/services/auth.service'
 import { InvalidRecipientError } from '@core/errors'
 
-const logger = loggerWithLabel(module)
-
-async function sendMessage(
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> {
-  const ACTION = 'sendMessage'
-
-  try {
-    const { subject, body, from, recipient, reply_to: replyTo } = req.body
-
-    logger.info({ message: 'Sending email', action: ACTION })
-    await EmailTransactionalService.sendMessage({
-      subject,
-      body,
-      from,
-      recipient,
-      replyTo:
-        replyTo ?? (await AuthService.findUser(req.session?.user?.id))?.email,
-    })
-    res.sendStatus(202)
-  } catch (err) {
-    logger.error({
-      message: 'Failed to send email',
-      action: ACTION,
-      error: err,
-    })
-
-    const BAD_REQUEST_ERRORS = [TemplateError, InvalidRecipientError]
-    if (BAD_REQUEST_ERRORS.some((errType) => err instanceof errType)) {
-      res.status(400).json({ message: err.message })
-      return
-    }
-    next(err)
-  }
+export interface EmailTransactionalMiddleware {
+  sendMessage: Handler
+  rateLimit: Handler
 }
 
-const rateLimit = expressRateLimit({
-  store: new RedisStore({
-    prefix: 'transactionalEmail:',
-    client: RedisService.rateLimitClient,
-    expiry: config.get('transactionalEmail.window'),
-  }),
-  keyGenerator: (req: Request) => req?.session?.user.id,
-  windowMs: config.get('transactionalEmail.window') * 1000,
-  max: config.get('transactionalEmail.rate'),
-  draft_polli_ratelimit_headers: true,
-  message: {
-    status: 429,
-    message: 'Too many requests. Please try again later.',
-  },
-  handler: (req: Request, res: Response) => {
-    logger.warn({
-      message: 'Rate limited request to send transactional email',
-      userId: req?.session?.user.id,
-    })
-    res.sendStatus(429)
-  },
-})
+export const InitEmailTransactionalMiddleware = (
+  redisService: RedisService,
+  authService: AuthService
+): EmailTransactionalMiddleware => {
+  const logger = loggerWithLabel(module)
 
-export const EmailTransactionalMiddleware = {
-  sendMessage,
-  rateLimit,
+  async function sendMessage(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const ACTION = 'sendMessage'
+
+    try {
+      const { subject, body, from, recipient, reply_to: replyTo } = req.body
+
+      logger.info({ message: 'Sending email', action: ACTION })
+      await EmailTransactionalService.sendMessage({
+        subject,
+        body,
+        from,
+        recipient,
+        replyTo:
+          replyTo ?? (await authService.findUser(req.session?.user?.id))?.email,
+      })
+      res.sendStatus(202)
+    } catch (err) {
+      logger.error({
+        message: 'Failed to send email',
+        action: ACTION,
+        error: err,
+      })
+
+      const BAD_REQUEST_ERRORS = [TemplateError, InvalidRecipientError]
+      if (BAD_REQUEST_ERRORS.some((errType) => err instanceof errType)) {
+        res.status(400).json({ message: err.message })
+        return
+      }
+      next(err)
+    }
+  }
+
+  const rateLimit = expressRateLimit({
+    store: new RedisStore({
+      prefix: 'transactionalEmail:',
+      client: redisService.rateLimitClient,
+      expiry: config.get('transactionalEmail.window'),
+    }),
+    keyGenerator: (req: Request) => req?.session?.user.id,
+    windowMs: config.get('transactionalEmail.window') * 1000,
+    max: config.get('transactionalEmail.rate'),
+    draft_polli_ratelimit_headers: true,
+    message: {
+      status: 429,
+      message: 'Too many requests. Please try again later.',
+    },
+    handler: (req: Request, res: Response) => {
+      logger.warn({
+        message: 'Rate limited request to send transactional email',
+        userId: req?.session?.user.id,
+      })
+      res.sendStatus(429)
+    },
+  })
+
+  return {
+    sendMessage,
+    rateLimit,
+  }
 }

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import { EmailService, CustomDomainService } from '@email/services'
 import { isDefaultFromAddress } from '@core/utils/from-address'
 import { parseFromAddress } from '@shared/utils/from-address'
@@ -7,378 +7,397 @@ import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { ThemeClient } from '@shared/theme'
 
-const logger = loggerWithLabel(module)
+export interface EmailMiddleware {
+  isEmailCampaignOwnedByUser: Handler
+  validateAndStoreCredentials: Handler
+  getCampaignDetails: Handler
+  previewFirstMessage: Handler
+  verifyFromAddress: Handler
+  storeFromAddress: Handler
+  getCustomFromAddress: Handler
+  existsFromAddress: Handler
+  isCustomFromAddressAllowed: Handler
+  isFromAddressAccepted: Handler
+  sendValidationMessage: Handler
+  duplicateCampaign: Handler
+}
 
-/**
- * Checks if the campaign id supplied is indeed a campaign of the 'Email' type, and belongs to the user
- * @param req
- * @param res
- * @param next
- */
-const isEmailCampaignOwnedByUser = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { campaignId } = req.params
-  const userId = req.session?.user?.id
-  try {
-    const campaign = await EmailService.findCampaign(+campaignId, +userId)
-    if (campaign) {
-      return next()
-    } else {
-      return res.sendStatus(403)
+export const InitEmailMiddleware = (
+  authService: AuthService
+): EmailMiddleware => {
+  const logger = loggerWithLabel(module)
+
+  /**
+   * Checks if the campaign id supplied is indeed a campaign of the 'Email' type, and belongs to the user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const isEmailCampaignOwnedByUser = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { campaignId } = req.params
+    const userId = req.session?.user?.id
+    try {
+      const campaign = await EmailService.findCampaign(+campaignId, +userId)
+      if (campaign) {
+        return next()
+      } else {
+        return res.sendStatus(403)
+      }
+    } catch (err) {
+      return next(err)
     }
-  } catch (err) {
-    return next(err)
   }
-}
 
-/**
- * Sends a test message. If the test message succeeds, store the credentials
- * @param req
- * @param res
- */
-const validateAndStoreCredentials = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  const { campaignId } = req.params
-  const { recipient } = req.body
-  const logMeta = {
-    campaignId,
-    recipient,
-    action: 'validateAndStoreCredentials',
-  }
-  try {
-    await EmailService.sendCampaignMessage(+campaignId, recipient)
-    await EmailService.setCampaignCredential(+campaignId)
-  } catch (err) {
-    logger.error({
-      message: 'Failed to validate and store credentials',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: `${err.message}` })
-  }
-  return res.json({ message: 'OK' })
-}
-
-/**
- * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
- * @param req
- * @param res
- * @param next
- */
-const getCampaignDetails = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+  /**
+   * Sends a test message. If the test message succeeds, store the credentials
+   * @param req
+   * @param res
+   */
+  const validateAndStoreCredentials = async (
+    req: Request,
+    res: Response
+  ): Promise<Response | void> => {
     const { campaignId } = req.params
-    const result = await EmailService.getCampaignDetails(+campaignId)
-    return res.json(result)
-  } catch (err) {
-    return next(err)
+    const { recipient } = req.body
+    const logMeta = {
+      campaignId,
+      recipient,
+      action: 'validateAndStoreCredentials',
+    }
+    try {
+      await EmailService.sendCampaignMessage(+campaignId, recipient)
+      await EmailService.setCampaignCredential(+campaignId)
+    } catch (err) {
+      logger.error({
+        message: 'Failed to validate and store credentials',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: `${err.message}` })
+    }
+    return res.json({ message: 'OK' })
   }
-}
 
-/**
- * Retrieves a message for this campaign
- * @param req
- * @param res
- * @param next
- */
-const previewFirstMessage = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const message = await EmailService.getHydratedMessage(+campaignId)
+  /**
+   * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCampaignDetails = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const result = await EmailService.getCampaignDetails(+campaignId)
+      return res.json(result)
+    } catch (err) {
+      return next(err)
+    }
+  }
 
-    if (!message) return res.json({})
+  /**
+   * Retrieves a message for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const previewFirstMessage = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const message = await EmailService.getHydratedMessage(+campaignId)
 
-    const {
-      body,
-      subject,
-      replyTo,
-      from,
-      agencyName,
-      agencyLogoURI,
-      showMasthead,
-    } = message
-    const themedBody = await ThemeClient.generateThemedBody({
-      body,
-      unsubLink: UnsubscriberService.generateTestUnsubLink(),
-      agencyName,
-      agencyLogoURI,
-      showMasthead,
-    })
+      if (!message) return res.json({})
 
-    return res.json({
-      preview: {
+      const {
         body,
         subject,
-        reply_to: replyTo,
+        replyTo,
         from,
-        themed_body: themedBody,
-      },
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Checks if the from address is custom and rejects it if necessary.
- */
-const isCustomFromAddressAllowed = (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): void => {
-  const { from } = req.body
-  if (isDefaultFromAddress(from)) return next()
-
-  // We don't allow custom from address for the SendGrid fallback
-  // since they aren't DKIM-authenticated currently
-  if (config.get('emailFallback.activate')) {
-    res.status(503).json({
-      message:
-        'Unable to use a custom from address due to downtime. Please use the default from address instead.',
-    })
-    return
-  }
-
-  next()
-}
-
-/**
- * Checks that the from address is either the user's email or the default app email
- */
-const isFromAddressAccepted = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  // Since from addresses with display name are accepted, we need to extract just the email address
-  const { from } = req.body
-  const { fromName, fromAddress } = parseFromAddress(from)
-
-  // Retrieve logged in user's email
-  const userEmail =
-    req.session?.user?.email ||
-    (await AuthService.findUser(req.session?.user?.id))?.email
-
-  // Get default mail address for comparison
-  const { fromName: defaultFromName, fromAddress: defaultFromAddress } =
-    parseFromAddress(config.get('mailFrom'))
-
-  if (fromAddress !== userEmail && fromAddress !== defaultFromAddress) {
-    logger.error({
-      message: "Invalid 'from' email address",
-      from,
-      userEmail,
-      defaultFromName,
-      defaultFromAddress,
-      fromAddress,
-      action: 'isFromAddressAccepted',
-    })
-    return res.status(400).json({ message: "Invalid 'from' email address." })
-  }
-
-  res.locals.fromName = fromName
-  res.locals.fromAddress = fromAddress
-
-  return next()
-}
-
-/**
- * Verifies that the 'from' address provided is valid
- */
-const existsFromAddress = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { from } = req.body
-  if (isDefaultFromAddress(from)) return next()
-
-  const { fromName, fromAddress } = res.locals
-  try {
-    const exists = await CustomDomainService.existsFromAddress(fromAddress)
-    if (!exists) throw new Error('From Address has not been verified.')
-  } catch (err) {
-    logger.error({
-      message: "Invalid 'from' email address",
-      from,
-      defaultEmail: config.get('mailFrom'),
-      fromName,
-      fromAddress,
-      error: err,
-      action: 'existsFromAddress',
-    })
-    return res.status(400).json({ message: err.message })
-  }
-  return next()
-}
-
-/**
- * Verifies the user's email address to see if it can be used as custom 'from' address
- */
-const verifyFromAddress = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { from } = req.body
-  if (isDefaultFromAddress(from)) return next()
-
-  const { fromAddress } = res.locals
-  try {
-    await CustomDomainService.verifyFromAddress(fromAddress)
-  } catch (err) {
-    logger.error({
-      message: "Failed to verify 'from' email address",
-      from,
-      defaultEmail: config.get('mailFrom'),
-      fromAddress,
-      error: err,
-      action: 'verifyFromAddress',
-    })
-    return res.status(400).json({ message: err.message })
-  }
-  return next()
-}
-
-/**
- * Stores the verified email address that we can use to send out emails.
- */
-const storeFromAddress = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { from } = req.body
-  const defaultEmail = config.get('mailFrom')
-  if (from === defaultEmail) {
-    return res.sendStatus(200)
-  }
-  const { fromName, fromAddress } = res.locals
-
-  try {
-    await CustomDomainService.storeFromAddress(fromName, fromAddress)
-  } catch (err) {
-    return next(err)
-  }
-  return res.status(200).json({ email: from })
-}
-
-/**
- * Verifies if the user's email address can be used as custom 'from' address
- */
-const getCustomFromAddress = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const email =
-    req.session?.user?.email ||
-    (await AuthService.findUser(req.session?.user?.id))?.email
-  const defaultEmail = config.get('mailFrom')
-  const result = []
-
-  try {
-    const fromAddress = await CustomDomainService.getCustomFromAddress(email)
-    if (fromAddress) result.push(fromAddress)
-    result.push(defaultEmail)
-  } catch (err) {
-    return next(err)
-  }
-
-  return res.status(200).json({ from: result })
-}
-
-/**
- * Sends a test email from the specified from address
- */
-const sendValidationMessage = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { recipient, from } = req.body
-  try {
-    await CustomDomainService.sendValidationMessage(recipient, from)
-  } catch (err) {
-    logger.error({
-      message:
-        "Failed to send validation email from the specified 'from' email address",
-      recipient,
-      from,
-      error: err,
-      action: 'sendValidationMessage',
-    })
-    return res.status(400).json({ message: err.message })
-  }
-  return next()
-}
-
-/**
- *  duplicate a campaign and its template
- * @param req
- * @param res
- * @param next
- */
-const duplicateCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const { name } = req.body
-    const campaign = await EmailService.duplicateCampaign({
-      campaignId: +campaignId,
-      name,
-    })
-    if (!campaign) {
-      return res.status(400).json({
-        message: `Unable to duplicate campaign with these parameters`,
+        agencyName,
+        agencyLogoURI,
+        showMasthead,
+      } = message
+      const themedBody = await ThemeClient.generateThemedBody({
+        body,
+        unsubLink: UnsubscriberService.generateTestUnsubLink(),
+        agencyName,
+        agencyLogoURI,
+        showMasthead,
       })
-    }
-    logger.info({
-      message: 'Successfully copied campaign',
-      campaignId: campaign.id,
-      action: 'duplicateCampaign',
-    })
-    return res.status(201).json({
-      id: campaign.id,
-      name: campaign.name,
-      created_at: campaign.createdAt,
-      type: campaign.type,
-      protect: campaign.protect,
-      demo_message_limit: campaign.demoMessageLimit,
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
 
-export const EmailMiddleware = {
-  isEmailCampaignOwnedByUser,
-  validateAndStoreCredentials,
-  getCampaignDetails,
-  previewFirstMessage,
-  verifyFromAddress,
-  storeFromAddress,
-  getCustomFromAddress,
-  existsFromAddress,
-  isCustomFromAddressAllowed,
-  isFromAddressAccepted,
-  sendValidationMessage,
-  duplicateCampaign,
+      return res.json({
+        preview: {
+          body,
+          subject,
+          reply_to: replyTo,
+          from,
+          themed_body: themedBody,
+        },
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Checks if the from address is custom and rejects it if necessary.
+   */
+  const isCustomFromAddressAllowed = (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): void => {
+    const { from } = req.body
+    if (isDefaultFromAddress(from)) return next()
+
+    // We don't allow custom from address for the SendGrid fallback
+    // since they aren't DKIM-authenticated currently
+    if (config.get('emailFallback.activate')) {
+      res.status(503).json({
+        message:
+          'Unable to use a custom from address due to downtime. Please use the default from address instead.',
+      })
+      return
+    }
+
+    next()
+  }
+
+  /**
+   * Checks that the from address is either the user's email or the default app email
+   */
+  const isFromAddressAccepted = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    // Since from addresses with display name are accepted, we need to extract just the email address
+    const { from } = req.body
+    const { fromName, fromAddress } = parseFromAddress(from)
+
+    // Retrieve logged in user's email
+    const userEmail =
+      req.session?.user?.email ||
+      (await authService.findUser(req.session?.user?.id))?.email
+
+    // Get default mail address for comparison
+    const { fromName: defaultFromName, fromAddress: defaultFromAddress } =
+      parseFromAddress(config.get('mailFrom'))
+
+    if (fromAddress !== userEmail && fromAddress !== defaultFromAddress) {
+      logger.error({
+        message: "Invalid 'from' email address",
+        from,
+        userEmail,
+        defaultFromName,
+        defaultFromAddress,
+        fromAddress,
+        action: 'isFromAddressAccepted',
+      })
+      return res.status(400).json({ message: "Invalid 'from' email address." })
+    }
+
+    res.locals.fromName = fromName
+    res.locals.fromAddress = fromAddress
+
+    return next()
+  }
+
+  /**
+   * Verifies that the 'from' address provided is valid
+   */
+  const existsFromAddress = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { from } = req.body
+    if (isDefaultFromAddress(from)) return next()
+
+    const { fromName, fromAddress } = res.locals
+    try {
+      const exists = await CustomDomainService.existsFromAddress(fromAddress)
+      if (!exists) throw new Error('From Address has not been verified.')
+    } catch (err) {
+      logger.error({
+        message: "Invalid 'from' email address",
+        from,
+        defaultEmail: config.get('mailFrom'),
+        fromName,
+        fromAddress,
+        error: err,
+        action: 'existsFromAddress',
+      })
+      return res.status(400).json({ message: err.message })
+    }
+    return next()
+  }
+
+  /**
+   * Verifies the user's email address to see if it can be used as custom 'from' address
+   */
+  const verifyFromAddress = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { from } = req.body
+    if (isDefaultFromAddress(from)) return next()
+
+    const { fromAddress } = res.locals
+    try {
+      await CustomDomainService.verifyFromAddress(fromAddress)
+    } catch (err) {
+      logger.error({
+        message: "Failed to verify 'from' email address",
+        from,
+        defaultEmail: config.get('mailFrom'),
+        fromAddress,
+        error: err,
+        action: 'verifyFromAddress',
+      })
+      return res.status(400).json({ message: err.message })
+    }
+    return next()
+  }
+
+  /**
+   * Stores the verified email address that we can use to send out emails.
+   */
+  const storeFromAddress = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { from } = req.body
+    const defaultEmail = config.get('mailFrom')
+    if (from === defaultEmail) {
+      return res.sendStatus(200)
+    }
+    const { fromName, fromAddress } = res.locals
+
+    try {
+      await CustomDomainService.storeFromAddress(fromName, fromAddress)
+    } catch (err) {
+      return next(err)
+    }
+    return res.status(200).json({ email: from })
+  }
+
+  /**
+   * Verifies if the user's email address can be used as custom 'from' address
+   */
+  const getCustomFromAddress = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const email =
+      req.session?.user?.email ||
+      (await authService.findUser(req.session?.user?.id))?.email
+    const defaultEmail = config.get('mailFrom')
+    const result = []
+
+    try {
+      const fromAddress = await CustomDomainService.getCustomFromAddress(email)
+      if (fromAddress) result.push(fromAddress)
+      result.push(defaultEmail)
+    } catch (err) {
+      return next(err)
+    }
+
+    return res.status(200).json({ from: result })
+  }
+
+  /**
+   * Sends a test email from the specified from address
+   */
+  const sendValidationMessage = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { recipient, from } = req.body
+    try {
+      await CustomDomainService.sendValidationMessage(recipient, from)
+    } catch (err) {
+      logger.error({
+        message:
+          "Failed to send validation email from the specified 'from' email address",
+        recipient,
+        from,
+        error: err,
+        action: 'sendValidationMessage',
+      })
+      return res.status(400).json({ message: err.message })
+    }
+    return next()
+  }
+
+  /**
+   *  duplicate a campaign and its template
+   * @param req
+   * @param res
+   * @param next
+   */
+  const duplicateCampaign = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { name } = req.body
+      const campaign = await EmailService.duplicateCampaign({
+        campaignId: +campaignId,
+        name,
+      })
+      if (!campaign) {
+        return res.status(400).json({
+          message: `Unable to duplicate campaign with these parameters`,
+        })
+      }
+      logger.info({
+        message: 'Successfully copied campaign',
+        campaignId: campaign.id,
+        action: 'duplicateCampaign',
+      })
+      return res.status(201).json({
+        id: campaign.id,
+        name: campaign.name,
+        created_at: campaign.createdAt,
+        type: campaign.type,
+        protect: campaign.protect,
+        demo_message_limit: campaign.demoMessageLimit,
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  return {
+    isEmailCampaignOwnedByUser,
+    validateAndStoreCredentials,
+    getCampaignDetails,
+    previewFirstMessage,
+    verifyFromAddress,
+    storeFromAddress,
+    getCustomFromAddress,
+    existsFromAddress,
+    isCustomFromAddressAllowed,
+    isFromAddressAccepted,
+    sendValidationMessage,
+    duplicateCampaign,
+  }
 }

--- a/backend/src/email/middlewares/tests/email.middleware.test.ts
+++ b/backend/src/email/middlewares/tests/email.middleware.test.ts
@@ -2,14 +2,17 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
+import { InitAuthService, RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { EmailMiddleware } from '@email/middlewares/email.middleware'
+import { InitEmailMiddleware } from '..'
 
 let sequelize: Sequelize
 let campaignId: number
 let mockRequest: Partial<Request>
 let mockResponse: Partial<Response>
+let emailMiddleware: EmailMiddleware
+const redisService = new RedisService()
 const nextFunction: NextFunction = jest.fn()
 
 beforeEach(() => {
@@ -17,6 +20,7 @@ beforeEach(() => {
   mockResponse = {
     sendStatus: jest.fn(),
   }
+  emailMiddleware = InitEmailMiddleware(InitAuthService(redisService))
 })
 
 beforeAll(async () => {
@@ -36,7 +40,7 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await redisService.shutdown()
 })
 
 describe('isEmailCampaignOwnedByUser middleware', () => {
@@ -46,7 +50,7 @@ describe('isEmailCampaignOwnedByUser middleware', () => {
       session: { user: { id: 2 } } as any,
     }
 
-    await EmailMiddleware.isEmailCampaignOwnedByUser(
+    await emailMiddleware.isEmailCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction
@@ -59,7 +63,7 @@ describe('isEmailCampaignOwnedByUser middleware', () => {
       params: { campaignId: String(campaignId) },
       session: { user: { id: 1 } } as any,
     }
-    await EmailMiddleware.isEmailCampaignOwnedByUser(
+    await emailMiddleware.isEmailCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -14,820 +14,825 @@ import {
 import config from '@core/config'
 import { fromAddressValidator } from '@core/utils/from-address'
 
-const router = Router({ mergeParams: true })
+export const InitEmailCampaignRoute = (
+  emailTemplateMiddleware: EmailTemplateMiddleware,
+  emailMiddleware: EmailMiddleware
+): Router => {
+  const router = Router({ mergeParams: true })
 
-// validators
-const storeTemplateValidator = {
-  [Segments.BODY]: Joi.object({
-    subject: Joi.string().required(),
-    body: Joi.string().required(),
-    reply_to: Joi.string()
-      .trim()
-      .email()
-      .options({ convert: true })
-      .lowercase()
-      .allow(null)
-      .required(),
-    from: fromAddressValidator,
-    show_logo: Joi.boolean().default(true),
-  }),
+  // validators
+  const storeTemplateValidator = {
+    [Segments.BODY]: Joi.object({
+      subject: Joi.string().required(),
+      body: Joi.string().required(),
+      reply_to: Joi.string()
+        .trim()
+        .email()
+        .options({ convert: true })
+        .lowercase()
+        .allow(null)
+        .required(),
+      from: fromAddressValidator,
+      show_logo: Joi.boolean().default(true),
+    }),
+  }
+
+  const uploadStartValidator = {
+    [Segments.QUERY]: Joi.object({
+      mime_type: Joi.string().required(),
+      md5: Joi.string().required(),
+    }),
+  }
+
+  const uploadCompleteValidator = {
+    [Segments.BODY]: Joi.object({
+      transaction_id: Joi.string().required(),
+      filename: Joi.string().required(),
+      etag: Joi.string().required(),
+    }),
+  }
+
+  const storeCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string()
+        .email()
+        .options({ convert: true }) // Converts email to lowercase if it isn't
+        .lowercase()
+        .required(),
+    }),
+  }
+
+  const sendCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      rate: Joi.number()
+        .integer()
+        .positive()
+        .default(config.get('mailDefaultRate')),
+    }),
+  }
+
+  const startMultipartValidator = {
+    [Segments.QUERY]: Joi.object({
+      mime_type: Joi.string().required(),
+      part_count: Joi.number().integer().min(1).max(10000).default(1),
+    }),
+  }
+
+  const completeMultipartValidator = {
+    [Segments.BODY]: Joi.object({
+      filename: Joi.string().required(),
+      transaction_id: Joi.string().required(),
+      part_count: Joi.number().integer().min(1).max(10000).required(),
+      etags: Joi.array().items(Joi.string()).required(),
+    }),
+  }
+
+  const duplicateCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      name: Joi.string().max(255).trim().required(),
+    }),
+  }
+
+  // Routes
+
+  // Check if campaign belongs to user for this router
+  router.use(emailMiddleware.isEmailCampaignOwnedByUser)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email:
+   *    get:
+   *      tags:
+   *        - Email
+   *      summary: Get email campaign details
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/EmailCampaign'
+   *
+   *        "400" :
+   *           description: Invalid campaign type or not owned by user
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/', emailMiddleware.getCampaignDetails)
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/email/template:
+   *     put:
+   *       tags:
+   *         - Email
+   *       summary: Stores body template for email campaign
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         required: true
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 subject:
+   *                   type: string
+   *                 body:
+   *                   type: string
+   *                   minLength: 1
+   *                   maxLength: 200
+   *                 reply_to:
+   *                   type: string
+   *                   nullable: true
+   *                 from:
+   *                   type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 required:
+   *                   - message
+   *                   - valid
+   *                   - num_recipients
+   *                 properties:
+   *                   message:
+   *                     type: string
+   *                   extra_keys:
+   *                     type: array
+   *                     items:
+   *                       type: string
+   *                   valid:
+   *                     type: boolean
+   *                   num_recipients:
+   *                     type: integer
+   *                   template:
+   *                     type: object
+   *                     properties:
+   *                       subject:
+   *                         type: string
+   *                       body:
+   *                         type: string
+   *                       reply_to:
+   *                         type: string
+   *                         nullable: true
+   *                       params:
+   *                         type: array
+   *                         items:
+   *                           type: string
+   *                       from:
+   *                         type: string
+   *
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   *         "503":
+   *           description: Service Unavailable. Try using the default from address instead.
+   */
+  router.put(
+    '/template',
+    celebrate(storeTemplateValidator),
+    CampaignMiddleware.canEditCampaign,
+    emailMiddleware.isCustomFromAddressAllowed,
+    emailMiddleware.isFromAddressAccepted,
+    emailMiddleware.existsFromAddress,
+    emailMiddleware.verifyFromAddress,
+    ProtectedMiddleware.verifyTemplate,
+    emailTemplateMiddleware.storeTemplate
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/email/upload/start:
+   *     get:
+   *       summary: "Get a presigned URL for upload with Content-MD5 header"
+   *       tags:
+   *         - Email
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: mime_type
+   *           in: query
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: md5
+   *           in: query
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   presigned_url:
+   *                     type: string
+   *                   transaction_id:
+   *                     type: string
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/upload/start',
+    celebrate(uploadStartValidator),
+    CampaignMiddleware.canEditCampaign,
+    UploadMiddleware.uploadStartHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/email/upload/complete:
+   *     post:
+   *       summary: "Complete upload session with ETag verification"
+   *       tags:
+   *         - Email
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - transaction_id
+   *                 - filename
+   *               properties:
+   *                 transaction_id:
+   *                   type: string
+   *                 filename:
+   *                   type: string
+   *                 etag:
+   *                   type: string
+   *       responses:
+   *         "202" :
+   *           description: Accepted. The uploaded file is being processed.
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/upload/complete',
+    celebrate(uploadCompleteValidator),
+    CampaignMiddleware.canEditCampaign,
+    emailTemplateMiddleware.uploadCompleteHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/email/upload/status:
+   *     get:
+   *       summary: "Get csv processing status"
+   *       tags:
+   *         - Email
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   is_csv_processing:
+   *                     type: boolean
+   *                   csv_filename:
+   *                     type: string
+   *                   temp_csv_filename:
+   *                     type: string
+   *                   csv_error:
+   *                     type: string
+   *                   num_recipients:
+   *                     type: number
+   *                   preview:
+   *                     type: object
+   *                     properties:
+   *                       subject:
+   *                         type: string
+   *                       body:
+   *                         type: string
+   *                       reply_to:
+   *                         type: string
+   *                         nullable: true
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get('/upload/status', emailTemplateMiddleware.pollCsvStatusHandler)
+
+  /**
+   * @swagger
+   * post:
+   *   /campaign/{campaignId}/email/upload/status:
+   *     delete:
+   *       description: "Deletes error status from previous failed upload"
+   *       tags:
+   *         - Email
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.delete(
+    '/upload/status',
+    CampaignMiddleware.canEditCampaign,
+    emailTemplateMiddleware.deleteCsvErrorHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/credentials:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Sends a test message and defaults to Postman's credentials for the campaign
+   *      requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - recipient
+   *               properties:
+   *                 recipient:
+   *                   type: string
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden as there is a job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/credentials',
+    celebrate(storeCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    emailMiddleware.validateAndStoreCredentials
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/preview:
+   *    get:
+   *      tags:
+   *        - Email
+   *      summary: Preview templated message
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  preview:
+   *                    type: object
+   *                    properties:
+   *                      body:
+   *                        type: string
+   *                      subject:
+   *                        type: string
+   *                      reply_to:
+   *                        type: string
+   *                        nullable: true
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/preview', emailMiddleware.previewFirstMessage)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/send:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Start sending campaign
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                rate:
+   *                  type: integer
+   *                  minimum: 1
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *                 job_id:
+   *                  type: array
+   *                  items:
+   *                    type: number
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden as there is a job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/send',
+    celebrate(sendCampaignValidator),
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.sendCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/stop:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Stop sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/stop', JobMiddleware.stopCampaign)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/retry:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Retry sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden as there is a job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/retry',
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.retryCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/stats:
+   *    get:
+   *      tags:
+   *        - Email
+   *      summary: Get email campaign stats
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/stats', EmailStatsMiddleware.getStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/refresh-stats:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Get email campaign stats
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/refresh-stats', EmailStatsMiddleware.updateAndGetStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/export:
+   *    get:
+   *      tags:
+   *        - Email
+   *      summary: Get recipients of unsuccessful emails in campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: array
+   *                items:
+   *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "410":
+   *           description: Campaign has been redacted
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/export',
+    CampaignMiddleware.isCampaignRedacted,
+    EmailStatsMiddleware.getDeliveredRecipients
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/protect/upload/start:
+   *    get:
+   *      tags:
+   *        - Email
+   *      summary: Start multipart upload
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *        - name: mime_type
+   *          in: query
+   *          required: true
+   *          schema:
+   *            type: string
+   *        - name: part_count
+   *          in: query
+   *          required: true
+   *          schema:
+   *            type: integer
+   *            minimum: 1
+   *            maximum: 100
+   *            default: 1
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 transaction_id:
+   *                  type: string
+   *                 presigned_urls:
+   *                  type: array
+   *                  items:
+   *                    type: string
+   *
+   *        "400" :
+   *           description: Invalid campaign type, not owned by user
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/protect/upload/start',
+    celebrate(startMultipartValidator),
+    CampaignMiddleware.canEditCampaign,
+    ProtectedMiddleware.isProtectedCampaign,
+    UploadMiddleware.startMultipartUpload
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/email/protect/upload/complete:
+   *     post:
+   *       summary: Complete multipart upload
+   *       tags:
+   *         - Email
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - filename
+   *                 - transaction_id
+   *                 - part_count
+   *                 - etags
+   *               properties:
+   *                 filename:
+   *                   type: string
+   *                 transaction_id:
+   *                   type: string
+   *                 part_count:
+   *                   type: integer
+   *                 etags:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *       responses:
+   *         200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 transaction_id:
+   *                  type: string
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/protect/upload/complete',
+    celebrate(completeMultipartValidator),
+    CampaignMiddleware.canEditCampaign,
+    ProtectedMiddleware.isProtectedCampaign,
+    UploadMiddleware.completeMultipart,
+    emailTemplateMiddleware.uploadProtectedCompleteHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/email/duplicate:
+   *    post:
+   *      tags:
+   *        - Email
+   *      summary: Duplicate the campaign and its template
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                name:
+   *                  type: string
+   *
+   *      responses:
+   *        "201":
+   *           description: A duplicate of the campaign was created
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/duplicate',
+    celebrate(duplicateCampaignValidator),
+    emailMiddleware.duplicateCampaign
+  )
+
+  return router
 }
-
-const uploadStartValidator = {
-  [Segments.QUERY]: Joi.object({
-    mime_type: Joi.string().required(),
-    md5: Joi.string().required(),
-  }),
-}
-
-const uploadCompleteValidator = {
-  [Segments.BODY]: Joi.object({
-    transaction_id: Joi.string().required(),
-    filename: Joi.string().required(),
-    etag: Joi.string().required(),
-  }),
-}
-
-const storeCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string()
-      .email()
-      .options({ convert: true }) // Converts email to lowercase if it isn't
-      .lowercase()
-      .required(),
-  }),
-}
-
-const sendCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    rate: Joi.number()
-      .integer()
-      .positive()
-      .default(config.get('mailDefaultRate')),
-  }),
-}
-
-const startMultipartValidator = {
-  [Segments.QUERY]: Joi.object({
-    mime_type: Joi.string().required(),
-    part_count: Joi.number().integer().min(1).max(10000).default(1),
-  }),
-}
-
-const completeMultipartValidator = {
-  [Segments.BODY]: Joi.object({
-    filename: Joi.string().required(),
-    transaction_id: Joi.string().required(),
-    part_count: Joi.number().integer().min(1).max(10000).required(),
-    etags: Joi.array().items(Joi.string()).required(),
-  }),
-}
-
-const duplicateCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    name: Joi.string().max(255).trim().required(),
-  }),
-}
-
-// Routes
-
-// Check if campaign belongs to user for this router
-router.use(EmailMiddleware.isEmailCampaignOwnedByUser)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email:
- *    get:
- *      tags:
- *        - Email
- *      summary: Get email campaign details
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/EmailCampaign'
- *
- *        "400" :
- *           description: Invalid campaign type or not owned by user
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/', EmailMiddleware.getCampaignDetails)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/email/template:
- *     put:
- *       tags:
- *         - Email
- *       summary: Stores body template for email campaign
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 subject:
- *                   type: string
- *                 body:
- *                   type: string
- *                   minLength: 1
- *                   maxLength: 200
- *                 reply_to:
- *                   type: string
- *                   nullable: true
- *                 from:
- *                   type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 required:
- *                   - message
- *                   - valid
- *                   - num_recipients
- *                 properties:
- *                   message:
- *                     type: string
- *                   extra_keys:
- *                     type: array
- *                     items:
- *                       type: string
- *                   valid:
- *                     type: boolean
- *                   num_recipients:
- *                     type: integer
- *                   template:
- *                     type: object
- *                     properties:
- *                       subject:
- *                         type: string
- *                       body:
- *                         type: string
- *                       reply_to:
- *                         type: string
- *                         nullable: true
- *                       params:
- *                         type: array
- *                         items:
- *                           type: string
- *                       from:
- *                         type: string
- *
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- *         "503":
- *           description: Service Unavailable. Try using the default from address instead.
- */
-router.put(
-  '/template',
-  celebrate(storeTemplateValidator),
-  CampaignMiddleware.canEditCampaign,
-  EmailMiddleware.isCustomFromAddressAllowed,
-  EmailMiddleware.isFromAddressAccepted,
-  EmailMiddleware.existsFromAddress,
-  EmailMiddleware.verifyFromAddress,
-  ProtectedMiddleware.verifyTemplate,
-  EmailTemplateMiddleware.storeTemplate
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/email/upload/start:
- *     get:
- *       summary: "Get a presigned URL for upload with Content-MD5 header"
- *       tags:
- *         - Email
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *         - name: mime_type
- *           in: query
- *           required: true
- *           schema:
- *             type: string
- *         - name: md5
- *           in: query
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 type: object
- *                 properties:
- *                   presigned_url:
- *                     type: string
- *                   transaction_id:
- *                     type: string
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/upload/start',
-  celebrate(uploadStartValidator),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/email/upload/complete:
- *     post:
- *       summary: "Complete upload session with ETag verification"
- *       tags:
- *         - Email
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - transaction_id
- *                 - filename
- *               properties:
- *                 transaction_id:
- *                   type: string
- *                 filename:
- *                   type: string
- *                 etag:
- *                   type: string
- *       responses:
- *         "202" :
- *           description: Accepted. The uploaded file is being processed.
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/upload/complete',
-  celebrate(uploadCompleteValidator),
-  CampaignMiddleware.canEditCampaign,
-  EmailTemplateMiddleware.uploadCompleteHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/email/upload/status:
- *     get:
- *       summary: "Get csv processing status"
- *       tags:
- *         - Email
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 properties:
- *                   is_csv_processing:
- *                     type: boolean
- *                   csv_filename:
- *                     type: string
- *                   temp_csv_filename:
- *                     type: string
- *                   csv_error:
- *                     type: string
- *                   num_recipients:
- *                     type: number
- *                   preview:
- *                     type: object
- *                     properties:
- *                       subject:
- *                         type: string
- *                       body:
- *                         type: string
- *                       reply_to:
- *                         type: string
- *                         nullable: true
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get('/upload/status', EmailTemplateMiddleware.pollCsvStatusHandler)
-
-/**
- * @swagger
- * post:
- *   /campaign/{campaignId}/email/upload/status:
- *     delete:
- *       description: "Deletes error status from previous failed upload"
- *       tags:
- *         - Email
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.delete(
-  '/upload/status',
-  CampaignMiddleware.canEditCampaign,
-  EmailTemplateMiddleware.deleteCsvErrorHandler
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/credentials:
- *    post:
- *      tags:
- *        - Email
- *      summary: Sends a test message and defaults to Postman's credentials for the campaign
- *      requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - recipient
- *               properties:
- *                 recipient:
- *                   type: string
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden as there is a job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/credentials',
-  celebrate(storeCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  EmailMiddleware.validateAndStoreCredentials
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/preview:
- *    get:
- *      tags:
- *        - Email
- *      summary: Preview templated message
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  preview:
- *                    type: object
- *                    properties:
- *                      body:
- *                        type: string
- *                      subject:
- *                        type: string
- *                      reply_to:
- *                        type: string
- *                        nullable: true
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/preview', EmailMiddleware.previewFirstMessage)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/send:
- *    post:
- *      tags:
- *        - Email
- *      summary: Start sending campaign
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                rate:
- *                  type: integer
- *                  minimum: 1
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *                 job_id:
- *                  type: array
- *                  items:
- *                    type: number
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden as there is a job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/send',
-  celebrate(sendCampaignValidator),
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.sendCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/stop:
- *    post:
- *      tags:
- *        - Email
- *      summary: Stop sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/stop', JobMiddleware.stopCampaign)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/retry:
- *    post:
- *      tags:
- *        - Email
- *      summary: Retry sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden as there is a job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/retry',
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.retryCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/stats:
- *    get:
- *      tags:
- *        - Email
- *      summary: Get email campaign stats
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/stats', EmailStatsMiddleware.getStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/refresh-stats:
- *    post:
- *      tags:
- *        - Email
- *      summary: Get email campaign stats
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/refresh-stats', EmailStatsMiddleware.updateAndGetStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/export:
- *    get:
- *      tags:
- *        - Email
- *      summary: Get recipients of unsuccessful emails in campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: array
- *                items:
- *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "410":
- *           description: Campaign has been redacted
- *        "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/export',
-  CampaignMiddleware.isCampaignRedacted,
-  EmailStatsMiddleware.getDeliveredRecipients
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/protect/upload/start:
- *    get:
- *      tags:
- *        - Email
- *      summary: Start multipart upload
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *        - name: mime_type
- *          in: query
- *          required: true
- *          schema:
- *            type: string
- *        - name: part_count
- *          in: query
- *          required: true
- *          schema:
- *            type: integer
- *            minimum: 1
- *            maximum: 100
- *            default: 1
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 transaction_id:
- *                  type: string
- *                 presigned_urls:
- *                  type: array
- *                  items:
- *                    type: string
- *
- *        "400" :
- *           description: Invalid campaign type, not owned by user
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/protect/upload/start',
-  celebrate(startMultipartValidator),
-  CampaignMiddleware.canEditCampaign,
-  ProtectedMiddleware.isProtectedCampaign,
-  UploadMiddleware.startMultipartUpload
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/email/protect/upload/complete:
- *     post:
- *       summary: Complete multipart upload
- *       tags:
- *         - Email
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - filename
- *                 - transaction_id
- *                 - part_count
- *                 - etags
- *               properties:
- *                 filename:
- *                   type: string
- *                 transaction_id:
- *                   type: string
- *                 part_count:
- *                   type: integer
- *                 etags:
- *                   type: array
- *                   items:
- *                     type: string
- *       responses:
- *         200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 transaction_id:
- *                  type: string
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/protect/upload/complete',
-  celebrate(completeMultipartValidator),
-  CampaignMiddleware.canEditCampaign,
-  ProtectedMiddleware.isProtectedCampaign,
-  UploadMiddleware.completeMultipart,
-  EmailTemplateMiddleware.uploadProtectedCompleteHandler
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/email/duplicate:
- *    post:
- *      tags:
- *        - Email
- *      summary: Duplicate the campaign and its template
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                name:
- *                  type: string
- *
- *      responses:
- *        "201":
- *           description: A duplicate of the campaign was created
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/duplicate',
-  celebrate(duplicateCampaignValidator),
-  EmailMiddleware.duplicateCampaign
-)
-
-export default router

--- a/backend/src/email/routes/email-settings.routes.ts
+++ b/backend/src/email/routes/email-settings.routes.ts
@@ -4,84 +4,88 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { EmailMiddleware } from '@email/middlewares'
 import { fromAddressValidator } from '@core/utils/from-address'
 
-const router = Router()
+export const InitEmailSettingsRoute = (
+  emailMiddleware: EmailMiddleware
+): Router => {
+  const router = Router()
 
-// validators
-const verifyValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string()
-      .email()
-      .options({ convert: true })
-      .lowercase()
-      .optional(),
-    from: fromAddressValidator,
-  }),
+  // validators
+  const verifyValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string()
+        .email()
+        .options({ convert: true })
+        .lowercase()
+        .optional(),
+      from: fromAddressValidator,
+    }),
+  }
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/email/from/verify:
+   *    post:
+   *      summary: Verifies the user's email address to see if it can be used to send out emails
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                recipient:
+   *                  type: string
+   *                from:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request (verification fails)
+   *        503:
+   *          description: Service Unavailable. Try using the default from address instead.
+   *
+   */
+  router.post(
+    '/from/verify',
+    celebrate(verifyValidator),
+    emailMiddleware.isCustomFromAddressAllowed,
+    emailMiddleware.isFromAddressAccepted,
+    emailMiddleware.verifyFromAddress,
+    emailMiddleware.sendValidationMessage,
+    emailMiddleware.storeFromAddress
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/email/from:
+   *    get:
+   *      summary: Returns an array of valid custom 'from' email addresses for the user
+   *      tags:
+   *        - Settings
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  from:
+   *                    type: array
+   *                    items:
+   *                      type: string
+   *        500:
+   *          description: Internal Server Error
+   *
+   */
+  router.get('/from', emailMiddleware.getCustomFromAddress)
+
+  return router
 }
-
-/**
- * @swagger
- * paths:
- *  /settings/email/from/verify:
- *    post:
- *      summary: Verifies the user's email address to see if it can be used to send out emails
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                recipient:
- *                  type: string
- *                from:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request (verification fails)
- *        503:
- *          description: Service Unavailable. Try using the default from address instead.
- *
- */
-router.post(
-  '/from/verify',
-  celebrate(verifyValidator),
-  EmailMiddleware.isCustomFromAddressAllowed,
-  EmailMiddleware.isFromAddressAccepted,
-  EmailMiddleware.verifyFromAddress,
-  EmailMiddleware.sendValidationMessage,
-  EmailMiddleware.storeFromAddress
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/email/from:
- *    get:
- *      summary: Returns an array of valid custom 'from' email addresses for the user
- *      tags:
- *        - Settings
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  from:
- *                    type: array
- *                    items:
- *                      type: string
- *        500:
- *          description: Internal Server Error
- *
- */
-router.get('/from', EmailMiddleware.getCustomFromAddress)
-
-export default router

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -6,75 +6,80 @@ import {
 } from '@email/middlewares'
 import { fromAddressValidator } from '@core/utils/from-address'
 
-const router = Router({ mergeParams: true })
+export const InitEmailTransactionalRoute = (
+  emailTransactionalMiddleware: EmailTransactionalMiddleware,
+  emailMiddleware: EmailMiddleware
+): Router => {
+  const router = Router({ mergeParams: true })
 
-// Validators
-const sendValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string()
-      .email()
-      .options({ convert: true })
-      .lowercase()
-      .required(),
-    subject: Joi.string().required(),
-    body: Joi.string().required(),
-    from: fromAddressValidator,
-    reply_to: Joi.string()
-      .trim()
-      .email()
-      .options({ convert: true })
-      .lowercase(),
-  }),
+  // Validators
+  const sendValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string()
+        .email()
+        .options({ convert: true })
+        .lowercase()
+        .required(),
+      subject: Joi.string().required(),
+      body: Joi.string().required(),
+      from: fromAddressValidator,
+      reply_to: Joi.string()
+        .trim()
+        .email()
+        .options({ convert: true })
+        .lowercase(),
+    }),
+  }
+
+  // Routes
+
+  /**
+   * @swagger
+   * paths:
+   *   /transactional/email/send:
+   *     post:
+   *       summary: "Send a transactional email"
+   *       tags:
+   *         - Email
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - subject
+   *                 - body
+   *                 - recipient
+   *               properties:
+   *                 subject:
+   *                   type: string
+   *                 body:
+   *                   type: string
+   *                 recipient:
+   *                   type: string
+   *                 from:
+   *                   type: string
+   *                 reply_to:
+   *                   type: string
+   *                   nullable: true
+   *       responses:
+   *         "202":
+   *           description: Accepted. The message is being sent.
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "429":
+   *           description: Too many requests. Please try again later.
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.use(
+    '/send',
+    celebrate(sendValidator),
+    emailMiddleware.isFromAddressAccepted,
+    emailTransactionalMiddleware.rateLimit,
+    emailTransactionalMiddleware.sendMessage
+  )
+
+  return router
 }
-
-// Routes
-
-/**
- * @swagger
- * paths:
- *   /transactional/email/send:
- *     post:
- *       summary: "Send a transactional email"
- *       tags:
- *         - Email
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - subject
- *                 - body
- *                 - recipient
- *               properties:
- *                 subject:
- *                   type: string
- *                 body:
- *                   type: string
- *                 recipient:
- *                   type: string
- *                 from:
- *                   type: string
- *                 reply_to:
- *                   type: string
- *                   nullable: true
- *       responses:
- *         "202":
- *           description: Accepted. The message is being sent.
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "429":
- *           description: Too many requests. Please try again later.
- *         "500":
- *           description: Internal Server Error
- */
-router.use(
-  '/send',
-  celebrate(sendValidator),
-  EmailMiddleware.isFromAddressAccepted,
-  EmailTransactionalMiddleware.rateLimit,
-  EmailTransactionalMiddleware.sendMessage
-)
-
-export default router

--- a/backend/src/email/routes/index.ts
+++ b/backend/src/email/routes/index.ts
@@ -1,4 +1,4 @@
-export { default as emailCampaignRoutes } from './email-campaign.routes'
-export { default as emailSettingsRoutes } from './email-settings.routes'
+export * from './email-campaign.routes'
+export * from './email-settings.routes'
 export { default as emailCallbackRoutes } from './email-callback.routes'
-export { default as emailTransactionalRoutes } from './email-transactional.routes'
+export * from './email-transactional.routes'

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -4,7 +4,7 @@ import initialiseServer from '@test-utils/server'
 import config from '@core/config'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 import { EmailFromAddress, EmailMessage } from '@email/models'
 import { CustomDomainService } from '@email/services'
 import { ChannelType } from '@core/constants'
@@ -41,8 +41,7 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
   await UploadService.destroyUploadQueue()
-  RedisService.otpClient.quit()
-  RedisService.sessionClient.quit()
+  await (app as any).cleanup()
 })
 
 describe('PUT /campaign/{campaignId}/email/template', () => {

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -2,7 +2,6 @@ import request from 'supertest'
 import { Sequelize } from 'sequelize-typescript'
 
 import { User } from '@core/models'
-import { RedisService } from '@core/services'
 import { EmailService } from '@email/services'
 
 import initialiseServer from '@test-utils/server'
@@ -27,7 +26,9 @@ beforeEach(async () => {
 beforeAll(async () => {
   sequelize = await sequelizeLoader(process.env.JEST_WORKER_ID || '1')
   // Flush the rate limit redis database
-  await new Promise((resolve) => RedisService.rateLimitClient.flushdb(resolve))
+  await new Promise((resolve) =>
+    (app as any).redisService.rateLimitClient.flushdb(resolve)
+  )
 })
 
 afterEach(() => jest.resetAllMocks())
@@ -36,8 +37,10 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
 
-  await new Promise((resolve) => RedisService.rateLimitClient.flushdb(resolve))
-  await RedisService.shutdown()
+  await new Promise((resolve) =>
+    (app as any).redisService.rateLimitClient.flushdb(resolve)
+  )
+  await (app as any).cleanup()
 })
 
 describe('POST /transactional/email/send', () => {

--- a/backend/src/email/services/tests/email-template.service.test.ts
+++ b/backend/src/email/services/tests/email-template.service.test.ts
@@ -4,7 +4,7 @@ import sequelizeLoader from '@test-utils/sequelize-loader'
 import S3Client from '@core/services/s3-client.class'
 import { ChannelType } from '@core/constants'
 import { Campaign, User, ProtectedMessage } from '@core/models'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { EmailTemplateService } from '@email/services'
@@ -47,8 +47,6 @@ afterAll(async () => {
 
   await UploadService.destroyUploadQueue()
 
-  await new Promise((resolve) => RedisService.otpClient.quit(resolve))
-  await new Promise((resolve) => RedisService.sessionClient.quit(resolve))
   await new Promise((resolve) => setImmediate(resolve))
 })
 

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import { ChannelType, DefaultCredentialName } from '@core/constants'
 import { CredentialService } from '@core/services'
 import { SmsService } from '@sms/services'
@@ -6,367 +6,388 @@ import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
 
-const logger = loggerWithLabel(module)
-
-/**
- * Checks if the campaign id supplied is indeed a campaign of the 'SMS' type, and belongs to the user
- * @param req
- * @param res
- * @param next
- */
-const isSmsCampaignOwnedByUser = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const userId = req.session?.user?.id
-    const campaign = await SmsService.findCampaign(+campaignId, +userId)
-    if (campaign) {
-      return next()
-    } else {
-      return res.sendStatus(403)
-    }
-  } catch (err) {
-    return next(err)
-  }
+export interface SmsMiddleware {
+  getCredentialsFromBody: Handler
+  getCredentialsFromLabel: Handler
+  isSmsCampaignOwnedByUser: Handler
+  validateAndStoreCredentials: Handler
+  setCampaignCredential: Handler
+  getCampaignDetails: Handler
+  previewFirstMessage: Handler
+  disabledForDemoCampaign: Handler
+  duplicateCampaign: Handler
+  canValidateCredentials: Handler
 }
 
-/**
- * Disable a request made for a demo campaign
- * @param req
- * @param res
- * @param next
- */
-const disabledForDemoCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+export const InitSmsMiddleware = (
+  credentialService: CredentialService
+): SmsMiddleware => {
+  const logger = loggerWithLabel(module)
+
+  /**
+   * Checks if the campaign id supplied is indeed a campaign of the 'SMS' type, and belongs to the user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const isSmsCampaignOwnedByUser = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const userId = req.session?.user?.id
+      const campaign = await SmsService.findCampaign(+campaignId, +userId)
+      if (campaign) {
+        return next()
+      } else {
+        return res.sendStatus(403)
+      }
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Disable a request made for a demo campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const disabledForDemoCampaign = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const campaign = await SmsService.findCampaign(
+        +req.params.campaignId,
+        userId
+      )
+      if (campaign.demoMessageLimit) {
+        return res.status(400).json({
+          message: `Action not allowed for demo campaign`,
+        })
+      }
+      return next()
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Parse twilio credentials from request body, setting it to res.locals.credentials to be passed downstream
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCredentialsFromBody = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
+    const {
+      twilio_account_sid: accountSid,
+      twilio_api_key: apiKey,
+      twilio_api_secret: apiSecret,
+      twilio_messaging_service_sid: messagingServiceSid,
+    } = req.body
+
+    res.locals.credentials = {
+      accountSid,
+      apiKey,
+      apiSecret,
+      messagingServiceSid,
+    }
+    return next()
+  }
+
+  const getDemoCredentialName = (label: string): string => {
+    // Demo campaigns can only use default credentials
+    if (label === DefaultCredentialName.SMS) {
+      return formatDefaultCredentialName(label)
+    } else {
+      throw new Error(
+        `Demo campaign must use demo credentials. ${label} is not allowed.`
+      )
+    }
+  }
+  const getCredentialName = async (
+    label: string,
+    userId: number
+  ): Promise<string> => {
+    // Non-demo campaigns cannot use default credentials
+    if (label === DefaultCredentialName.SMS) {
+      throw new Error(
+        `Campaign cannot use demo credentials. ${label} is not allowed.`
+      )
+    } else {
+      // if label provided, fetch from aws secrets
+      const userCred = await credentialService.getUserCredential(userId, label)
+
+      if (!userCred) {
+        throw new Error('User credential cannot be found')
+      }
+
+      return userCred.credName
+    }
+  }
+
+  /**
+   * Parse label from request body. Retrieve credentials associated with this label,
+   * and set the credentials to res.locals.credentials, credName to res.locals.credentialName, to be passed downstream
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCredentialsFromLabel = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
+    const { campaignId } = req.params // May be undefined if invoked from settings page
+    const { label } = req.body
     const userId = req.session?.user?.id
-    const campaign = await SmsService.findCampaign(
-      +req.params.campaignId,
-      userId
-    )
-    if (campaign.demoMessageLimit) {
+    const logMeta = {
+      campaignId,
+      label,
+      action: 'getCredentialsFromLabel',
+    }
+    try {
+      /* Determine if credential name can be used */
+      const campaign = campaignId
+        ? await SmsService.findCampaign(+campaignId, userId)
+        : null
+      const credentialName = campaign?.demoMessageLimit
+        ? getDemoCredentialName(label)
+        : await getCredentialName(label, +userId)
+
+      /* Get credential from the name */
+      const credentials = await credentialService.getTwilioCredentials(
+        credentialName
+      )
+      res.locals.credentials = credentials
+      res.locals.credentialName = credentialName
+      return next()
+    } catch (err) {
+      logger.error({
+        ...logMeta,
+        message: `${err.stack}`,
+      })
+      return res.status(400).json({ message: `${err.message}` })
+    }
+  }
+
+  /**
+   * Sends a test message. If the test message succeeds,
+   * store the credentials in AWS secrets manager and db.
+   * Set the credentialName and channelType in res.locals to be passed downstream
+   * @param req
+   * @param res
+   */
+  const validateAndStoreCredentials = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { recipient } = req.body
+    const { campaignId } = req.params
+    const { credentials, credentialName } = res.locals
+    const logMeta = {
+      campaignId,
+      recipient,
+      action: 'validateAndStoreCredentials',
+    }
+    try {
+      if (campaignId) {
+        // Sends first hydrated message from campaign
+        await SmsService.sendCampaignMessage(
+          +campaignId,
+          recipient,
+          credentials
+        )
+      } else {
+        // Sends generic validation message if campaignId not specified
+        await SmsService.sendValidationMessage(recipient, credentials)
+      }
+      // If credentialName exists, credential has already been stored
+      if (credentialName) {
+        return next()
+      }
+    } catch (err) {
+      logger.error({
+        message: 'Failed to validate and store credentials',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: `${err}` })
+    }
+    try {
+      // Store credentials in AWS secrets manager
+      const stringifiedCredential = JSON.stringify(credentials)
+      const credentialName = await SmsService.getEncodedHash(
+        stringifiedCredential
+      )
+
+      // We only want to tag Twilio credentials with the environment tag in SecretsManager
+      // when env is development. This allows us to quickly identify and clean up dev secrets.
+      await credentialService.storeCredential(
+        credentialName,
+        stringifiedCredential,
+        config.get('env') === 'development'
+      )
+      // Pass on to next middleware/handler
+      res.locals.credentialName = credentialName
+      res.locals.channelType = ChannelType.SMS
+      next()
+    } catch (err) {
+      logger.error({
+        message: 'Failed to store credentials in AWS secrets manager',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: `${err.message}` })
+    }
+  }
+
+  /**
+   * Associate campaign with a credential
+   * @param req
+   * @param res
+   * @param next
+   */
+  const setCampaignCredential = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { credentialName } = res.locals
+      if (!credentialName) {
+        throw new Error('Credential does not exist')
+      }
+      await SmsService.setCampaignCredential(+campaignId, credentialName)
+      return res.json({ message: 'OK' })
+    } catch (err) {
+      next(err)
+    }
+  }
+
+  /**
+   * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCampaignDetails = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const result = await SmsService.getCampaignDetails(+campaignId)
+      return res.json(result)
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Retrieves a message for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const previewFirstMessage = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      return res.json({
+        preview: await SmsService.getHydratedMessage(+campaignId),
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   *  Duplicate a campaign and its template
+   * @param req
+   * @param res
+   * @param next
+   */
+  const duplicateCampaign = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { name } = req.body
+      const campaign = await SmsService.duplicateCampaign({
+        campaignId: +campaignId,
+        name,
+      })
+      if (!campaign) {
+        return res.status(400).json({
+          message: `Unable to duplicate campaign with these parameters`,
+        })
+      }
+      logger.info({
+        message: 'Successfully copied campaign',
+        campaignId: campaign.id,
+        action: 'duplicateCampaign',
+      })
+      return res.status(201).json({
+        id: campaign.id,
+        name: campaign.name,
+        created_at: campaign.createdAt,
+        type: campaign.type,
+        protect: campaign.protect,
+        demo_message_limit: campaign.demoMessageLimit,
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Determine if new credentials can be validated based on whether fallback is activated.
+   * @param req
+   * @param res
+   * @param next
+   */
+  const canValidateCredentials = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    if (config.get('smsFallback.activate')) {
       return res.status(400).json({
-        message: `Action not allowed for demo campaign`,
+        message:
+          'We are temporarily unable to validate Twilio credentials. Please try again later.',
       })
     }
-    return next()
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Parse twilio credentials from request body, setting it to res.locals.credentials to be passed downstream
- * @param req
- * @param res
- * @param next
- */
-const getCredentialsFromBody = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void | Response> => {
-  const {
-    twilio_account_sid: accountSid,
-    twilio_api_key: apiKey,
-    twilio_api_secret: apiSecret,
-    twilio_messaging_service_sid: messagingServiceSid,
-  } = req.body
-
-  res.locals.credentials = {
-    accountSid,
-    apiKey,
-    apiSecret,
-    messagingServiceSid,
-  }
-  return next()
-}
-
-const getDemoCredentialName = (label: string): string => {
-  // Demo campaigns can only use default credentials
-  if (label === DefaultCredentialName.SMS) {
-    return formatDefaultCredentialName(label)
-  } else {
-    throw new Error(
-      `Demo campaign must use demo credentials. ${label} is not allowed.`
-    )
-  }
-}
-const getCredentialName = async (
-  label: string,
-  userId: number
-): Promise<string> => {
-  // Non-demo campaigns cannot use default credentials
-  if (label === DefaultCredentialName.SMS) {
-    throw new Error(
-      `Campaign cannot use demo credentials. ${label} is not allowed.`
-    )
-  } else {
-    // if label provided, fetch from aws secrets
-    const userCred = await CredentialService.getUserCredential(userId, label)
-
-    if (!userCred) {
-      throw new Error('User credential cannot be found')
-    }
-
-    return userCred.credName
-  }
-}
-
-/**
- * Parse label from request body. Retrieve credentials associated with this label,
- * and set the credentials to res.locals.credentials, credName to res.locals.credentialName, to be passed downstream
- * @param req
- * @param res
- * @param next
- */
-const getCredentialsFromLabel = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void | Response> => {
-  const { campaignId } = req.params // May be undefined if invoked from settings page
-  const { label } = req.body
-  const userId = req.session?.user?.id
-  const logMeta = {
-    campaignId,
-    label,
-    action: 'getCredentialsFromLabel',
-  }
-  try {
-    /* Determine if credential name can be used */
-    const campaign = campaignId
-      ? await SmsService.findCampaign(+campaignId, userId)
-      : null
-    const credentialName = campaign?.demoMessageLimit
-      ? getDemoCredentialName(label)
-      : await getCredentialName(label, +userId)
-
-    /* Get credential from the name */
-    const credentials = await CredentialService.getTwilioCredentials(
-      credentialName
-    )
-    res.locals.credentials = credentials
-    res.locals.credentialName = credentialName
-    return next()
-  } catch (err) {
-    logger.error({
-      ...logMeta,
-      message: `${err.stack}`,
-    })
-    return res.status(400).json({ message: `${err.message}` })
-  }
-}
-
-/**
- * Sends a test message. If the test message succeeds,
- * store the credentials in AWS secrets manager and db.
- * Set the credentialName and channelType in res.locals to be passed downstream
- * @param req
- * @param res
- */
-const validateAndStoreCredentials = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { recipient } = req.body
-  const { campaignId } = req.params
-  const { credentials, credentialName } = res.locals
-  const logMeta = {
-    campaignId,
-    recipient,
-    action: 'validateAndStoreCredentials',
-  }
-  try {
-    if (campaignId) {
-      // Sends first hydrated message from campaign
-      await SmsService.sendCampaignMessage(+campaignId, recipient, credentials)
-    } else {
-      // Sends generic validation message if campaignId not specified
-      await SmsService.sendValidationMessage(recipient, credentials)
-    }
-    // If credentialName exists, credential has already been stored
-    if (credentialName) {
-      return next()
-    }
-  } catch (err) {
-    logger.error({
-      message: 'Failed to validate and store credentials',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: `${err}` })
-  }
-  try {
-    // Store credentials in AWS secrets manager
-    const stringifiedCredential = JSON.stringify(credentials)
-    const credentialName = await SmsService.getEncodedHash(
-      stringifiedCredential
-    )
-
-    // We only want to tag Twilio credentials with the environment tag in SecretsManager
-    // when env is development. This allows us to quickly identify and clean up dev secrets.
-    await CredentialService.storeCredential(
-      credentialName,
-      stringifiedCredential,
-      config.get('env') === 'development'
-    )
-    // Pass on to next middleware/handler
-    res.locals.credentialName = credentialName
-    res.locals.channelType = ChannelType.SMS
     next()
-  } catch (err) {
-    logger.error({
-      message: 'Failed to store credentials in AWS secrets manager',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: `${err.message}` })
   }
-}
 
-/**
- * Associate campaign with a credential
- * @param req
- * @param res
- * @param next
- */
-const setCampaignCredential = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const { credentialName } = res.locals
-    if (!credentialName) {
-      throw new Error('Credential does not exist')
-    }
-    await SmsService.setCampaignCredential(+campaignId, credentialName)
-    return res.json({ message: 'OK' })
-  } catch (err) {
-    next(err)
+  return {
+    getCredentialsFromBody,
+    getCredentialsFromLabel,
+    isSmsCampaignOwnedByUser,
+    validateAndStoreCredentials,
+    setCampaignCredential,
+    getCampaignDetails,
+    previewFirstMessage,
+    disabledForDemoCampaign,
+    duplicateCampaign,
+    canValidateCredentials,
   }
-}
-
-/**
- * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
- * @param req
- * @param res
- * @param next
- */
-const getCampaignDetails = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const result = await SmsService.getCampaignDetails(+campaignId)
-    return res.json(result)
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Retrieves a message for this campaign
- * @param req
- * @param res
- * @param next
- */
-const previewFirstMessage = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    return res.json({
-      preview: await SmsService.getHydratedMessage(+campaignId),
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- *  Duplicate a campaign and its template
- * @param req
- * @param res
- * @param next
- */
-const duplicateCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const { name } = req.body
-    const campaign = await SmsService.duplicateCampaign({
-      campaignId: +campaignId,
-      name,
-    })
-    if (!campaign) {
-      return res.status(400).json({
-        message: `Unable to duplicate campaign with these parameters`,
-      })
-    }
-    logger.info({
-      message: 'Successfully copied campaign',
-      campaignId: campaign.id,
-      action: 'duplicateCampaign',
-    })
-    return res.status(201).json({
-      id: campaign.id,
-      name: campaign.name,
-      created_at: campaign.createdAt,
-      type: campaign.type,
-      protect: campaign.protect,
-      demo_message_limit: campaign.demoMessageLimit,
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Determine if new credentials can be validated based on whether fallback is activated.
- * @param req
- * @param res
- * @param next
- */
-const canValidateCredentials = async (
-  _req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  if (config.get('smsFallback.activate')) {
-    return res.status(400).json({
-      message:
-        'We are temporarily unable to validate Twilio credentials. Please try again later.',
-    })
-  }
-  next()
-}
-
-export const SmsMiddleware = {
-  getCredentialsFromBody,
-  getCredentialsFromLabel,
-  isSmsCampaignOwnedByUser,
-  validateAndStoreCredentials,
-  setCampaignCredential,
-  getCampaignDetails,
-  previewFirstMessage,
-  disabledForDemoCampaign,
-  duplicateCampaign,
-  canValidateCredentials,
 }

--- a/backend/src/sms/middlewares/tests/sms.middleware.test.ts
+++ b/backend/src/sms/middlewares/tests/sms.middleware.test.ts
@@ -2,14 +2,17 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
+import { InitCredentialService, RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { SmsMiddleware } from '@sms/middlewares/sms.middleware'
+import { InitSmsMiddleware } from '..'
 
 let sequelize: Sequelize
 let campaignId: number
 let mockRequest: Partial<Request>
 let mockResponse: Partial<Response>
+const redisService = new RedisService()
+let smsMiddleware: SmsMiddleware
 const nextFunction: NextFunction = jest.fn()
 
 beforeEach(() => {
@@ -17,6 +20,7 @@ beforeEach(() => {
   mockResponse = {
     sendStatus: jest.fn(),
   }
+  smsMiddleware = InitSmsMiddleware(InitCredentialService(redisService))
 })
 
 beforeAll(async () => {
@@ -36,7 +40,7 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await redisService.shutdown()
 })
 
 describe('isSmsCampaignOwnedByUser middleware', () => {
@@ -46,7 +50,7 @@ describe('isSmsCampaignOwnedByUser middleware', () => {
       session: { user: { id: 2 } } as any,
     }
 
-    await SmsMiddleware.isSmsCampaignOwnedByUser(
+    await smsMiddleware.isSmsCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction
@@ -60,7 +64,7 @@ describe('isSmsCampaignOwnedByUser middleware', () => {
       session: { user: { id: 1 } } as any,
     }
 
-    await SmsMiddleware.isSmsCampaignOwnedByUser(
+    await smsMiddleware.isSmsCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction

--- a/backend/src/sms/routes/index.ts
+++ b/backend/src/sms/routes/index.ts
@@ -1,4 +1,4 @@
-export { default as smsCampaignRoutes } from './sms-campaign.routes'
-export { default as smsSettingsRoutes } from './sms-settings.routes'
+export * from './sms-campaign.routes'
+export * from './sms-settings.routes'
 export { default as smsCallbackRoutes } from './sms-callback.routes'
-export { default as smsTransactionalRoutes } from './sms-transactional.routes'
+export * from './sms-transactional.routes'

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -12,744 +12,749 @@ import {
   SmsTemplateMiddleware,
 } from '@sms/middlewares'
 
-const router = Router({ mergeParams: true })
+export const InitSmsCampaignRoute = (
+  smsMiddleware: SmsMiddleware,
+  settingsMiddleware: SettingsMiddleware
+): Router => {
+  const router = Router({ mergeParams: true })
 
-// validators
-const storeTemplateValidator = {
-  [Segments.BODY]: Joi.object({
-    body: Joi.string().required(),
-  }),
+  // validators
+  const storeTemplateValidator = {
+    [Segments.BODY]: Joi.object({
+      body: Joi.string().required(),
+    }),
+  }
+
+  const uploadStartValidator = {
+    [Segments.QUERY]: Joi.object({
+      mime_type: Joi.string().required(),
+      md5: Joi.string().required(),
+    }),
+  }
+
+  const uploadCompleteValidator = {
+    [Segments.BODY]: Joi.object({
+      transaction_id: Joi.string().required(),
+      filename: Joi.string().required(),
+      etag: Joi.string().required(),
+    }),
+  }
+
+  const storeCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      twilio_account_sid: Joi.string().trim().required(),
+      twilio_api_secret: Joi.string().trim().required(),
+      twilio_api_key: Joi.string().trim().required(),
+      twilio_messaging_service_sid: Joi.string().trim().required(),
+      recipient: Joi.string().trim().required(),
+      label: Joi.string()
+        .min(1)
+        .max(50)
+        .pattern(/^[a-z0-9-]+$/)
+        .optional(),
+    }),
+  }
+
+  const useCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      label: Joi.string().required(),
+      recipient: Joi.string().trim().required(),
+    }),
+  }
+
+  const sendCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      rate: Joi.number().integer().positive().default(10),
+    }),
+  }
+
+  const duplicateCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      name: Joi.string().max(255).trim().required(),
+    }),
+  }
+
+  // Routes
+
+  // Check if campaign belongs to user for this router
+  router.use(smsMiddleware.isSmsCampaignOwnedByUser)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms:
+   *    get:
+   *      tags:
+   *        - SMS
+   *      summary: Get sms campaign details
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/SMSCampaign'
+   *
+   *        "401":
+   *           description: Unauthorized
+   *        "403" :
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/', smsMiddleware.getCampaignDetails)
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/sms/template:
+   *     put:
+   *       tags:
+   *         - SMS
+   *       summary: Stores body template for sms campaign
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         required: true
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 body:
+   *                   type: string
+   *                   minLength: 1
+   *                   maxLength: 200
+   *
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 required:
+   *                   - message
+   *                   - valid
+   *                   - num_recipients
+   *                   - template
+   *                 properties:
+   *                   message:
+   *                     type: string
+   *                   extra_keys:
+   *                     type: array
+   *                     items:
+   *                       type: string
+   *                   valid:
+   *                     type: boolean
+   *                   num_recipients:
+   *                     type: integer
+   *                   template:
+   *                     type: object
+   *                     properties:
+   *                       body:
+   *                         type: string
+   *                       params:
+   *                         type: array
+   *                         items:
+   *                           type: string
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.put(
+    '/template',
+    celebrate(storeTemplateValidator),
+    CampaignMiddleware.canEditCampaign,
+    SmsTemplateMiddleware.storeTemplate
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/sms/upload/start:
+   *     get:
+   *       summary: "Get a presigned URL for upload with Content-MD5 header"
+   *       tags:
+   *         - SMS
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: mime_type
+   *           in: query
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: md5
+   *           required: true
+   *           in: query
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   presigned_url:
+   *                     type: string
+   *                   transaction_id:
+   *                     type: string
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/upload/start',
+    celebrate(uploadStartValidator),
+    CampaignMiddleware.canEditCampaign,
+    UploadMiddleware.uploadStartHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/sms/upload/complete:
+   *     post:
+   *       summary: "Complete upload session with ETag verification"
+   *       tags:
+   *         - SMS
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - transaction_id
+   *                 - filename
+   *               properties:
+   *                 transaction_id:
+   *                   type: string
+   *                 filename:
+   *                   type: string
+   *                 etag:
+   *                   type: string
+   *       responses:
+   *         "202" :
+   *           description: Accepted. The uploaded file is being processed.
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *          description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/upload/complete',
+    celebrate(uploadCompleteValidator),
+    CampaignMiddleware.canEditCampaign,
+    SmsTemplateMiddleware.uploadCompleteHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/sms/upload/status:
+   *     get:
+   *       summary: "Get csv processing status"
+   *       tags:
+   *         - SMS
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   is_csv_processing:
+   *                     type: boolean
+   *                   csv_filename:
+   *                     type: string
+   *                   temp_csv_filename:
+   *                     type: string
+   *                   csv_error:
+   *                     type: string
+   *                   num_recipients:
+   *                     type: number
+   *                   preview:
+   *                     type: object
+   *                     properties:
+   *                       subject:
+   *                         type: string
+   *                       body:
+   *                         type: string
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get('/upload/status', SmsTemplateMiddleware.pollCsvStatusHandler)
+
+  /**
+   * @swagger
+   * post:
+   *   /campaign/{campaignId}/sms/upload/status:
+   *     delete:
+   *       description: "Deletes error status from previous failed upload"
+   *       tags:
+   *         - SMS
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.delete(
+    '/upload/status',
+    CampaignMiddleware.canEditCampaign,
+    SmsTemplateMiddleware.deleteCsvErrorHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/new-credentials:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Validate twilio credentials and assign to campaign, if label is provided - store credentials for user
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              allOf:
+   *                - $ref: '#/components/schemas/TwilioCredentials'
+   *                - type: object
+   *                  properties:
+   *                    recipient:
+   *                      type: string
+   *                    label:
+   *                      type: string
+   *                      pattern: '/^[a-z0-9-]+$/'
+   *                      minLength: 1
+   *                      maxLength: 50
+   *                      description: should only consist of lowercase alphanumeric characters and dashes
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/new-credentials',
+    celebrate(storeCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    smsMiddleware.canValidateCredentials,
+    smsMiddleware.disabledForDemoCampaign,
+    smsMiddleware.getCredentialsFromBody,
+    smsMiddleware.validateAndStoreCredentials,
+    settingsMiddleware.checkAndStoreLabelIfExists,
+    smsMiddleware.setCampaignCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/credentials:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Validate stored credentials and assign to campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                recipient:
+   *                  type: string
+   *                label:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/credentials',
+    celebrate(useCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    smsMiddleware.getCredentialsFromLabel,
+    smsMiddleware.validateAndStoreCredentials,
+    smsMiddleware.setCampaignCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/preview:
+   *    get:
+   *      tags:
+   *        - SMS
+   *      summary: Preview templated message
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  preview:
+   *                    type: object
+   *                    properties:
+   *                      body:
+   *                        type: string
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/preview', smsMiddleware.previewFirstMessage)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/send:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Start sending campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: false
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                rate:
+   *                  example: 10
+   *                  type: integer
+   *                  minimum: 1
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *                 job_id:
+   *                  type: array
+   *                  items:
+   *                    type: number
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/send',
+    celebrate(sendCampaignValidator),
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.sendCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/stop:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Stop sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/stop', JobMiddleware.stopCampaign)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/retry:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Retry sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/retry',
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.retryCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/stats:
+   *    get:
+   *      tags:
+   *        - SMS
+   *      summary: Get sms campaign stats
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/stats', SmsStatsMiddleware.getStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/refresh-stats:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Forcibly refresh sms campaign stats, then retrieves them
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/refresh-stats', SmsStatsMiddleware.updateAndGetStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/export:
+   *    get:
+   *      tags:
+   *        - SMS
+   *      summary: Get invalid recipients in campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: array
+   *                items:
+   *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "410":
+   *           description: Campaign has been redacted
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/export',
+    CampaignMiddleware.isCampaignRedacted,
+    SmsStatsMiddleware.getDeliveredRecipients
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/sms/duplicate:
+   *    post:
+   *      tags:
+   *        - SMS
+   *      summary: Duplicate the campaign and its template
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                name:
+   *                  type: string
+   *      responses:
+   *        "201":
+   *           description: A duplicate of the campaign was created
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/duplicate',
+    celebrate(duplicateCampaignValidator),
+    smsMiddleware.duplicateCampaign
+  )
+
+  return router
 }
-
-const uploadStartValidator = {
-  [Segments.QUERY]: Joi.object({
-    mime_type: Joi.string().required(),
-    md5: Joi.string().required(),
-  }),
-}
-
-const uploadCompleteValidator = {
-  [Segments.BODY]: Joi.object({
-    transaction_id: Joi.string().required(),
-    filename: Joi.string().required(),
-    etag: Joi.string().required(),
-  }),
-}
-
-const storeCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    twilio_account_sid: Joi.string().trim().required(),
-    twilio_api_secret: Joi.string().trim().required(),
-    twilio_api_key: Joi.string().trim().required(),
-    twilio_messaging_service_sid: Joi.string().trim().required(),
-    recipient: Joi.string().trim().required(),
-    label: Joi.string()
-      .min(1)
-      .max(50)
-      .pattern(/^[a-z0-9-]+$/)
-      .optional(),
-  }),
-}
-
-const useCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    label: Joi.string().required(),
-    recipient: Joi.string().trim().required(),
-  }),
-}
-
-const sendCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    rate: Joi.number().integer().positive().default(10),
-  }),
-}
-
-const duplicateCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    name: Joi.string().max(255).trim().required(),
-  }),
-}
-
-// Routes
-
-// Check if campaign belongs to user for this router
-router.use(SmsMiddleware.isSmsCampaignOwnedByUser)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms:
- *    get:
- *      tags:
- *        - SMS
- *      summary: Get sms campaign details
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/SMSCampaign'
- *
- *        "401":
- *           description: Unauthorized
- *        "403" :
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/', SmsMiddleware.getCampaignDetails)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/sms/template:
- *     put:
- *       tags:
- *         - SMS
- *       summary: Stores body template for sms campaign
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 body:
- *                   type: string
- *                   minLength: 1
- *                   maxLength: 200
- *
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 required:
- *                   - message
- *                   - valid
- *                   - num_recipients
- *                   - template
- *                 properties:
- *                   message:
- *                     type: string
- *                   extra_keys:
- *                     type: array
- *                     items:
- *                       type: string
- *                   valid:
- *                     type: boolean
- *                   num_recipients:
- *                     type: integer
- *                   template:
- *                     type: object
- *                     properties:
- *                       body:
- *                         type: string
- *                       params:
- *                         type: array
- *                         items:
- *                           type: string
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.put(
-  '/template',
-  celebrate(storeTemplateValidator),
-  CampaignMiddleware.canEditCampaign,
-  SmsTemplateMiddleware.storeTemplate
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/sms/upload/start:
- *     get:
- *       summary: "Get a presigned URL for upload with Content-MD5 header"
- *       tags:
- *         - SMS
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *         - name: mime_type
- *           in: query
- *           required: true
- *           schema:
- *             type: string
- *         - name: md5
- *           required: true
- *           in: query
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 type: object
- *                 properties:
- *                   presigned_url:
- *                     type: string
- *                   transaction_id:
- *                     type: string
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/upload/start',
-  celebrate(uploadStartValidator),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/sms/upload/complete:
- *     post:
- *       summary: "Complete upload session with ETag verification"
- *       tags:
- *         - SMS
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - transaction_id
- *                 - filename
- *               properties:
- *                 transaction_id:
- *                   type: string
- *                 filename:
- *                   type: string
- *                 etag:
- *                   type: string
- *       responses:
- *         "202" :
- *           description: Accepted. The uploaded file is being processed.
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *          description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/upload/complete',
-  celebrate(uploadCompleteValidator),
-  CampaignMiddleware.canEditCampaign,
-  SmsTemplateMiddleware.uploadCompleteHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/sms/upload/status:
- *     get:
- *       summary: "Get csv processing status"
- *       tags:
- *         - SMS
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 properties:
- *                   is_csv_processing:
- *                     type: boolean
- *                   csv_filename:
- *                     type: string
- *                   temp_csv_filename:
- *                     type: string
- *                   csv_error:
- *                     type: string
- *                   num_recipients:
- *                     type: number
- *                   preview:
- *                     type: object
- *                     properties:
- *                       subject:
- *                         type: string
- *                       body:
- *                         type: string
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get('/upload/status', SmsTemplateMiddleware.pollCsvStatusHandler)
-
-/**
- * @swagger
- * post:
- *   /campaign/{campaignId}/sms/upload/status:
- *     delete:
- *       description: "Deletes error status from previous failed upload"
- *       tags:
- *         - SMS
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.delete(
-  '/upload/status',
-  CampaignMiddleware.canEditCampaign,
-  SmsTemplateMiddleware.deleteCsvErrorHandler
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/new-credentials:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Validate twilio credentials and assign to campaign, if label is provided - store credentials for user
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              allOf:
- *                - $ref: '#/components/schemas/TwilioCredentials'
- *                - type: object
- *                  properties:
- *                    recipient:
- *                      type: string
- *                    label:
- *                      type: string
- *                      pattern: '/^[a-z0-9-]+$/'
- *                      minLength: 1
- *                      maxLength: 50
- *                      description: should only consist of lowercase alphanumeric characters and dashes
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/new-credentials',
-  celebrate(storeCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  SmsMiddleware.canValidateCredentials,
-  SmsMiddleware.disabledForDemoCampaign,
-  SmsMiddleware.getCredentialsFromBody,
-  SmsMiddleware.validateAndStoreCredentials,
-  SettingsMiddleware.checkAndStoreLabelIfExists,
-  SmsMiddleware.setCampaignCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/credentials:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Validate stored credentials and assign to campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                recipient:
- *                  type: string
- *                label:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/credentials',
-  celebrate(useCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  SmsMiddleware.getCredentialsFromLabel,
-  SmsMiddleware.validateAndStoreCredentials,
-  SmsMiddleware.setCampaignCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/preview:
- *    get:
- *      tags:
- *        - SMS
- *      summary: Preview templated message
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  preview:
- *                    type: object
- *                    properties:
- *                      body:
- *                        type: string
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/preview', SmsMiddleware.previewFirstMessage)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/send:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Start sending campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: false
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                rate:
- *                  example: 10
- *                  type: integer
- *                  minimum: 1
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *                 job_id:
- *                  type: array
- *                  items:
- *                    type: number
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/send',
-  celebrate(sendCampaignValidator),
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.sendCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/stop:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Stop sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/stop', JobMiddleware.stopCampaign)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/retry:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Retry sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/retry',
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.retryCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/stats:
- *    get:
- *      tags:
- *        - SMS
- *      summary: Get sms campaign stats
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/stats', SmsStatsMiddleware.getStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/refresh-stats:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Forcibly refresh sms campaign stats, then retrieves them
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/refresh-stats', SmsStatsMiddleware.updateAndGetStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/export:
- *    get:
- *      tags:
- *        - SMS
- *      summary: Get invalid recipients in campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: array
- *                items:
- *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "410":
- *           description: Campaign has been redacted
- *        "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/export',
-  CampaignMiddleware.isCampaignRedacted,
-  SmsStatsMiddleware.getDeliveredRecipients
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/sms/duplicate:
- *    post:
- *      tags:
- *        - SMS
- *      summary: Duplicate the campaign and its template
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                name:
- *                  type: string
- *      responses:
- *        "201":
- *           description: A duplicate of the campaign was created
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/duplicate',
-  celebrate(duplicateCampaignValidator),
-  SmsMiddleware.duplicateCampaign
-)
-
-export default router

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -5,107 +5,112 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { SmsMiddleware } from '@sms/middlewares'
 import { SettingsMiddleware } from '@core/middlewares'
 
-const router = Router()
+export const InitSmsSettingsRoute = (
+  smsMiddleware: SmsMiddleware,
+  settingsMiddleware: SettingsMiddleware
+): Router => {
+  const router = Router()
 
-const storeCredentialValidator = {
-  [Segments.BODY]: Joi.object({
-    label: Joi.string()
-      .min(1)
-      .max(50)
-      .pattern(/^[a-z0-9-]+$/)
-      .required(),
-    twilio_account_sid: Joi.string().trim().required(),
-    twilio_api_secret: Joi.string().trim().required(),
-    twilio_api_key: Joi.string().trim().required(),
-    twilio_messaging_service_sid: Joi.string().trim().required(),
-    recipient: Joi.string().trim().required(),
-  }),
+  const storeCredentialValidator = {
+    [Segments.BODY]: Joi.object({
+      label: Joi.string()
+        .min(1)
+        .max(50)
+        .pattern(/^[a-z0-9-]+$/)
+        .required(),
+      twilio_account_sid: Joi.string().trim().required(),
+      twilio_api_secret: Joi.string().trim().required(),
+      twilio_api_key: Joi.string().trim().required(),
+      twilio_messaging_service_sid: Joi.string().trim().required(),
+      recipient: Joi.string().trim().required(),
+    }),
+  }
+
+  const verifyCredentialValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string().trim().required(),
+      label: Joi.string().required(),
+    }),
+  }
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/sms/credentials:
+   *    post:
+   *      summary: Store new twilio credentials for user
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              allOf:
+   *                - $ref: '#/components/schemas/TwilioCredentials'
+   *                - type: object
+   *                  properties:
+   *                    label:
+   *                      type: string
+   *                      pattern: '/^[a-z0-9-]+$/'
+   *                      minLength: 1
+   *                      maxLength: 50
+   *                      description: should only consist of lowercase alphanumeric characters and dashes
+   *                    recipient:
+   *                      type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request (invalid credentials, malformed request, duplicate labels)
+   *
+   */
+  router.post(
+    '/credentials',
+    celebrate(storeCredentialValidator),
+    settingsMiddleware.checkUserCredentialLabel,
+    smsMiddleware.canValidateCredentials,
+    smsMiddleware.getCredentialsFromBody,
+    smsMiddleware.validateAndStoreCredentials,
+    settingsMiddleware.storeUserCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/sms/credentials/verify:
+   *    post:
+   *      summary: Verify stored credential for user
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                recipient:
+   *                  type: string
+   *                label:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request (invalid credentials, malformed request)
+   *
+   */
+  router.post(
+    '/credentials/verify',
+    celebrate(verifyCredentialValidator),
+    smsMiddleware.canValidateCredentials,
+    smsMiddleware.getCredentialsFromLabel,
+    smsMiddleware.validateAndStoreCredentials,
+    (_req: Request, res: Response) => res.sendStatus(200)
+  )
+
+  return router
 }
-
-const verifyCredentialValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string().trim().required(),
-    label: Joi.string().required(),
-  }),
-}
-
-/**
- * @swagger
- * paths:
- *  /settings/sms/credentials:
- *    post:
- *      summary: Store new twilio credentials for user
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              allOf:
- *                - $ref: '#/components/schemas/TwilioCredentials'
- *                - type: object
- *                  properties:
- *                    label:
- *                      type: string
- *                      pattern: '/^[a-z0-9-]+$/'
- *                      minLength: 1
- *                      maxLength: 50
- *                      description: should only consist of lowercase alphanumeric characters and dashes
- *                    recipient:
- *                      type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request (invalid credentials, malformed request, duplicate labels)
- *
- */
-router.post(
-  '/credentials',
-  celebrate(storeCredentialValidator),
-  SettingsMiddleware.checkUserCredentialLabel,
-  SmsMiddleware.canValidateCredentials,
-  SmsMiddleware.getCredentialsFromBody,
-  SmsMiddleware.validateAndStoreCredentials,
-  SettingsMiddleware.storeUserCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/sms/credentials/verify:
- *    post:
- *      summary: Verify stored credential for user
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                recipient:
- *                  type: string
- *                label:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request (invalid credentials, malformed request)
- *
- */
-router.post(
-  '/credentials/verify',
-  celebrate(verifyCredentialValidator),
-  SmsMiddleware.canValidateCredentials,
-  SmsMiddleware.getCredentialsFromLabel,
-  SmsMiddleware.validateAndStoreCredentials,
-  (_req: Request, res: Response) => res.sendStatus(200)
-)
-
-export default router

--- a/backend/src/sms/routes/sms-transactional.routes.ts
+++ b/backend/src/sms/routes/sms-transactional.routes.ts
@@ -2,59 +2,63 @@ import { Router } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { SmsMiddleware, SmsTransactionalMiddleware } from '@sms/middlewares'
 
-const router = Router({ mergeParams: true })
+export const InitSmsTransactionalRoute = (
+  smsMiddleware: SmsMiddleware
+): Router => {
+  const router = Router({ mergeParams: true })
 
-// Validators
-const sendValidator = {
-  [Segments.BODY]: {
-    body: Joi.string().required(),
-    recipient: Joi.string().trim().required(),
-    label: Joi.string().required(),
-  },
+  // Validators
+  const sendValidator = {
+    [Segments.BODY]: {
+      body: Joi.string().required(),
+      recipient: Joi.string().trim().required(),
+      label: Joi.string().required(),
+    },
+  }
+
+  // Routes
+
+  /**
+   * @swagger
+   * paths:
+   *   /transactional/sms/send:
+   *     post:
+   *       summary: "Send a transactional SMS"
+   *       tags:
+   *         - SMS
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - body
+   *                 - recipient
+   *                 - label
+   *               properties:
+   *                 body:
+   *                   type: string
+   *                 recipient:
+   *                   type: string
+   *                 label:
+   *                   type: string
+   *       responses:
+   *         "202":
+   *           description: Accepted. The message is being sent.
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "429":
+   *           description: Too many requests. Please try again later.
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/send',
+    celebrate(sendValidator),
+    smsMiddleware.getCredentialsFromLabel,
+    SmsTransactionalMiddleware.sendMessage
+  )
+
+  return router
 }
-
-// Routes
-
-/**
- * @swagger
- * paths:
- *   /transactional/sms/send:
- *     post:
- *       summary: "Send a transactional SMS"
- *       tags:
- *         - SMS
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - body
- *                 - recipient
- *                 - label
- *               properties:
- *                 body:
- *                   type: string
- *                 recipient:
- *                   type: string
- *                 label:
- *                   type: string
- *       responses:
- *         "202":
- *           description: Accepted. The message is being sent.
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "429":
- *           description: Too many requests. Please try again later.
- *         "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/send',
-  celebrate(sendValidator),
-  SmsMiddleware.getCredentialsFromLabel,
-  SmsTransactionalMiddleware.sendMessage
-)
-
-export default router

--- a/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-campaign.routes.test.ts
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Campaign, User, Credential } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 import { DefaultCredentialName } from '@core/constants'
 import { formatDefaultCredentialName } from '@core/utils'
 import { SmsMessage, SmsTemplate } from '@sms/models'
@@ -48,8 +48,7 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
   await UploadService.destroyUploadQueue()
-  RedisService.otpClient.quit()
-  RedisService.sessionClient.quit()
+  await (app as any).cleanup()
 })
 
 describe('GET /campaign/{id}/sms', () => {

--- a/backend/src/sms/routes/tests/sms-settings.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-settings.routes.test.ts
@@ -3,7 +3,6 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Credential, UserCredential, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { mockSecretsManager } from '@mocks/aws-sdk'
 import { SmsService } from '@sms/services'
@@ -21,7 +20,7 @@ afterAll(async () => {
   await Credential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await (app as any).cleanup()
 })
 
 describe('POST /settings/sms/credentials', () => {

--- a/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
@@ -3,7 +3,6 @@ import { Sequelize } from 'sequelize-typescript'
 
 import { User, Credential, UserCredential } from '@core/models'
 import { ChannelType } from '@core/constants'
-import { RedisService } from '@core/services'
 import { RateLimitError, InvalidRecipientError } from '@core/errors'
 import { TemplateError } from '@shared/templating'
 import { SmsService } from '@sms/services'
@@ -55,7 +54,7 @@ afterAll(async () => {
   await UserCredential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await (app as any).cleanup()
 })
 
 describe('POST /transactional/sms/send', () => {

--- a/backend/src/sms/services/tests/sms-template.service.test.ts
+++ b/backend/src/sms/services/tests/sms-template.service.test.ts
@@ -4,7 +4,7 @@ import sequelizeLoader from '@test-utils/sequelize-loader'
 import S3Client from '@core/services/s3-client.class'
 import { ChannelType } from '@core/constants'
 import { Campaign, User } from '@core/models'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 
 import { SmsTemplate, SmsMessage } from '@sms/models'
 import { SmsTemplateService } from '@sms/services'
@@ -45,8 +45,6 @@ afterAll(async () => {
 
   await UploadService.destroyUploadQueue()
 
-  await new Promise((resolve) => RedisService.otpClient.quit(resolve))
-  await new Promise((resolve) => RedisService.sessionClient.quit(resolve))
   await new Promise((resolve) => setImmediate(resolve))
 })
 

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -1,408 +1,426 @@
-import { Request, Response, NextFunction } from 'express'
+import { Request, Response, NextFunction, Handler } from 'express'
 import { ChannelType, DefaultCredentialName } from '@core/constants'
 import { CredentialService } from '@core/services'
 import { TelegramService } from '@telegram/services'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
 
-const logger = loggerWithLabel(module)
+export interface TelegramMiddleware {
+  getCredentialsFromBody: Handler
+  getCredentialsFromLabel: Handler
+  getCampaignCredential: Handler
+  isTelegramCampaignOwnedByUser: Handler
+  getCampaignDetails: Handler
+  previewFirstMessage: Handler
+  validateAndStoreCredentials: Handler
+  setCampaignCredential: Handler
+  sendValidationMessage: Handler
+  disabledForDemoCampaign: Handler
+  duplicateCampaign: Handler
+}
 
-const botId = (telegramBotToken: string): string =>
-  telegramBotToken.split(':')[0]
+export const InitTelegramMiddleware = (
+  credentialService: CredentialService
+): TelegramMiddleware => {
+  const logger = loggerWithLabel(module)
 
-/**
- * Disable a request made for a demo campaign
- * @param req
- * @param res
- * @param next
- */
-const disabledForDemoCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const userId = req.session?.user?.id
-    const campaign = await TelegramService.findCampaign(
-      +req.params.campaignId,
-      userId
-    )
-    if (campaign.demoMessageLimit) {
-      return res.status(400).json({
-        message: `Action disabled for demo campaign`,
-      })
+  const botId = (telegramBotToken: string): string =>
+    telegramBotToken.split(':')[0]
+
+  /**
+   * Disable a request made for a demo campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const disabledForDemoCampaign = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const userId = req.session?.user?.id
+      const campaign = await TelegramService.findCampaign(
+        +req.params.campaignId,
+        userId
+      )
+      if (campaign.demoMessageLimit) {
+        return res.status(400).json({
+          message: `Action disabled for demo campaign`,
+        })
+      }
+      return next()
+    } catch (err) {
+      return next(err)
     }
-    return next()
-  } catch (err) {
-    return next(err)
   }
-}
-/**
- * Parse telegram credentials from request body, setting it to res.locals.credentials to be passed downstream
- * @param req
- * @param res
- * @param next
- */
-const getCredentialsFromBody = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void | Response> => {
-  const { telegram_bot_token: telegramBotToken } = req.body
+  /**
+   * Parse telegram credentials from request body, setting it to res.locals.credentials to be passed downstream
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCredentialsFromBody = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
+    const { telegram_bot_token: telegramBotToken } = req.body
 
-  res.locals.credentials = { telegramBotToken }
-  res.locals.credentialName = `${process.env.NODE_ENV}-${botId(
-    telegramBotToken
-  )}`
-  return next()
-}
-
-const getDemoCredentialName = (label: string): string => {
-  // Demo campaigns can only use default credentials
-  if (label === DefaultCredentialName.Telegram) {
-    return formatDefaultCredentialName(label)
-  } else {
-    throw new Error(
-      `Demo campaign must use demo credentials. ${label} is not allowed.`
-    )
-  }
-}
-const getCredentialName = async (
-  label: string,
-  userId: number
-): Promise<string> => {
-  // Non-demo campaigns cannot use default credentials
-  if (label === DefaultCredentialName.Telegram) {
-    throw new Error(
-      `Campaign cannot use demo credentials. ${label} is not allowed.`
-    )
-  } else {
-    // if label provided, fetch from aws secrets
-    const userCred = await CredentialService.getUserCredential(userId, label)
-
-    if (!userCred) {
-      throw new Error('User credential cannot be found')
-    }
-
-    return userCred.credName
-  }
-}
-
-/**
- * Parse label from request body. Retrieve credentials associated with this label,
- * and set the credentials to res.locals.credentials to be passed downstream
- * @param req
- * @param res
- * @param next
- */
-const getCredentialsFromLabel = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { campaignId } = req.params // May be undefined if invoked from settings page
-  const { label } = req.body
-  const userId = req.session?.user?.id
-  const logMeta = {
-    campaignId,
-    label,
-    action: 'getCredentialsFromLabel',
-  }
-  try {
-    /* Determine if credential name can be used */
-    const campaign = campaignId
-      ? await TelegramService.findCampaign(+campaignId, userId)
-      : null
-    const credentialName = campaign?.demoMessageLimit
-      ? getDemoCredentialName(label)
-      : await getCredentialName(label, +userId)
-
-    const telegramBotToken = await CredentialService.getTelegramCredential(
-      credentialName
-    )
     res.locals.credentials = { telegramBotToken }
-    res.locals.credentialName = botId(telegramBotToken)
+    res.locals.credentialName = `${process.env.NODE_ENV}-${botId(
+      telegramBotToken
+    )}`
     return next()
-  } catch (err) {
-    logger.error({
-      ...logMeta,
-      message: `${err.stack}`,
-    })
-    return res.status(400).json({ message: `${err.message}` })
-  }
-}
-
-/**
- * Retrieve credential for campaign
- * @param res
- * @param req
- * @param next
- */
-const getCampaignCredential = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void | Response> => {
-  const { campaignId } = req.params
-  const userId = req.session?.user?.id
-  const campaign = await TelegramService.findCampaign(+campaignId, userId)
-
-  const { credName } = campaign
-  if (!credName) {
-    logger.error({
-      message: 'Credential not found for this campaign',
-      campaignId,
-      credName,
-      action: 'getCampaignCredential',
-    })
-    return res
-      .status(400)
-      .json({ message: 'No credentials found for this campaign.' })
   }
 
-  const telegramBotToken = await CredentialService.getTelegramCredential(
-    credName
-  )
-
-  res.locals.credentials = { telegramBotToken }
-  res.locals.credentialName = botId(telegramBotToken)
-  next()
-}
-
-/**
- * Call Telegram API getMe to validate token. If the token is valid,
- * we will set the callback url and store the credentials in AWS
- * SecretsManager and db.
- * Set the credentialName and channelType in res.locals to be passed downstream
- * @param req
- * @param res
- */
-const validateAndStoreCredentials = async (
-  _req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  const { telegramBotToken } = res.locals.credentials
-  const { credentialName } = res.locals
-  const logMeta = {
-    credentialName,
-    action: 'validateAndStoreCredentials',
-  }
-  try {
-    await TelegramService.validateAndConfigureBot(telegramBotToken)
-  } catch (err) {
-    logger.error({
-      message: 'Failed to validate and store credentials',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: `${err}` })
-  }
-
-  try {
-    // Credential name will be raw botId. The botId will not be hashed as we
-    // want to preserve the mapping between botId and token even in the event
-    // of a change in salt for future token revocations/updates for the given
-    // botId.
-
-    await CredentialService.storeCredential(
-      credentialName,
-      telegramBotToken,
-      true
-    )
-  } catch (err) {
-    logger.error({
-      message: 'Failed to validate and store credentials',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: 'Error storing credentials' })
-  }
-
-  // Pass on to next middleware/handler
-  res.locals.channelType = ChannelType.Telegram
-  next()
-}
-
-/**
- * Send validation message to recipient
- * @param req
- * @param res
- */
-const sendValidationMessage = async (
-  req: Request,
-  res: Response
-): Promise<Response> => {
-  const { campaignId } = req.params
-  const { recipient } = req.body
-  const { credentials } = res.locals
-  const { telegramBotToken } = credentials
-  const logMeta = { campaignId, recipient, action: 'sendValidationMessage' }
-
-  try {
-    if (!campaignId) {
-      await TelegramService.sendValidationMessage(recipient, telegramBotToken)
+  const getDemoCredentialName = (label: string): string => {
+    // Demo campaigns can only use default credentials
+    if (label === DefaultCredentialName.Telegram) {
+      return formatDefaultCredentialName(label)
     } else {
-      await TelegramService.sendCampaignMessage(
-        +campaignId,
-        recipient,
-        telegramBotToken
+      throw new Error(
+        `Demo campaign must use demo credentials. ${label} is not allowed.`
       )
     }
-    logger.info({ message: 'Sent validation message', ...logMeta })
-    return res.json({ message: 'OK' })
-  } catch (err) {
-    logger.info({
-      message: 'Failed to send validation message',
-      error: err,
-      ...logMeta,
-    })
-    return res.status(400).json({ message: `${err.message}` })
   }
-}
+  const getCredentialName = async (
+    label: string,
+    userId: number
+  ): Promise<string> => {
+    // Non-demo campaigns cannot use default credentials
+    if (label === DefaultCredentialName.Telegram) {
+      throw new Error(
+        `Campaign cannot use demo credentials. ${label} is not allowed.`
+      )
+    } else {
+      // if label provided, fetch from aws secrets
+      const userCred = await credentialService.getUserCredential(userId, label)
 
-/**
- * Checks if the campaign id supplied is indeed a campaign of the 'TELEGRAM' type, and belongs to the user
- * @param req
- * @param res
- * @param next
- */
-const isTelegramCampaignOwnedByUser = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
+      if (!userCred) {
+        throw new Error('User credential cannot be found')
+      }
+
+      return userCred.credName
+    }
+  }
+
+  /**
+   * Parse label from request body. Retrieve credentials associated with this label,
+   * and set the credentials to res.locals.credentials to be passed downstream
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCredentialsFromLabel = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { campaignId } = req.params // May be undefined if invoked from settings page
+    const { label } = req.body
+    const userId = req.session?.user?.id
+    const logMeta = {
+      campaignId,
+      label,
+      action: 'getCredentialsFromLabel',
+    }
+    try {
+      /* Determine if credential name can be used */
+      const campaign = campaignId
+        ? await TelegramService.findCampaign(+campaignId, userId)
+        : null
+      const credentialName = campaign?.demoMessageLimit
+        ? getDemoCredentialName(label)
+        : await getCredentialName(label, +userId)
+
+      const telegramBotToken = await credentialService.getTelegramCredential(
+        credentialName
+      )
+      res.locals.credentials = { telegramBotToken }
+      res.locals.credentialName = botId(telegramBotToken)
+      return next()
+    } catch (err) {
+      logger.error({
+        ...logMeta,
+        message: `${err.stack}`,
+      })
+      return res.status(400).json({ message: `${err.message}` })
+    }
+  }
+
+  /**
+   * Retrieve credential for campaign
+   * @param res
+   * @param req
+   * @param next
+   */
+  const getCampaignCredential = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
     const { campaignId } = req.params
     const userId = req.session?.user?.id
     const campaign = await TelegramService.findCampaign(+campaignId, userId)
-    if (campaign) {
-      return next()
-    } else {
-      return res.sendStatus(403)
-    }
-  } catch (err) {
-    return next(err)
-  }
-}
 
-/**
- * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
- * @param req
- * @param res
- * @param next
- */
-const getCampaignDetails = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const result = await TelegramService.getCampaignDetails(+campaignId)
-    return res.json(result)
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Retrieves a message for this campaign
- * @param req
- * @param res
- * @param next
- */
-const previewFirstMessage = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    return res.json({
-      preview: await TelegramService.getHydratedMessage(+campaignId),
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
-
-/**
- * Associate campaign with a credential
- * @param req
- * @param res
- * @param next
- */
-const setCampaignCredential = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const { credentialName } = res.locals
-    if (!credentialName) {
-      throw new Error('Credential does not exist')
-    }
-
-    await TelegramService.setCampaignCredential(+campaignId, credentialName)
-    return res.json({ message: 'OK' })
-  } catch (err) {
-    next(err)
-  }
-}
-
-/**
- *  Duplicate a campaign and its template
- * @param req
- * @param res
- * @param next
- */
-const duplicateCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const { name } = req.body
-    const campaign = await TelegramService.duplicateCampaign({
-      campaignId: +campaignId,
-      name,
-    })
-    if (!campaign) {
-      return res.status(400).json({
-        message: `Unable to duplicate campaign with these parameters`,
+    const { credName } = campaign
+    if (!credName) {
+      logger.error({
+        message: 'Credential not found for this campaign',
+        campaignId,
+        credName,
+        action: 'getCampaignCredential',
       })
+      return res
+        .status(400)
+        .json({ message: 'No credentials found for this campaign.' })
     }
-    logger.info({
-      message: 'Successfully copied campaign',
-      campaignId: campaign.id,
-      action: 'duplicateCampaign',
-    })
-    return res.status(201).json({
-      id: campaign.id,
-      name: campaign.name,
-      created_at: campaign.createdAt,
-      type: campaign.type,
-      protect: campaign.protect,
-      demo_message_limit: campaign.demoMessageLimit,
-    })
-  } catch (err) {
-    return next(err)
-  }
-}
 
-export const TelegramMiddleware = {
-  getCredentialsFromBody,
-  getCredentialsFromLabel,
-  getCampaignCredential,
-  isTelegramCampaignOwnedByUser,
-  getCampaignDetails,
-  previewFirstMessage,
-  validateAndStoreCredentials,
-  setCampaignCredential,
-  sendValidationMessage,
-  disabledForDemoCampaign,
-  duplicateCampaign,
+    const telegramBotToken = await credentialService.getTelegramCredential(
+      credName
+    )
+
+    res.locals.credentials = { telegramBotToken }
+    res.locals.credentialName = botId(telegramBotToken)
+    next()
+  }
+
+  /**
+   * Call Telegram API getMe to validate token. If the token is valid,
+   * we will set the callback url and store the credentials in AWS
+   * SecretsManager and db.
+   * Set the credentialName and channelType in res.locals to be passed downstream
+   * @param req
+   * @param res
+   */
+  const validateAndStoreCredentials = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    const { telegramBotToken } = res.locals.credentials
+    const { credentialName } = res.locals
+    const logMeta = {
+      credentialName,
+      action: 'validateAndStoreCredentials',
+    }
+    try {
+      await TelegramService.validateAndConfigureBot(telegramBotToken)
+    } catch (err) {
+      logger.error({
+        message: 'Failed to validate and store credentials',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: `${err}` })
+    }
+
+    try {
+      // Credential name will be raw botId. The botId will not be hashed as we
+      // want to preserve the mapping between botId and token even in the event
+      // of a change in salt for future token revocations/updates for the given
+      // botId.
+
+      await credentialService.storeCredential(
+        credentialName,
+        telegramBotToken,
+        true
+      )
+    } catch (err) {
+      logger.error({
+        message: 'Failed to validate and store credentials',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: 'Error storing credentials' })
+    }
+
+    // Pass on to next middleware/handler
+    res.locals.channelType = ChannelType.Telegram
+    next()
+  }
+
+  /**
+   * Send validation message to recipient
+   * @param req
+   * @param res
+   */
+  const sendValidationMessage = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    const { campaignId } = req.params
+    const { recipient } = req.body
+    const { credentials } = res.locals
+    const { telegramBotToken } = credentials
+    const logMeta = { campaignId, recipient, action: 'sendValidationMessage' }
+
+    try {
+      if (!campaignId) {
+        await TelegramService.sendValidationMessage(recipient, telegramBotToken)
+      } else {
+        await TelegramService.sendCampaignMessage(
+          +campaignId,
+          recipient,
+          telegramBotToken
+        )
+      }
+      logger.info({ message: 'Sent validation message', ...logMeta })
+      return res.json({ message: 'OK' })
+    } catch (err) {
+      logger.info({
+        message: 'Failed to send validation message',
+        error: err,
+        ...logMeta,
+      })
+      return res.status(400).json({ message: `${err.message}` })
+    }
+  }
+
+  /**
+   * Checks if the campaign id supplied is indeed a campaign of the 'TELEGRAM' type, and belongs to the user
+   * @param req
+   * @param res
+   * @param next
+   */
+  const isTelegramCampaignOwnedByUser = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const userId = req.session?.user?.id
+      const campaign = await TelegramService.findCampaign(+campaignId, userId)
+      if (campaign) {
+        return next()
+      } else {
+        return res.sendStatus(403)
+      }
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Gets details of a campaign and the number of recipients that have been uploaded for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const getCampaignDetails = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const result = await TelegramService.getCampaignDetails(+campaignId)
+      return res.json(result)
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Retrieves a message for this campaign
+   * @param req
+   * @param res
+   * @param next
+   */
+  const previewFirstMessage = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      return res.json({
+        preview: await TelegramService.getHydratedMessage(+campaignId),
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  /**
+   * Associate campaign with a credential
+   * @param req
+   * @param res
+   * @param next
+   */
+  const setCampaignCredential = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { credentialName } = res.locals
+      if (!credentialName) {
+        throw new Error('Credential does not exist')
+      }
+
+      await TelegramService.setCampaignCredential(+campaignId, credentialName)
+      return res.json({ message: 'OK' })
+    } catch (err) {
+      next(err)
+    }
+  }
+
+  /**
+   *  Duplicate a campaign and its template
+   * @param req
+   * @param res
+   * @param next
+   */
+  const duplicateCampaign = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    try {
+      const { campaignId } = req.params
+      const { name } = req.body
+      const campaign = await TelegramService.duplicateCampaign({
+        campaignId: +campaignId,
+        name,
+      })
+      if (!campaign) {
+        return res.status(400).json({
+          message: `Unable to duplicate campaign with these parameters`,
+        })
+      }
+      logger.info({
+        message: 'Successfully copied campaign',
+        campaignId: campaign.id,
+        action: 'duplicateCampaign',
+      })
+      return res.status(201).json({
+        id: campaign.id,
+        name: campaign.name,
+        created_at: campaign.createdAt,
+        type: campaign.type,
+        protect: campaign.protect,
+        demo_message_limit: campaign.demoMessageLimit,
+      })
+    } catch (err) {
+      return next(err)
+    }
+  }
+
+  return {
+    getCredentialsFromBody,
+    getCredentialsFromLabel,
+    getCampaignCredential,
+    isTelegramCampaignOwnedByUser,
+    getCampaignDetails,
+    previewFirstMessage,
+    validateAndStoreCredentials,
+    setCampaignCredential,
+    sendValidationMessage,
+    disabledForDemoCampaign,
+    duplicateCampaign,
+  }
 }

--- a/backend/src/telegram/middlewares/tests/telegram.middleware.test.ts
+++ b/backend/src/telegram/middlewares/tests/telegram.middleware.test.ts
@@ -2,14 +2,17 @@ import { NextFunction, Request, Response } from 'express'
 import { Sequelize } from 'sequelize-typescript'
 import { Campaign, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
+import { InitCredentialService, RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { TelegramMiddleware } from '@telegram/middlewares/telegram.middleware'
+import { InitTelegramMiddleware } from '..'
 
 let sequelize: Sequelize
 let campaignId: number
 let mockRequest: Partial<Request>
 let mockResponse: Partial<Response>
+const redisService = new RedisService()
+let telegramMiddleware: TelegramMiddleware
 const nextFunction: NextFunction = jest.fn()
 
 beforeEach(() => {
@@ -17,6 +20,9 @@ beforeEach(() => {
   mockResponse = {
     sendStatus: jest.fn(),
   }
+  telegramMiddleware = InitTelegramMiddleware(
+    InitCredentialService(redisService)
+  )
 })
 
 beforeAll(async () => {
@@ -36,7 +42,7 @@ afterAll(async () => {
   await Campaign.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await redisService.shutdown()
 })
 
 describe('isTelegramCampaignOwnedByUser middleware', () => {
@@ -46,7 +52,7 @@ describe('isTelegramCampaignOwnedByUser middleware', () => {
       session: { user: { id: 2 } } as any,
     }
 
-    await TelegramMiddleware.isTelegramCampaignOwnedByUser(
+    await telegramMiddleware.isTelegramCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction
@@ -60,7 +66,7 @@ describe('isTelegramCampaignOwnedByUser middleware', () => {
       session: { user: { id: 1 } } as any,
     }
 
-    await TelegramMiddleware.isTelegramCampaignOwnedByUser(
+    await telegramMiddleware.isTelegramCampaignOwnedByUser(
       mockRequest as Request,
       mockResponse as Response,
       nextFunction

--- a/backend/src/telegram/routes/index.ts
+++ b/backend/src/telegram/routes/index.ts
@@ -1,3 +1,3 @@
-export { default as telegramCampaignRoutes } from './telegram-campaign.routes'
-export { default as telegramSettingsRoutes } from './telegram-settings.routes'
+export * from './telegram-campaign.routes'
+export * from './telegram-settings.routes'
 export { default as telegramCallbackRoutes } from './telegram-callback.routes'

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -12,806 +12,811 @@ import {
   TelegramTemplateMiddleware,
 } from '@telegram/middlewares'
 
-const router = Router({ mergeParams: true })
+export const InitTelegramCampaignMiddleware = (
+  settingsMiddleware: SettingsMiddleware,
+  telegramMiddleware: TelegramMiddleware
+): Router => {
+  const router = Router({ mergeParams: true })
 
-// Validators
-const storeTemplateValidator = {
-  [Segments.BODY]: Joi.object({
-    body: Joi.string().required(),
-  }),
+  // Validators
+  const storeTemplateValidator = {
+    [Segments.BODY]: Joi.object({
+      body: Joi.string().required(),
+    }),
+  }
+
+  const uploadStartValidator = {
+    [Segments.QUERY]: Joi.object({
+      mime_type: Joi.string().required(),
+      md5: Joi.string().required(),
+    }),
+  }
+
+  const uploadCompleteValidator = {
+    [Segments.BODY]: Joi.object({
+      transaction_id: Joi.string().required(),
+      filename: Joi.string().required(),
+      etag: Joi.string().required(),
+    }),
+  }
+
+  const storeCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      telegram_bot_token: Joi.string().trim().required(),
+      label: Joi.string()
+        .min(1)
+        .max(50)
+        .pattern(/^[a-z0-9-]+$/)
+        .optional(),
+    }),
+  }
+
+  const useCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      label: Joi.string().required(),
+    }),
+  }
+
+  const verifyCredentialsValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string().trim().required(),
+    }),
+  }
+
+  const sendCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      rate: Joi.number().integer().positive().max(30).default(30),
+    }),
+  }
+
+  const duplicateCampaignValidator = {
+    [Segments.BODY]: Joi.object({
+      name: Joi.string().max(255).trim().required(),
+    }),
+  }
+
+  // Routes
+
+  // Check if campaign belongs to user for this router
+  router.use(telegramMiddleware.isTelegramCampaignOwnedByUser)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram:
+   *    get:
+   *      tags:
+   *        - Telegram
+   *      summary: Get telegram campaign details
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  campaign:
+   *                    $ref: '#/components/schemas/TelegramCampaign'
+   *                  num_recipients:
+   *                    type: number
+   *        "401":
+   *           description: Unauthorized
+   *        "403" :
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/', telegramMiddleware.getCampaignDetails)
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/telegram/template:
+   *     put:
+   *       tags:
+   *         - Telegram
+   *       summary: Stores body template for telegram campaign
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         required: true
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 body:
+   *                   type: string
+   *                   minLength: 1
+   *                   maxLength: 200
+   *
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 required:
+   *                   - message
+   *                   - valid
+   *                   - num_recipients
+   *                   - template
+   *                 properties:
+   *                   message:
+   *                     type: string
+   *                   extra_keys:
+   *                     type: array
+   *                     items:
+   *                       type: string
+   *                   valid:
+   *                     type: boolean
+   *                   num_recipients:
+   *                     type: integer
+   *                   template:
+   *                     type: object
+   *                     properties:
+   *                       body:
+   *                         type: string
+   *                       params:
+   *                         type: array
+   *                         items:
+   *                           type: string
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.put(
+    '/template',
+    celebrate(storeTemplateValidator),
+    CampaignMiddleware.canEditCampaign,
+    TelegramTemplateMiddleware.storeTemplate
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/telegram/upload/start:
+   *     get:
+   *       summary: "Get a presigned URL for upload with Content-MD5 header"
+   *       tags:
+   *         - Telegram
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: mime_type
+   *           in: query
+   *           required: true
+   *           schema:
+   *             type: string
+   *         - name: md5
+   *           required: true
+   *           in: query
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 type: object
+   *                 properties:
+   *                   presigned_url:
+   *                     type: string
+   *                   transaction_id:
+   *                     type: string
+   *         "400":
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/upload/start',
+    celebrate(uploadStartValidator),
+    CampaignMiddleware.canEditCampaign,
+    UploadMiddleware.uploadStartHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/telegram/upload/complete:
+   *     post:
+   *       summary: "Complete upload session with ETag verification"
+   *       tags:
+   *         - Telegram
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       requestBody:
+   *         content:
+   *           application/json:
+   *             schema:
+   *               required:
+   *                 - transaction_id
+   *                 - filename
+   *               properties:
+   *                 transaction_id:
+   *                   type: string
+   *                 filename:
+   *                   type: string
+   *                 etag:
+   *                   type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   num_recipients:
+   *                     type: number
+   *                   preview:
+   *                     type: object
+   *                     properties:
+   *                       body:
+   *                         type: string
+   *
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *          description: Forbidden, campaign not owned by user or job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/upload/complete',
+    celebrate(uploadCompleteValidator),
+    CampaignMiddleware.canEditCampaign,
+    TelegramTemplateMiddleware.uploadCompleteHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *   /campaign/{campaignId}/telegram/upload/status:
+   *     get:
+   *       summary: "Get csv processing status"
+   *       tags:
+   *         - Telegram
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 properties:
+   *                   is_csv_processing:
+   *                     type: boolean
+   *                   csv_filename:
+   *                     type: string
+   *                   temp_csv_filename:
+   *                     type: string
+   *                   csv_error:
+   *                     type: string
+   *                   num_recipients:
+   *                     type: number
+   *                   preview:
+   *                     type: object
+   *                     properties:
+   *                       subject:
+   *                         type: string
+   *                       body:
+   *                         type: string
+   *         "400" :
+   *           description: Bad Request
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.get('/upload/status', TelegramTemplateMiddleware.pollCsvStatusHandler)
+
+  /**
+   * @swagger
+   * post:
+   *   /campaign/{campaignId}/telegram/upload/status:
+   *     delete:
+   *       description: "Deletes error status from previous failed upload"
+   *       tags:
+   *         - Telegram
+   *       parameters:
+   *         - name: campaignId
+   *           in: path
+   *           required: true
+   *           schema:
+   *             type: string
+   *       responses:
+   *         200:
+   *           description: Success
+   *         "401":
+   *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden as there is a job in progress
+   *         "500":
+   *           description: Internal Server Error
+   */
+  router.delete(
+    '/upload/status',
+    CampaignMiddleware.canEditCampaign,
+    TelegramTemplateMiddleware.deleteCsvErrorHandler
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/preview:
+   *    get:
+   *      tags:
+   *        - Telegram
+   *      summary: Preview templated message
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                  preview:
+   *                    type: object
+   *                    properties:
+   *                      body:
+   *                        type: string
+   *        "401":
+   *           description: Unauthorized
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/preview', telegramMiddleware.previewFirstMessage)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/new-credentials:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Validate Telegram bot token and assign to campaign, if label is provided store new telegram credentials for user
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                telegram_bot_token:
+   *                  type: string
+   *                label:
+   *                      type: string
+   *                      pattern: '/^[a-z0-9-]+$/'
+   *                      minLength: 1
+   *                      maxLength: 50
+   *                      description: should only consist of lowercase alphanumeric characters and dashes
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/new-credentials',
+    celebrate(storeCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    telegramMiddleware.disabledForDemoCampaign,
+    telegramMiddleware.getCredentialsFromBody,
+    telegramMiddleware.validateAndStoreCredentials,
+    settingsMiddleware.checkAndStoreLabelIfExists,
+    telegramMiddleware.setCampaignCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/credentials:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Validate stored credentials and assign to campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                label:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/credentials',
+    celebrate(useCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    telegramMiddleware.getCredentialsFromLabel,
+    telegramMiddleware.validateAndStoreCredentials,
+    telegramMiddleware.setCampaignCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/credentials/verify:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Send a validation message using the campaign credentials.
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                recipient:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/credentials/verify',
+    celebrate(verifyCredentialsValidator),
+    CampaignMiddleware.canEditCampaign,
+    telegramMiddleware.getCampaignCredential,
+    telegramMiddleware.sendValidationMessage
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/send:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Start sending campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: false
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                rate:
+   *                  type: integer
+   *                  default: 30
+   *                  minimum: 1
+   *                  maximum: 30
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *                 job_id:
+   *                  type: array
+   *                  items:
+   *                    type: number
+   *        "400" :
+   *           description: Bad Request
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/send',
+    celebrate(sendCampaignValidator),
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.sendCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/stop:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Stop sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/stop', JobMiddleware.stopCampaign)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/retry:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Retry sending campaign
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: object
+   *                properties:
+   *                 campaign_id:
+   *                  type: integer
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/retry',
+    CampaignMiddleware.canEditCampaign,
+    JobMiddleware.retryCampaign
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/stats:
+   *    get:
+   *      tags:
+   *        - Telegram
+   *      summary: Get telegram campaign stats
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get('/stats', TelegramStatsMiddleware.getStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/update-stats:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Get telegram campaign stats
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignStats'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post('/refresh-stats', TelegramStatsMiddleware.updateAndGetStats)
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/export:
+   *    get:
+   *      tags:
+   *        - Telegram
+   *      summary: Get invalid recipients in campaign
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *
+   *      responses:
+   *        200:
+   *          content:
+   *            application/json:
+   *              schema:
+   *                type: array
+   *                items:
+   *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "410":
+   *           description: Campaign has been redacted
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.get(
+    '/export',
+    CampaignMiddleware.isCampaignRedacted,
+    TelegramStatsMiddleware.getDeliveredRecipients
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /campaign/{campaignId}/telegram/duplicate:
+   *    post:
+   *      tags:
+   *        - Telegram
+   *      summary: Duplicate the campaign and its template
+   *      parameters:
+   *        - name: campaignId
+   *          in: path
+   *          required: true
+   *          schema:
+   *            type: string
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                name:
+   *                  type: string
+   *
+   *      responses:
+   *        "201":
+   *           description: A duplicate of the campaign was created
+   *        "401":
+   *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user
+   *        "500":
+   *           description: Internal Server Error
+   */
+  router.post(
+    '/duplicate',
+    celebrate(duplicateCampaignValidator),
+    telegramMiddleware.duplicateCampaign
+  )
+
+  return router
 }
-
-const uploadStartValidator = {
-  [Segments.QUERY]: Joi.object({
-    mime_type: Joi.string().required(),
-    md5: Joi.string().required(),
-  }),
-}
-
-const uploadCompleteValidator = {
-  [Segments.BODY]: Joi.object({
-    transaction_id: Joi.string().required(),
-    filename: Joi.string().required(),
-    etag: Joi.string().required(),
-  }),
-}
-
-const storeCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    telegram_bot_token: Joi.string().trim().required(),
-    label: Joi.string()
-      .min(1)
-      .max(50)
-      .pattern(/^[a-z0-9-]+$/)
-      .optional(),
-  }),
-}
-
-const useCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    label: Joi.string().required(),
-  }),
-}
-
-const verifyCredentialsValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string().trim().required(),
-  }),
-}
-
-const sendCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    rate: Joi.number().integer().positive().max(30).default(30),
-  }),
-}
-
-const duplicateCampaignValidator = {
-  [Segments.BODY]: Joi.object({
-    name: Joi.string().max(255).trim().required(),
-  }),
-}
-
-// Routes
-
-// Check if campaign belongs to user for this router
-router.use(TelegramMiddleware.isTelegramCampaignOwnedByUser)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram:
- *    get:
- *      tags:
- *        - Telegram
- *      summary: Get telegram campaign details
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  campaign:
- *                    $ref: '#/components/schemas/TelegramCampaign'
- *                  num_recipients:
- *                    type: number
- *        "401":
- *           description: Unauthorized
- *        "403" :
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/', TelegramMiddleware.getCampaignDetails)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/telegram/template:
- *     put:
- *       tags:
- *         - Telegram
- *       summary: Stores body template for telegram campaign
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         required: true
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 body:
- *                   type: string
- *                   minLength: 1
- *                   maxLength: 200
- *
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 required:
- *                   - message
- *                   - valid
- *                   - num_recipients
- *                   - template
- *                 properties:
- *                   message:
- *                     type: string
- *                   extra_keys:
- *                     type: array
- *                     items:
- *                       type: string
- *                   valid:
- *                     type: boolean
- *                   num_recipients:
- *                     type: integer
- *                   template:
- *                     type: object
- *                     properties:
- *                       body:
- *                         type: string
- *                       params:
- *                         type: array
- *                         items:
- *                           type: string
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.put(
-  '/template',
-  celebrate(storeTemplateValidator),
-  CampaignMiddleware.canEditCampaign,
-  TelegramTemplateMiddleware.storeTemplate
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/telegram/upload/start:
- *     get:
- *       summary: "Get a presigned URL for upload with Content-MD5 header"
- *       tags:
- *         - Telegram
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *         - name: mime_type
- *           in: query
- *           required: true
- *           schema:
- *             type: string
- *         - name: md5
- *           required: true
- *           in: query
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 type: object
- *                 properties:
- *                   presigned_url:
- *                     type: string
- *                   transaction_id:
- *                     type: string
- *         "400":
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/upload/start',
-  celebrate(uploadStartValidator),
-  CampaignMiddleware.canEditCampaign,
-  UploadMiddleware.uploadStartHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/telegram/upload/complete:
- *     post:
- *       summary: "Complete upload session with ETag verification"
- *       tags:
- *         - Telegram
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       requestBody:
- *         content:
- *           application/json:
- *             schema:
- *               required:
- *                 - transaction_id
- *                 - filename
- *               properties:
- *                 transaction_id:
- *                   type: string
- *                 filename:
- *                   type: string
- *                 etag:
- *                   type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 properties:
- *                   num_recipients:
- *                     type: number
- *                   preview:
- *                     type: object
- *                     properties:
- *                       body:
- *                         type: string
- *
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *          description: Forbidden, campaign not owned by user or job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/upload/complete',
-  celebrate(uploadCompleteValidator),
-  CampaignMiddleware.canEditCampaign,
-  TelegramTemplateMiddleware.uploadCompleteHandler
-)
-
-/**
- * @swagger
- * paths:
- *   /campaign/{campaignId}/telegram/upload/status:
- *     get:
- *       summary: "Get csv processing status"
- *       tags:
- *         - Telegram
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *           content:
- *             application/json:
- *               schema:
- *                 properties:
- *                   is_csv_processing:
- *                     type: boolean
- *                   csv_filename:
- *                     type: string
- *                   temp_csv_filename:
- *                     type: string
- *                   csv_error:
- *                     type: string
- *                   num_recipients:
- *                     type: number
- *                   preview:
- *                     type: object
- *                     properties:
- *                       subject:
- *                         type: string
- *                       body:
- *                         type: string
- *         "400" :
- *           description: Bad Request
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.get('/upload/status', TelegramTemplateMiddleware.pollCsvStatusHandler)
-
-/**
- * @swagger
- * post:
- *   /campaign/{campaignId}/telegram/upload/status:
- *     delete:
- *       description: "Deletes error status from previous failed upload"
- *       tags:
- *         - Telegram
- *       parameters:
- *         - name: campaignId
- *           in: path
- *           required: true
- *           schema:
- *             type: string
- *       responses:
- *         200:
- *           description: Success
- *         "401":
- *           description: Unauthorized
- *         "403":
- *           description: Forbidden as there is a job in progress
- *         "500":
- *           description: Internal Server Error
- */
-router.delete(
-  '/upload/status',
-  CampaignMiddleware.canEditCampaign,
-  TelegramTemplateMiddleware.deleteCsvErrorHandler
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/preview:
- *    get:
- *      tags:
- *        - Telegram
- *      summary: Preview templated message
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                  preview:
- *                    type: object
- *                    properties:
- *                      body:
- *                        type: string
- *        "401":
- *           description: Unauthorized
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/preview', TelegramMiddleware.previewFirstMessage)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/new-credentials:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Validate Telegram bot token and assign to campaign, if label is provided store new telegram credentials for user
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                telegram_bot_token:
- *                  type: string
- *                label:
- *                      type: string
- *                      pattern: '/^[a-z0-9-]+$/'
- *                      minLength: 1
- *                      maxLength: 50
- *                      description: should only consist of lowercase alphanumeric characters and dashes
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/new-credentials',
-  celebrate(storeCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  TelegramMiddleware.disabledForDemoCampaign,
-  TelegramMiddleware.getCredentialsFromBody,
-  TelegramMiddleware.validateAndStoreCredentials,
-  SettingsMiddleware.checkAndStoreLabelIfExists,
-  TelegramMiddleware.setCampaignCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/credentials:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Validate stored credentials and assign to campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                label:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/credentials',
-  celebrate(useCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  TelegramMiddleware.getCredentialsFromLabel,
-  TelegramMiddleware.validateAndStoreCredentials,
-  TelegramMiddleware.setCampaignCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/credentials/verify:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Send a validation message using the campaign credentials.
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                recipient:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/credentials/verify',
-  celebrate(verifyCredentialsValidator),
-  CampaignMiddleware.canEditCampaign,
-  TelegramMiddleware.getCampaignCredential,
-  TelegramMiddleware.sendValidationMessage
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/send:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Start sending campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: false
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                rate:
- *                  type: integer
- *                  default: 30
- *                  minimum: 1
- *                  maximum: 30
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *                 job_id:
- *                  type: array
- *                  items:
- *                    type: number
- *        "400" :
- *           description: Bad Request
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/send',
-  celebrate(sendCampaignValidator),
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.sendCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/stop:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Stop sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/stop', JobMiddleware.stopCampaign)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/retry:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Retry sending campaign
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: object
- *                properties:
- *                 campaign_id:
- *                  type: integer
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user or job in progress
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/retry',
-  CampaignMiddleware.canEditCampaign,
-  JobMiddleware.retryCampaign
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/stats:
- *    get:
- *      tags:
- *        - Telegram
- *      summary: Get telegram campaign stats
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.get('/stats', TelegramStatsMiddleware.getStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/update-stats:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Get telegram campaign stats
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                $ref: '#/components/schemas/CampaignStats'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post('/refresh-stats', TelegramStatsMiddleware.updateAndGetStats)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/export:
- *    get:
- *      tags:
- *        - Telegram
- *      summary: Get invalid recipients in campaign
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *
- *      responses:
- *        200:
- *          content:
- *            application/json:
- *              schema:
- *                type: array
- *                items:
- *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "410":
- *           description: Campaign has been redacted
- *        "500":
- *           description: Internal Server Error
- */
-router.get(
-  '/export',
-  CampaignMiddleware.isCampaignRedacted,
-  TelegramStatsMiddleware.getDeliveredRecipients
-)
-
-/**
- * @swagger
- * paths:
- *  /campaign/{campaignId}/telegram/duplicate:
- *    post:
- *      tags:
- *        - Telegram
- *      summary: Duplicate the campaign and its template
- *      parameters:
- *        - name: campaignId
- *          in: path
- *          required: true
- *          schema:
- *            type: string
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                name:
- *                  type: string
- *
- *      responses:
- *        "201":
- *           description: A duplicate of the campaign was created
- *        "401":
- *           description: Unauthorized
- *        "403":
- *           description: Forbidden, campaign not owned by user
- *        "500":
- *           description: Internal Server Error
- */
-router.post(
-  '/duplicate',
-  celebrate(duplicateCampaignValidator),
-  TelegramMiddleware.duplicateCampaign
-)
-
-export default router

--- a/backend/src/telegram/routes/telegram-settings.routes.ts
+++ b/backend/src/telegram/routes/telegram-settings.routes.ts
@@ -4,102 +4,107 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { TelegramMiddleware } from '@telegram/middlewares'
 import { SettingsMiddleware } from '@core/middlewares'
 
-const router = Router()
+export const InitTelegramSettingsRoute = (
+  telegramMiddleware: TelegramMiddleware,
+  settingsMiddleware: SettingsMiddleware
+): Router => {
+  const router = Router()
 
-// Validators
+  // Validators
 
-const storeCredentialValidator = {
-  [Segments.BODY]: Joi.object({
-    label: Joi.string()
-      .min(1)
-      .max(50)
-      .pattern(/^[a-z0-9-]+$/)
-      .required(),
-    telegram_bot_token: Joi.string().trim().required(),
-  }),
+  const storeCredentialValidator = {
+    [Segments.BODY]: Joi.object({
+      label: Joi.string()
+        .min(1)
+        .max(50)
+        .pattern(/^[a-z0-9-]+$/)
+        .required(),
+      telegram_bot_token: Joi.string().trim().required(),
+    }),
+  }
+
+  const verifyCredentialValidator = {
+    [Segments.BODY]: Joi.object({
+      recipient: Joi.string().trim().required(),
+      label: Joi.string().required(),
+    }),
+  }
+
+  // Routes
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/telegram/credentials:
+   *    post:
+   *      summary: Store new telegram credentials for user
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                telegram_bot_token:
+   *                  type: string
+   *                label:
+   *                  type: string
+   *                  pattern: '/^[a-z0-9-]+$/'
+   *                  minLength: 1
+   *                  maxLength: 50
+   *                  description: should only consist of lowercase alphanumeric characters and dashes
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request (invalid credentials, malformed request, duplicate labels)
+   *
+   */
+  router.post(
+    '/credentials',
+    celebrate(storeCredentialValidator),
+    settingsMiddleware.checkUserCredentialLabel,
+    telegramMiddleware.getCredentialsFromBody,
+    telegramMiddleware.validateAndStoreCredentials,
+    settingsMiddleware.storeUserCredential
+  )
+
+  /**
+   * @swagger
+   * paths:
+   *  /settings/telegram/credentials/verify:
+   *    post:
+   *      summary: Verify stored credential for user
+   *      tags:
+   *        - Settings
+   *      requestBody:
+   *        required: true
+   *        content:
+   *          application/json:
+   *            schema:
+   *              type: object
+   *              properties:
+   *                recipient:
+   *                  type: string
+   *                label:
+   *                  type: string
+   *
+   *      responses:
+   *        200:
+   *          description: OK
+   *        400:
+   *          description: Bad Request (invalid credentials, malformed request)
+   *
+   */
+  router.post(
+    '/credentials/verify',
+    celebrate(verifyCredentialValidator),
+    telegramMiddleware.getCredentialsFromLabel,
+    telegramMiddleware.sendValidationMessage
+  )
+
+  return router
 }
-
-const verifyCredentialValidator = {
-  [Segments.BODY]: Joi.object({
-    recipient: Joi.string().trim().required(),
-    label: Joi.string().required(),
-  }),
-}
-
-// Routes
-
-/**
- * @swagger
- * paths:
- *  /settings/telegram/credentials:
- *    post:
- *      summary: Store new telegram credentials for user
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                telegram_bot_token:
- *                  type: string
- *                label:
- *                  type: string
- *                  pattern: '/^[a-z0-9-]+$/'
- *                  minLength: 1
- *                  maxLength: 50
- *                  description: should only consist of lowercase alphanumeric characters and dashes
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request (invalid credentials, malformed request, duplicate labels)
- *
- */
-router.post(
-  '/credentials',
-  celebrate(storeCredentialValidator),
-  SettingsMiddleware.checkUserCredentialLabel,
-  TelegramMiddleware.getCredentialsFromBody,
-  TelegramMiddleware.validateAndStoreCredentials,
-  SettingsMiddleware.storeUserCredential
-)
-
-/**
- * @swagger
- * paths:
- *  /settings/telegram/credentials/verify:
- *    post:
- *      summary: Verify stored credential for user
- *      tags:
- *        - Settings
- *      requestBody:
- *        required: true
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                recipient:
- *                  type: string
- *                label:
- *                  type: string
- *
- *      responses:
- *        200:
- *          description: OK
- *        400:
- *          description: Bad Request (invalid credentials, malformed request)
- *
- */
-router.post(
-  '/credentials/verify',
-  celebrate(verifyCredentialValidator),
-  TelegramMiddleware.getCredentialsFromLabel,
-  TelegramMiddleware.sendValidationMessage
-)
-
-export default router

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -5,7 +5,7 @@ import { Campaign, User, Credential } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { DefaultCredentialName } from '@core/constants'
 import { formatDefaultCredentialName } from '@core/utils'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 import { TelegramMessage } from '@telegram/models'
 import { ChannelType } from '@core/constants'
 import { mockSecretsManager } from '@mocks/aws-sdk'
@@ -44,8 +44,7 @@ afterAll(async () => {
   await User.destroy({ where: {} })
   await sequelize.close()
   await UploadService.destroyUploadQueue()
-  RedisService.otpClient.quit()
-  RedisService.sessionClient.quit()
+  await (app as any).cleanup()
 })
 
 describe('POST /campaign/{campaignId}/telegram/credentials', () => {

--- a/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
@@ -3,7 +3,6 @@ import { Sequelize } from 'sequelize-typescript'
 import initialiseServer from '@test-utils/server'
 import { Credential, UserCredential, User } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { ChannelType } from '@core/constants'
 import { mockTelegram } from '@mocks/telegraf'
 import { mockSecretsManager } from '@mocks/aws-sdk'
@@ -20,7 +19,7 @@ afterAll(async () => {
   await UserCredential.destroy({ where: {} })
   await User.destroy({ where: {} })
   await sequelize.close()
-  await RedisService.shutdown()
+  await (app as any).cleanup()
 })
 
 describe('POST /settings/telegram/credentials', () => {

--- a/backend/src/telegram/services/tests/telegram-template.service.test.ts
+++ b/backend/src/telegram/services/tests/telegram-template.service.test.ts
@@ -4,7 +4,7 @@ import sequelizeLoader from '@test-utils/sequelize-loader'
 import S3Client from '@core/services/s3-client.class'
 import { ChannelType } from '@core/constants'
 import { Campaign, User } from '@core/models'
-import { RedisService, UploadService } from '@core/services'
+import { UploadService } from '@core/services'
 
 import { TelegramTemplate, TelegramMessage } from '@telegram/models'
 import { TelegramTemplateService } from '@telegram/services'
@@ -45,8 +45,6 @@ afterAll(async () => {
 
   await UploadService.destroyUploadQueue()
 
-  await new Promise((resolve) => RedisService.otpClient.quit(resolve))
-  await new Promise((resolve) => RedisService.sessionClient.quit(resolve))
   await new Promise((resolve) => setImmediate(resolve))
 })
 

--- a/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
+++ b/backend/src/telegram/utils/callback/handlers/tests/contact.test.ts
@@ -1,7 +1,6 @@
 import { Sequelize } from 'sequelize-typescript'
 import { TelegrafContext } from 'telegraf/typings/context'
 import sequelizeLoader from '@test-utils/sequelize-loader'
-import { RedisService } from '@core/services'
 import { BotSubscriber, TelegramSubscriber } from '@telegram/models'
 import { contactMessageHandler } from '../contact'
 
@@ -12,7 +11,6 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await sequelize.close()
-  await RedisService.shutdown()
 })
 
 describe('contactMessageHandler', () => {

--- a/backend/src/test-utils/global-setup.ts
+++ b/backend/src/test-utils/global-setup.ts
@@ -15,7 +15,7 @@ const TEST_DB = 'postmangovsg_test'
 // defined in  npm test command
 const JEST_WORKERS = 2
 
-module.exports = async () => {
+module.exports = async (): Promise<void> => {
   global.sequelize = new Sequelize(DB_URI, {
     dialect: 'postgres',
     logging: false,

--- a/backend/src/test-utils/global-teardown.ts
+++ b/backend/src/test-utils/global-teardown.ts
@@ -1,3 +1,3 @@
-module.exports = async function () {
+module.exports = async function (): Promise<void> {
   await global.sequelize.close()
 }

--- a/backend/src/test-utils/server.ts
+++ b/backend/src/test-utils/server.ts
@@ -1,10 +1,19 @@
 import express, { Request, Response, NextFunction } from 'express'
 import { errors as celebrateErrorMiddleware } from 'celebrate'
 import sessionLoader from '@core/loaders/session.loader'
-import routes from '@core/routes'
+import { InitV1Route } from '@core/routes'
+import {
+  InitAuthService,
+  InitCredentialService,
+  RedisService,
+} from '@core/services'
 
 const initialiseServer = (session?: boolean): express.Application => {
   const app: express.Application = express()
+  const redisService = new RedisService()
+  ;(app as any).redisService = redisService
+  ;(app as any).authService = InitAuthService(redisService)
+  ;(app as any).credentialService = InitCredentialService(redisService)
   sessionLoader({ app })
   app.use(express.json())
   app.use(express.urlencoded({ extended: false }))
@@ -19,8 +28,12 @@ const initialiseServer = (session?: boolean): express.Application => {
     next()
   })
 
+  const routes = InitV1Route(app)
   app.use(routes)
   app.use(celebrateErrorMiddleware())
+  ;(app as any).cleanup = async function (): Promise<void> {
+    await (app as any).redisService.shutdown()
+  }
 
   return app
 }

--- a/backend/src/test-utils/setup.ts
+++ b/backend/src/test-utils/setup.ts
@@ -4,7 +4,7 @@ global.console = {
   log: jest.fn(), // console.log are ignored in tests
   error: console.error,
   warn: console.warn,
-  info: console.info,
+  info: console.log,
   debug: console.debug,
 }
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,24 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:11-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postmangovsg_test
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:6-alpine
+    ports:
+      - "6379:6379"
+  localstack:
+    image: localstack/localstack:0.11.6
+    ports:
+      - "4566-4599:4566-4599"
+    environment:
+      - DEBUG=1
+      - DATA_DIR=/tmp/localstack/data
+      - FILE_STORAGE_BUCKET_NAME=${FILE_STORAGE_BUCKET_NAME:-localstack-upload}
+      - BACKUP_BUCKET_NAME=${BACKUP_BUCKET_NAME:-localstack-backup}
+      - AWS_LOG_GROUP_NAME=${AWS_LOG_GROUP_NAME:-postmangovsg-beanstalk-localstack}


### PR DESCRIPTION
- root cause: Previously, we create redis client right in the main
body of redis service file. This means that every import of redis
service will create a new set of redis clients. As a result, any
attempt to import RedisService to call RedisService.shutdown() will
only close the clients created by that immediate import instead of
closing all clients that might be imported from another file.

- solution: switch RedisService (and all related services that utilise
it) to an on-demand instance model that will be dependency-injected
into other services/middlewares/routes that utilise them. This way we
will only create exactly one set of redis clients and can safely add and
export a cleanup function from where they're initialised

resolves #1387 

Possible pending refactor as a result of this PR: switching the whole project to a DI model (even for those less obvious ones unlike redis service) and consolidate initialisation to a single places (Will create ticket once discussed)