### PR TITLE
feat: added cypress basic test

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,3 @@
+{
+    "baseUrl": "https://staging.postman.gov.sg/"
+}

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -1,0 +1,8 @@
+describe('The Home Page', () => {
+    it('successfully loads', () => {
+        // loads site and checks for both sign in buttons
+        cy.visit('/')
+        cy.get('[class *= "NavBar_signInButton"]')
+        cy.get('[class *= "Landing_signInButton"]')
+    })
+})

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint-no-fix": "prettier --check '**/*.{yml,md}'",
     "lint": "prettier --write '**/*.{yml,md}' --loglevel warn",
     "wait:backend": "wait-on http-get://localhost:4000",
-    "secretlint": "secretlint --secretlintignore .secretlintignore '**/*'"
+    "secretlint": "secretlint --secretlintignore .secretlintignore '**/*'",
+    "cy:run": "npx cypress run -s cypress/integration/home.spec.js"
   },
   "repository": {
     "type": "git",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "^5.1.3",
     "concurrently": "^7.0.0",
+    "cypress": "^9.6.1",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.6",
     "prettier": "^2.0.5",
@@ -66,5 +68,6 @@
     "hooks": {
       "pre-commit": "npm run precommit"
     }
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## Problem

Manual smoke test is required at deployment

## Solution

Use cypress to automate smoke test

**Features**:

- added dev dependency and script for cypress
- added a basic cypress test that loads staging home page and checks for sign in buttons

## Deploy Notes

**New scripts**:

- "cy:run": "npx cypress run -s cypress/integration/home.spec.js"

**New dev dependencies**:

- "cypress": "^9.6.1"
