### PR TITLE
fix(email-template): force table style

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -260,7 +260,7 @@
   }
 
   table {
-    $border-color: adjust-color($primary-light, $alpha: -0.5);
+    $border-color: $primary-light;
     border: 1px solid $border-color;
     table-layout: fixed;
     width: auto;

--- a/frontend/src/components/common/rich-text-editor/utils/Converter.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/Converter.ts
@@ -70,15 +70,15 @@ const LIST_WRAPPER: Record<string, TagType> = {
 
 const TABLE_STYLE = {
   table: {
-    border: 'solid 1px rgba(181, 196, 255, 0.5)',
+    border: 'solid 1px #b5c4ff',
     'border-collapse': 'collapse',
     'min-width': '50%',
   },
   row: {
-    border: 'solid 1px rgba(181, 196, 255, 0.5)',
+    border: 'solid 1px #b5c4ff',
   },
   cell: {
-    border: 'solid 1px rgba(181, 196, 255, 0.5)',
+    border: 'solid 1px #b5c4ff',
     padding: '0.5rem',
   },
 }


### PR DESCRIPTION
Resolves #1486 

the `alpha` property in CSS `rgba` is not supported by the underlying browser engine of Outlook => switching to use a hex code without alpha