### PR TITLE
feat(frontend): make info banner fixed and colorful

### DIFF
--- a/frontend/src/components/common/info-banner/InfoBanner.module.scss
+++ b/frontend/src/components/common/info-banner/InfoBanner.module.scss
@@ -1,13 +1,16 @@
 @import 'styles/_variables';
+@import 'styles/base/_colours';
 @import 'styles/_mixins';
 .container {
-  background-color: $primary;
   height: auto;
   padding: 4px $site-padding;
   color: white;
   text-align: center;
   @include flex-horizontal;
   justify-content: center;
+  position: fixed;
+  width: 100%;
+  z-index: 5;
 
   .infoText {
     max-width: $header-max-width;
@@ -18,4 +21,13 @@
     padding: 4px $mobile-site-padding;
     text-align: justify;
   }
+}
+.primary {
+  background-color: $primary;
+}
+.danger {
+  background-color: $red-500;
+}
+.warning {
+  background-color: $yellow-700;
 }

--- a/frontend/src/components/common/info-banner/InfoBanner.tsx
+++ b/frontend/src/components/common/info-banner/InfoBanner.tsx
@@ -1,14 +1,34 @@
+import cx from 'classnames'
+import { RefObject } from 'react'
+
 import styles from './InfoBanner.module.scss'
 
