### PR TITLE
fix: changed position of info banner to relative by default and fixed…

### DIFF
--- a/frontend/src/components/common/info-banner/InfoBanner.module.scss
+++ b/frontend/src/components/common/info-banner/InfoBanner.module.scss
@@ -8,7 +8,7 @@
   text-align: center;
   @include flex-horizontal;
   justify-content: center;
-  position: fixed;
+  position: relative;
   width: 100%;
   z-index: 5;
 

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { createRef, useEffect } from 'react'
 import { Switch, Route } from 'react-router-dom'
 
 import Campaigns from './campaigns'
@@ -13,9 +14,30 @@ import FinishLaterContextProvider from 'contexts/finish-later.modal.context'
 import ModalContextProvider from 'contexts/modal.context'
 
 const Dashboard = () => {
+  const infoBannerRef = createRef<HTMLDivElement>()
+
+  useEffect(() => {
+    function recalculateBannerPos() {
+      const scrollTop = (document.documentElement.scrollTop ||
+        document.body.scrollTop) as number
+      if (infoBannerRef.current) {
+        const infoBannerHeight = infoBannerRef.current?.offsetHeight as number
+        if (scrollTop > infoBannerHeight) {
+          infoBannerRef.current.style.position = 'fixed'
+        } else {
+          infoBannerRef.current.style.position = 'relative'
+        }
+      }
+    }
+    window.addEventListener('scroll', recalculateBannerPos)
+    return () => {
+      window.removeEventListener('scroll', recalculateBannerPos)
+    }
+  })
+
   return (
     <ModalContextProvider>
-      <InfoBanner />
+      <InfoBanner innerRef={infoBannerRef} />
       <NavBar></NavBar>
       <Switch>
         <Route exact path="/campaigns" component={Campaigns}></Route>

--- a/frontend/src/components/landing/Landing.tsx
+++ b/frontend/src/components/landing/Landing.tsx
@@ -61,7 +61,13 @@ const Landing = () => {
       if (infoBannerRef.current) {
         const offsetTop =
           scrollTop >= govBannerHeight ? 0 : govBannerHeight - scrollTop
-        infoBannerRef.current.style.top = `${offsetTop}px`
+        const infoBannerHeight = infoBannerRef.current?.offsetHeight as number
+        if (scrollTop > govBannerHeight + infoBannerHeight) {
+          infoBannerRef.current.style.position = 'fixed'
+          infoBannerRef.current.style.top = `${offsetTop}px`
+        } else {
+          infoBannerRef.current.style.position = 'relative'
+        }
       }
     }
     window.addEventListener('scroll', recalculateBannerPos)

--- a/frontend/src/components/login/Login.tsx
+++ b/frontend/src/components/login/Login.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '@lingui/core'
 
-import { useContext } from 'react'
+import { createRef, useEffect, useContext } from 'react'
 
 import { OutboundLink } from 'react-ga'
 
@@ -19,6 +19,26 @@ import { AuthContext } from 'contexts/auth.context'
 
 const Login = () => {
   const authContext = useContext(AuthContext)
+  const infoBannerRef = createRef<HTMLDivElement>()
+
+  useEffect(() => {
+    function recalculateBannerPos() {
+      const scrollTop = (document.documentElement.scrollTop ||
+        document.body.scrollTop) as number
+      if (infoBannerRef.current) {
+        const infoBannerHeight = infoBannerRef.current?.offsetHeight as number
+        if (scrollTop > infoBannerHeight) {
+          infoBannerRef.current.style.position = 'fixed'
+        } else {
+          infoBannerRef.current.style.position = 'relative'
+        }
+      }
+    }
+    window.addEventListener('scroll', recalculateBannerPos)
+    return () => {
+      window.removeEventListener('scroll', recalculateBannerPos)
+    }
+  })
 
   if (authContext.isAuthenticated) {
     return <Redirect to="/campaigns"></Redirect>
@@ -26,7 +46,7 @@ const Login = () => {
 
   return (
     <>
-      <InfoBanner />
+      <InfoBanner innerRef={infoBannerRef} />
       <div className={styles.topContainer}>
         <div className={styles.innerContainer}>
           <div className={styles.textContainer}>


### PR DESCRIPTION
## Problem
Info banner blocking nav bar 

Closes [#1559 ]

## Solution

Set position to relative by default but fixed (and adjusted for it to be at the top) when user scrolls further down

## Style
might want to export banner position recalculation function instead of duplicating (not sure where to define)