### PR TITLE
feat(backend): update send email campaign to only take up 1 worker

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -302,7 +302,7 @@ const config = convict({
   },
   mailDefaultRate: {
     doc: 'The default rate at which an email campaign will be sent',
-    default: 35,
+    default: 150,
     env: 'EMAIL_DEFAULT_RATE',
     format: 'int',
   },

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -11,7 +11,6 @@ import {
   EmailStatsMiddleware,
   EmailMiddleware,
 } from '@email/middlewares'
-import config from '@core/config'
 import { fromAddressValidator } from '@core/utils/from-address'
 
 export const InitEmailCampaignRoute = (
@@ -59,15 +58,6 @@ export const InitEmailCampaignRoute = (
         .options({ convert: true }) // Converts email to lowercase if it isn't
         .lowercase()
         .required(),
-    }),
-  }
-
-  const sendCampaignValidator = {
-    [Segments.BODY]: Joi.object({
-      rate: Joi.number()
-        .integer()
-        .positive()
-        .default(config.get('mailDefaultRate')),
     }),
   }
 
@@ -524,7 +514,6 @@ export const InitEmailCampaignRoute = (
    */
   router.post(
     '/send',
-    celebrate(sendCampaignValidator),
     CampaignMiddleware.canEditCampaign,
     JobMiddleware.sendCampaign
   )


### PR DESCRIPTION
- deprecating custom send rate for email campaigns
- fix campaign rate to default mail rate at max capacity of our SES system

Fixes https://github.com/opengovsg/postmangovsg/issues/1422