### PR TITLE
fix TypeError by removing no-non-null-assertion operator in Landing.tsx

### DIFF
--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -3,7 +3,7 @@ import { i18n } from '@lingui/core'
 import cx from 'classnames'
 
 import Lottie from 'lottie-react'
-import { useState, useContext, useEffect, createRef } from 'react'
+import { createRef, useContext, useEffect, useState } from 'react'
 
 import { OutboundLink } from 'react-ga'
 import { Redirect, useHistory } from 'react-router-dom'
@@ -73,7 +73,7 @@ const Landing = () => {
   })
 
   if (isAuthenticated) {
-    return <Redirect to="/campaigns"></Redirect>
+    return <Redirect to="/campaigns" />
   }
 
   function directToSignIn() {
@@ -172,7 +172,7 @@ const Landing = () => {
       <Banner innerRef={bannerRef} />
       <InfoBanner innerRef={infoBannerRef} />
       <div className={styles.topContainer}>
-        <Navbar></Navbar>
+        <Navbar />
         <div className={styles.innerContainer}>
           <div className={styles.textContainer}>
             <h1 className={styles.headerText}>
@@ -266,7 +266,7 @@ const Landing = () => {
               target="_blank"
             >
               <PrimaryButton className={styles.button}>
-                Learn More <i className="bx bx-right-arrow-alt"></i>
+                Learn More <i className="bx bx-right-arrow-alt" />
               </PrimaryButton>
             </OutboundLink>
           </div>
@@ -292,7 +292,7 @@ const Landing = () => {
             ))}
           </div>
 
-          <div className={styles.lineBreak}></div>
+          <div className={styles.lineBreak} />
 
           <div className={styles.testimonial}>
             <span className={cx(styles.openInvertedComma, styles.comma)}>
@@ -395,7 +395,7 @@ const Landing = () => {
               <img src={companyLogo} alt="logo" />
             </div>
           </div>
-          <div className={styles.lineBreak}></div>
+          <div className={styles.lineBreak} />
           <div className={styles.footer}>
             <div className={styles.links}>
               <OutboundLink

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -58,12 +58,10 @@ const Landing = () => {
       const govBannerHeight = bannerRef.current?.offsetHeight as number
       const scrollTop = (document.documentElement.scrollTop ||
         document.body.scrollTop) as number
-      if (scrollTop >= govBannerHeight) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        infoBannerRef.current!.style.top = '0'
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        infoBannerRef.current!.style.top = `${govBannerHeight - scrollTop}px`
+      if (infoBannerRef.current) {
+        const offsetTop =
+          scrollTop >= govBannerHeight ? 0 : govBannerHeight - scrollTop
+        infoBannerRef.current.style.top = `${offsetTop}px`
       }
     }
     window.addEventListener('scroll', recalculateBannerPos)

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare global {
+  interface Window {
+    MSInputMethodContext: any
+  }
+}


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/postmangovsg/issues/1509

This error has been clogging up the Sentry alerts and #postman-alert on Slack, which might lead to other, more significant errors to be missed. 

Traced the error to the most recent release and looked through PRs that might've caused the error: 
![image](https://user-images.githubusercontent.com/67887489/165914386-aae8cfec-deab-48f6-9b6f-c1cb0b04afdb.png)

There is only one recent change to the frontend https://github.com/opengovsg/postmangovsg/commit/24f0252e4457720d3b4ff6bec3179a4fbf63db26

Replicated the error on local. 

## Solution

Instead of using no-non-null-assertion operator, `infoBannerRef.current.style.top` is set conditionally only when `infoBannerRef.current` exists.

Also did miscellaneous refactoring on `Landing.tsx` 