-const InfoBanner = (props: any) => {
-  const { children } = props
-  if (!children) {
+import { INFO_BANNER, INFO_BANNER_COLOR } from 'config'
+
+export enum BannerColors {
+  Primary = 'primary',
+  Warning = 'warning',
+  Danger = 'danger',
+}
+
+const InfoBanner = (props: { innerRef?: RefObject<HTMLDivElement> }) => {
+  const { innerRef } = props
+  if (!INFO_BANNER) {
     return null
   }
 
+  let colorClassname =
+    (INFO_BANNER_COLOR as BannerColors) || BannerColors.Primary
+  if (!Object.values(BannerColors).includes(colorClassname)) {
+    colorClassname = BannerColors.Primary
+  }
+
   return (
-    <div className={styles.container}>
-      <span className={styles.infoText}>{children}</span>
+    <div
+      className={cx(styles.container, styles[colorClassname])}
+      ref={innerRef}
+    >
+      <span className={styles.infoText}>{INFO_BANNER}</span>
     </div>
   )
 }

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -8,7 +8,6 @@ import Settings from './settings'
 
 import { InfoBanner, NavBar } from 'components/common'
 import Error from 'components/error'
-import { INFO_BANNER } from 'config'
 import CampaignContextProvider from 'contexts/campaign.context'
 import FinishLaterContextProvider from 'contexts/finish-later.modal.context'
 import ModalContextProvider from 'contexts/modal.context'
@@ -16,7 +15,7 @@ import ModalContextProvider from 'contexts/modal.context'
 const Dashboard = () => {
   return (
     <ModalContextProvider>
-      <InfoBanner>{INFO_BANNER}</InfoBanner>
+      <InfoBanner />
       <NavBar></NavBar>
       <Switch>
         <Route exact path="/campaigns" component={Campaigns}></Route>

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -3,7 +3,7 @@ import { i18n } from '@lingui/core'
 import cx from 'classnames'
 
 import Lottie from 'lottie-react'
-import { useState, useContext, useEffect } from 'react'
+import { useState, useContext, useEffect, createRef } from 'react'
 
 import { OutboundLink } from 'react-ga'
 import { Redirect, useHistory } from 'react-router-dom'
@@ -27,7 +27,7 @@ import whyUse1 from 'assets/mp4/why-use-1.mp4'
 import whyUse2 from 'assets/mp4/why-use-2.mp4'
 import whyUse3 from 'assets/mp4/why-use-3.mp4'
 import { InfoBanner, PrimaryButton } from 'components/common'
-import { LINKS, INFO_BANNER } from 'config'
+import { LINKS } from 'config'
 
 import { AuthContext } from 'contexts/auth.context'
 import { getLandingStats } from 'services/stats.service'
@@ -39,6 +39,9 @@ const Landing = () => {
   const [sentMessages, setSentMessages] = useState('0')
   const history = useHistory()
 
+  const bannerRef = createRef<HTMLDivElement>()
+  const infoBannerRef = createRef<HTMLDivElement>()
+
   useEffect(() => {
     if (isAuthenticated) return
     async function getSentMessages() {
@@ -49,6 +52,25 @@ const Landing = () => {
     }
     getSentMessages()
   }, [isAuthenticated])
+
+  useEffect(() => {
+    function recalculateBannerPos() {
+      const govBannerHeight = bannerRef.current?.offsetHeight as number
+      const scrollTop = (document.documentElement.scrollTop ||
+        document.body.scrollTop) as number
+      if (scrollTop >= govBannerHeight) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        infoBannerRef.current!.style.top = '0'
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        infoBannerRef.current!.style.top = `${govBannerHeight - scrollTop}px`
+      }
+    }
+    window.addEventListener('scroll', recalculateBannerPos)
+    return () => {
+      window.removeEventListener('scroll', recalculateBannerPos)
+    }
+  })
 
   if (isAuthenticated) {
     return <Redirect to="/campaigns"></Redirect>
@@ -147,8 +169,8 @@ const Landing = () => {
 
   return (
     <div className={styles.landing}>
-      <Banner></Banner>
-      <InfoBanner>{INFO_BANNER}</InfoBanner>
+      <Banner innerRef={bannerRef} />
+      <InfoBanner innerRef={infoBannerRef} />
       <div className={styles.topContainer}>
         <Navbar></Navbar>
         <div className={styles.innerContainer}>

--- a/frontend/src/components/landing/banner/Banner.tsx
+++ b/frontend/src/components/landing/banner/Banner.tsx
@@ -1,16 +1,16 @@
 import cx from 'classnames'
 
-import { useState } from 'react'
+import { RefObject, useState } from 'react'
 
 import styles from './Banner.module.scss'
 
-const Banner = () => {
+const Banner = ({ innerRef }: { innerRef?: RefObject<HTMLDivElement> }) => {
   const [open, setOpen] = useState(false)
 
   const toggleOpen = () => setOpen((open) => !open)
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} ref={innerRef}>
       <div className={styles.banner}>
         <div className={styles.icon}>
           <span className={cx(styles.sgdsIcon, styles.sgCrestIcon)}></span>

--- a/frontend/src/components/login/Login.tsx
+++ b/frontend/src/components/login/Login.tsx
@@ -14,7 +14,7 @@ import companyLogo from '!file-loader!assets/img/brand/company-logo-dark.svg'
 import appLogo from 'assets/img/brand/app-logo.svg'
 import loginImg from 'assets/img/landing/login.svg'
 import { InfoBanner } from 'components/common'
-import { LINKS, INFO_BANNER } from 'config'
+import { LINKS } from 'config'
 import { AuthContext } from 'contexts/auth.context'
 
 const Login = () => {
@@ -26,7 +26,7 @@ const Login = () => {
 
   return (
     <>
-      <InfoBanner>{INFO_BANNER}</InfoBanner>
+      <InfoBanner />
       <div className={styles.topContainer}>
         <div className={styles.innerContainer}>
           <div className={styles.textContainer}>

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -95,6 +95,8 @@ export const SENTRY_RELEASE = process.env.REACT_APP_SENTRY_RELEASE as string
 export const SENTRY_ENVIRONMENT =
   (process.env.REACT_APP_SENTRY_ENVIRONMENT as string) || 'development'
 export const INFO_BANNER = process.env.REACT_APP_INFO_BANNER as string
+export const INFO_BANNER_COLOR = process.env
+  .REACT_APP_INFO_BANNER_COLOR as string
 
 // Feature Launch Announcements
 // If `isActive` is false, the modal will not proc for ANY user


### PR DESCRIPTION
resolves #1454

Changes:
- info banner fixed on top

https://user-images.githubusercontent.com/12974927/161680637-4349141f-ca50-4edd-8220-4d2d015b2f78.mov

- 3 different color mode for info banner `primary`, `warning`, and `danger` for different kinda messages

<img width="500" alt="Screenshot 2022-04-05 at 11 42 09 AM" src="https://user-images.githubusercontent.com/12974927/161680683-195ef3a7-e7db-416e-9e1f-6bc52dddf474.png">

<img width="500" alt="Screenshot 2022-04-05 at 11 43 02 AM
" src="https://user-images.githubusercontent.com/12974927/161680689-ee2ba887-659b-4f46-86b9-325594bdd0ca.png">

<img width="500" alt="Screenshot 2022-04-05 at 11 43 38 AM" src="https://user-images.githubusercontent.com/12974927/161680696-d9d4ffd6-9fa7-4dbc-ab41-b93b95924d88.png">

- simplify info banner to take info from env directly since that's the only it's being used rn



