### PR TITLE
ci: decouple develop branch from staging env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Lint root
 on:
   push:
     branches:
-      - develop
+      - staging
       - master
       - github-actions-test
 jobs:

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -2,7 +2,7 @@ name: Deploy backend to AWS Elastic Beanstalk
 on:
   push:
     branches: # There should be 2 environments in github actions secrets: staging, production. This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name
-      - develop
+      - staging
       - master
       - github-actions-test
 

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -2,7 +2,7 @@ name: Deploy worker to AWS Elastic Container Service
 on:
   push:
     branches: # There should be 2 environments in github actions secrets: staging, production. This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name
-      - develop
+      - staging
       - master
       - github-actions-test
 

--- a/.github/workflows/deploy.serverless.database-backup.yml
+++ b/.github/workflows/deploy.serverless.database-backup.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - develop
+      - staging
       - github-actions-test
 
 env:

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - develop
+      - staging
       - github-actions-test
 
 env:

--- a/.github/workflows/deploy.serverless.redaction-digest.yml
+++ b/.github/workflows/deploy.serverless.redaction-digest.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - develop
+      - staging
       - github-actions-test
 
 env:

--- a/.github/workflows/deploy.serverless.unsubscribe-digest.yml
+++ b/.github/workflows/deploy.serverless.unsubscribe-digest.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - develop
+      - staging
       - github-actions-test
 
 env:


### PR DESCRIPTION
This PR modifies the GitHub actions workflow files to deploy `staging` branch to the `staging` environment. 

Closes https://github.com/opengovsg/postmangovsg/issues/1371
