### PR TITLE
build(mergify): merge non-major dependabot upgrades

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,10 @@
+pull_request_rules:
+  - name: Approve and merge non-major version dependabot upgrades
+    conditions:
+      - author~=^dependabot\[bot\]$
+      - title~=bump [^\s]+ from ([\d]+)\..+ to \1\.
+    actions:
+      review:
+        type: APPROVE
+      merge:
+        method: squash


### PR DESCRIPTION
Closes https://github.com/opengovsg/postmangovsg/issues/1385.

Mergify has already been added to the GitHub organization.