### PR TITLE
chore: turn off useUnknownInCatchVariables

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,6 +12,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",


### PR DESCRIPTION
## Problem
Getting these type errors in my IDE
![SCR-20220611-vys](https://user-images.githubusercontent.com/67887489/173193363-cf09d798-f421-4aeb-9159-3b343970c8d9.png)

## Solution

According to [this](https://stackoverflow.com/questions/68240884/error-object-inside-catch-is-of-type-unkown), one solution is to set `"useUnknownInCatchVariables": false`.

Another solution is to set the `instanceof Error` like this:
![image](https://user-images.githubusercontent.com/67887489/173193455-a7fd7bfc-8434-4ba7-a772-6abe88638bc7.png)

Have gone for the former in this PR