### PR TITLE
fix: backend/.env-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Example environment variables can be found in
 - [frontend/.env-example](frontend/.env-example)
 - [worker/.env-example](worker/.env-example)
 
-Set the environment variables in a file named `.env` in each folder
+Set the environment variables in a file named `.env` in each folder. You need to specify the set of `mailOptions` environment variables in `backend/src/core/config.ts` for `npm run dev` to work.
 
 ### Install dependencies
 

--- a/backend/.env-example
+++ b/backend/.env-example
@@ -1,7 +1,7 @@
 # Required env vars
 NODE_ENV="development"
-DB_URI="postgres://localhost:5432/postmangovsg_dev"
-DB_READ_REPLICA_URI="postgres://localhost:5432/postmangovsg_dev"
+DB_URI="postgres://postgres:postgres@localhost:5432/postmangovsg_dev"
+DB_READ_REPLICA_URI="postgres://postgres:postgres@localhost:5432/postmangovsg_dev"
 REDIS_OTP_URI="redis://localhost:6379/3"
 REDIS_SESSION_URI="redis://localhost:6379/4"
 REDIS_RATE_LIMIT_URI="redis://localhost:6379/5"
@@ -25,19 +25,29 @@ CALLBACK_SECRET="abc:xyz"
 TELEGRAM_BOT_CONTACT_US_URL="https://go.gov.sg/postman-contact-us-recipient"
 TELEGRAM_BOT_GUIDE_URL="https://go.gov.sg/postman-recipient-guide"
 
+# Need to specify these variables for npm run dev to work
+BACKEND_SES_HOST=""
+BACKEND_SES_PASS=""
+BACKEND_SES_USER=""
+BACKEND_SES_PORT=""
+
 # You can override other config too
 # See config.ts for the full list
-# BACKEND_SES_HOST=""
-# BACKEND_SES_PASS=""
-# BACKEND_SES_USER=""
-# BACKEND_SES_PORT=""
 
 # Use either AWS credentials or localstack endpoint
 # AWS_ACCESS_KEY_ID="YOURAWSACCESSKEYID"
 # AWS_SECRET_ACCESS_KEY="YOURAWSSECRETACCESSKEY"
+# FILE_STORAGE_BUCKET_NAME="file-staging.postman.gov.sg"
 
 # AWS_ENDPOINT="http://localhost:4566"
 # FILE_STORAGE_BUCKET_NAME="localstack-upload"
 # AWS_LOG_GROUP_NAME="postmangovsg-beanstalk-localstack"
 
+FRONTEND_URL="http://localhost:3000"
 # SENTRY_DSN="https://123.ingest.sentry.io/456"
+
+# set of twilio credentials used for testing locally only
+# TWILIO_API_SECRET=""
+# TWILIO_MESSAGING_SERVICE_SID=""
+# TWILIO_API_KEY=""
+# TWILIO_ACCOUNT_SID=""


### PR DESCRIPTION
# Changes Made
1. The `mailOptions` point is definitely something that should be noted in the README to facilitate setup.
2. The additional variables I added are based on the `backend/.env` file that @stanleynguyen shared with me (removed the variables in the file where there are already sensible defaults)
3. I'm not very sure whether the `DB_URI` and `DB_READ_REPLICA_UR` changes are only necessary because I'm using Docker, but I had to do this for `npm run dev` to work:

BEFORE:
```
DB_URI="postgres://localhost:5432/postmangovsg_dev"
DB_READ_REPLICA_URI="postgres://localhost:5432/postmangovsg_dev"
```

AFTER:
```
DB_URI="postgres://postgres:postgres@localhost:5432/postmangovsg_dev"
DB_READ_REPLICA_URI="postgres://postgres:postgres@localhost:5432/postmangovsg_dev"
```