### PR TITLE
build: deps upgrade worker folder

### DIFF
--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -14,7 +14,7 @@
         "@types/convict": "^5.2.1",
         "@types/validator": "^13.1.3",
         "aws-sdk": "^2.884.0",
-        "axios": "^0.21.1",
+        "axios": "^0.21.4",
         "bcrypt": "^5.0.1",
         "convict": "^6.0.1",
         "dotenv": "^8.2.0",
@@ -47,7 +47,7 @@
         "lint-staged": "^10.2.6",
         "prettier": "^2.5.1",
         "rimraf": "^3.0.2",
-        "tsc-watch": "^4.2.3",
+        "tsc-watch": "^4.6.0",
         "typescript": "^3.8.3"
       }
     },

--- a/worker/package.json
+++ b/worker/package.json
@@ -22,7 +22,7 @@
     "@types/convict": "^5.2.1",
     "@types/validator": "^13.1.3",
     "aws-sdk": "^2.884.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "bcrypt": "^5.0.1",
     "convict": "^6.0.1",
     "dotenv": "^8.2.0",
@@ -55,7 +55,7 @@
     "lint-staged": "^10.2.6",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
-    "tsc-watch": "^4.2.3",
+    "tsc-watch": "^4.6.0",
     "typescript": "^3.8.3"
   },
   "_moduleAliases": {


### PR DESCRIPTION
The PR upgrades most of the vulnerable dependencies in the `worker` subfolder. Done using `npm audit fix`, i.e. minor and patch version upgrades only.