### PR TITLE
ci(deployment): simplify deployment workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,47 +8,11 @@ Closes [insert issue #]
 
 _How did you solve the problem?_
 
-**Features**:
+## Deployment Checklist
 
-- Details ...
+_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_
 
-**Improvements**:
-
-- Details ...
-
-**Bug Fixes**:
-
-- Details ...
-
-## Before & After Screenshots
-
-**BEFORE**:
-[insert screenshot here]
-
-**AFTER**:
-[insert screenshot here]
-
-## Tests
-
-_What tests should be run to confirm functionality?_
-
-## Deploy Notes
-
-_Notes regarding deployment of the contained body of work. These should note any
-new dependencies, new scripts, etc._
-
-**New environment variables**:
-
-- `env var` : env var details
-
-**New scripts**:
-
-- `script` : script details
-
-**New dependencies**:
-
-- `dependency` : dependency details
-
-**New dev dependencies**:
-
-- `dependency` : dependency details
+- [ ] First task
+  - [ ] Sub-task 1
+  - [ ] Sub-task 2
+- [ ] Second task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-          cache: "npm"
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - run: npm ci --ignore-scripts
@@ -52,11 +51,10 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-          cache: "npm"
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 
@@ -78,11 +76,10 @@ jobs:
       run:
         working-directory: ./shared
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-          cache: "npm"
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - run: npm ci
@@ -96,11 +93,10 @@ jobs:
       run:
         working-directory: ./worker
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-          cache: "npm"
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 
@@ -120,11 +116,10 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: "16"
-          cache: "npm"
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v3.4.2
 
       - name: Write gmail credentials file
         env:

--- a/.github/workflows/db-migration.yml
+++ b/.github/workflows/db-migration.yml
@@ -1,0 +1,45 @@
+name: Migrate/undo DB migration
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Action to be done on the DB
+        required: true
+        default: migrate
+        type: choice
+        options:
+          - migrate
+          - undo
+      environment:
+        description: Which environment's database to run on
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
+jobs:
+  set_environment:
+    outputs:
+      current_env: ${{ steps.set-environment.outputs.current_env }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: set-environment
+        run: echo "::set-output name=current_env::${{ inputs.environment }}"
+  run_migration:
+    runs-on: ubuntu-latest
+    needs: [set_environment]
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Run migration
+        env:
+          DB_URI: ${{ secrets.DB_URI }}
+        run: |
+          npm ci
+          npm run db:${{ inputs.action }}

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -1,10 +1,10 @@
 name: Deploy backend to AWS Elastic Beanstalk
 on:
   push:
-    branches: # There should be 2 environments in github actions secrets: staging, production. This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name
+    branches:
       - staging
-      - master
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   # Update this common config
@@ -18,8 +18,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -18,8 +17,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"
@@ -47,11 +46,10 @@ jobs:
           - "6379:6379"
         options: --entrypoint redis-server
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd $DIRECTORY && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Lint and test app code
@@ -76,11 +74,10 @@ jobs:
       BRANCH: ${{ needs.set_environment.outputs.current_env }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Before deploy
         env:
           SECRET_ID: ${{ secrets.SECRET_ID }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - staging
-      - master
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   deploy-frontend:
@@ -18,7 +19,13 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: |
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "##[set-output name=branch;]master"
+          else
+            echo "##[set-output name=branch;]staging"
+          fi
         id: extract_branch
       - name: Deploy
         shell: bash

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -3,14 +3,13 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -20,8 +19,8 @@ jobs:
       - name: Extract branch name
         shell: bash
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "##[set-output name=branch;]master"
           else
             echo "##[set-output name=branch;]staging"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,10 +1,10 @@
 name: Deploy worker to AWS Elastic Container Service
 on:
   push:
-    branches: # There should be 2 environments in github actions secrets: staging, production. This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name
+    branches:
       - staging
-      - master
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   # Update this common config
@@ -18,8 +18,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -18,8 +17,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"
@@ -28,11 +27,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd $DIRECTORY && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Lint app code
@@ -56,11 +54,10 @@ jobs:
       image: ${{ steps.build-image.outputs.image }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Build shared package
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/deploy.serverless.database-backup.yml
+++ b/.github/workflows/deploy.serverless.database-backup.yml
@@ -3,9 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -21,7 +19,7 @@ jobs:
       - id: set-environment
         run: |
           echo "Running on branch ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"
@@ -30,11 +28,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd "$DIRECTORY" && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Test app code
@@ -48,11 +45,10 @@ jobs:
       BRANCH: "${{ needs.set_environment.outputs.current_env }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/deploy.serverless.database-backup.yml
+++ b/.github/workflows/deploy.serverless.database-backup.yml
@@ -2,9 +2,10 @@ name: Deploy serverless-database-backup
 on:
   push:
     branches:
-      - master
       - staging
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
 
 env:
   # Update this common config
@@ -20,7 +21,7 @@ jobs:
       - id: set-environment
         run: |
           echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -19,8 +18,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"
@@ -29,11 +28,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd "$DIRECTORY" && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Test app code
@@ -45,11 +43,10 @@ jobs:
       name: "${{ needs.set_environment.outputs.current_env }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -2,9 +2,9 @@ name: Deploy serverless-eb-env-update
 on:
   push:
     branches:
-      - master
       - staging
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   # Update this common config
@@ -19,8 +19,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
              echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy.serverless.redaction-digest.yml
+++ b/.github/workflows/deploy.serverless.redaction-digest.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -19,8 +18,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"
@@ -29,11 +28,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd "$DIRECTORY" && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Test app code
@@ -45,11 +43,10 @@ jobs:
       name: "${{ needs.set_environment.outputs.current_env }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/deploy.serverless.redaction-digest.yml
+++ b/.github/workflows/deploy.serverless.redaction-digest.yml
@@ -2,9 +2,9 @@ name: Deploy serverless-redaction-digest
 on:
   push:
     branches:
-      - master
       - staging
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   # Update this common config
@@ -19,8 +19,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy.serverless.unsubscribe-digest.yml
+++ b/.github/workflows/deploy.serverless.unsubscribe-digest.yml
@@ -2,9 +2,9 @@ name: Deploy serverless-unsubscribe-digest
 on:
   push:
     branches:
-      - master
       - staging
-      - github-actions-test
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   # Update this common config
@@ -19,8 +19,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on branch ${{ github.ref }}"
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Running on ref ${{ github.ref }}"
+          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"

--- a/.github/workflows/deploy.serverless.unsubscribe-digest.yml
+++ b/.github/workflows/deploy.serverless.unsubscribe-digest.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - staging
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+      - master
 
 env:
   # Update this common config
@@ -19,8 +18,8 @@ jobs:
     steps:
       - id: set-environment
         run: |
-          echo "Running on ref ${{ github.ref }}"
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Running on branch ${{ github.ref }}"
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
             echo "::set-output name=current_env::production"
           else
             echo "::set-output name=current_env::staging"
@@ -29,11 +28,10 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Lint lock file
         run: cd "$DIRECTORY" && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Test app code
@@ -45,11 +43,10 @@ jobs:
       name: "${{ needs.set_environment.outputs.current_env }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: "12"
-          cache: "npm"
+          node-version: "16"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -115,14 +115,14 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "d56d985300d4b52eb6e189be006f44f8d23c5ec9",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 28
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 36
       }
     ],
     ".github/workflows/deploy-eb.yml": [
@@ -131,7 +131,7 @@
         "filename": ".github/workflows/deploy-eb.yml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 34
       }
     ],
     "backend/.env-example": [
@@ -354,5 +354,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-10T06:50:40Z"
+  "generated_at": "2022-06-22T03:26:47Z"
 }

--- a/amplify.yml
+++ b/amplify.yml
@@ -13,6 +13,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - nvm install
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
           export REACT_APP_SENTRY_ENVIRONMENT="production";

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "backend",
-      "version": "1.36.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sns": "3.95.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "backend",
-  "version": "1.36.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "backend",
-  "version": "1.36.1",
   "description": "Backend / API server for Postman",
   "main": "build/server.js",
   "scripts": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24839,13 +24839,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.1.tgz",
       "integrity": "sha512-f1G1WGDXEU/RN1TWAxBPQgQudtLnLQPyiWdtypkPC+mVYNKFKH/HYXSxH4MVNqwF8M0eDsoiU7HumJHCg/L/jg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.0.tgz",
       "integrity": "sha512-rZ6vufeY/UjAgtyiJ4WvfF6XP6HizIyOfbZOg0RnecIwjrvH8Am3nN1BpKnnPZunYAkUcPPXDhwbxOtGop8cfQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@endemolshinegroup/cosmiconfig-typescript-loader": {
       "version": "3.0.2",
@@ -26807,7 +26809,8 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.0.tgz",
       "integrity": "sha512-+CGfMXlVM+OwREHDEsfTGsXIMI+rjr3a7YBUSutq7soELht+8kQrM5k46xa/WLfHdtX/wqsDIleL6bi4i+xz0w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -27797,13 +27800,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -27910,7 +27915,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -28143,7 +28149,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -28323,7 +28330,8 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
       "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -29310,7 +29318,8 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.3.0.tgz",
       "integrity": "sha512-OGT677UGHJTAVMRhPO+HJ4oKln3wkBTwtDFH0ojbqm+MJm6xuDMHp2nkhh/ThaBqq20IbraBQSWKfSLNHQO9Og==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-has-pseudo": {
       "version": "3.0.4",
@@ -29407,7 +29416,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
       "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-select": {
       "version": "4.3.0",
@@ -29520,7 +29530,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -30007,7 +30018,8 @@
     "draftjs-utils": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.10.2.tgz",
-      "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg=="
+      "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg==",
+      "requires": {}
     },
     "duplexer": {
       "version": "0.1.2",
@@ -30369,7 +30381,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "7.0.1",
@@ -30602,7 +30615,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "5.5.1",
@@ -31853,7 +31867,8 @@
     "html-to-draftjs": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.5.0.tgz",
-      "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ=="
+      "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ==",
+      "requires": {}
     },
     "html-webpack-plugin": {
       "version": "5.5.0",
@@ -31969,7 +31984,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "idb": {
       "version": "6.1.5",
@@ -33927,7 +33943,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -36751,7 +36768,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-browser-comments/-/postcss-browser-comments-4.0.0.tgz",
       "integrity": "sha512-X9X9/WN3KIvY9+hNERUqX9gncsgBA25XaeR+jshHz2j8+sYyHktHw1JdKuMjeLpGktXidqDhA7b/qm1mrBDmgg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-calc": {
       "version": "8.2.4",
@@ -36861,25 +36879,29 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
       "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "3.1.1",
@@ -36904,7 +36926,8 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-5.0.2.tgz",
       "integrity": "sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-focus-visible": {
       "version": "6.0.4",
@@ -36928,13 +36951,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
       "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -36960,7 +36985,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-js": {
       "version": "4.0.0",
@@ -37017,13 +37043,15 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
       "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
       "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-merge-longhand": {
       "version": "5.1.5",
@@ -37091,7 +37119,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -37156,7 +37185,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -37252,13 +37282,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
       "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -37356,7 +37388,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "6.0.0",
@@ -37730,7 +37763,8 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/react-app-rewire-alias/-/react-app-rewire-alias-1.1.7.tgz",
       "integrity": "sha512-vn4xU3E/wzh2/fGxda9ZQ6CtW2XdZB/WxAgNOdNPyUcX3hA3mh+kCRGwo19gSjzeTPpoZQwZRblHabLr6mwOTw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-app-rewired": {
       "version": "2.1.11",
@@ -37922,7 +37956,8 @@
     "react-ga": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.0.tgz",
-      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ=="
+      "integrity": "sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==",
+      "requires": {}
     },
     "react-interactive": {
       "version": "0.8.3",
@@ -37943,7 +37978,8 @@
     "react-moment": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/react-moment/-/react-moment-1.1.1.tgz",
-      "integrity": "sha512-WjwvxBSnmLMRcU33do0KixDB+9vP3e84eCse+rd+HNklAMNWyRgZTDEQlay/qK6lcXFPRuEIASJTpEt6pyK7Ww=="
+      "integrity": "sha512-WjwvxBSnmLMRcU33do0KixDB+9vP3e84eCse+rd+HNklAMNWyRgZTDEQlay/qK6lcXFPRuEIASJTpEt6pyK7Ww==",
+      "requires": {}
     },
     "react-paginate": {
       "version": "8.1.1",
@@ -39218,7 +39254,8 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.0",
@@ -39848,12 +39885,14 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.1",
@@ -40214,7 +40253,8 @@
           "version": "8.8.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
           "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -40675,7 +40715,8 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
       "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "frontend",
-  "version": "1.36.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.36.1",
       "dependencies": {
         "@lingui/react": "3.13.3",
         "@sentry/browser": "5.27.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "frontend",
-  "version": "1.36.1",
   "private": true,
   "proxy": "https://api-staging.postman.gov.sg",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "postmangovsg",
-      "version": "1.36.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "postmangovsg",
-  "version": "1.36.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "shared",
-  "version": "1.36.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "shared",
-      "version": "1.36.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "1.0.0-rc.10",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,5 @@
 {
   "name": "shared",
-  "version": "1.36.0",
   "description": "Shared modules for Postman",
   "main": "build/index.js",
   "scripts": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "worker",
-  "version": "1.36.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "worker",
-      "version": "1.36.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sns": "3.95.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,5 @@
 {
   "name": "worker",
-  "version": "1.36.1",
   "description": "Workers for Postman",
   "main": "build/server.js",
   "scripts": {


### PR DESCRIPTION
## Problem

We're current having a very tedious deployment process of:
- updating each sub-package's version
- creating a release branch
- create a release tag
- PR and merge the release branch into master (to trigger deploy to prod)
- PR and merge back release branch (with the release commit) to `develop`

Closes #1426 

## Solution

**TLDR;** New prod deployment process will be a one-step process of [creating a new release](https://github.com/opengovsg/postmangovsg/releases/new) on Github

**More deets**:
- Consolidating the git history for all deployment artefacts to use a single branch `master`.
- `master` will be set to the main branch and `develop` will be removed. All PRs will now target to `master` (Prod deployments won't be triggered on push to `master` anymore)
- To create deployment artefact and trigger deploy to prod, we will use semver tags (e.g. `v1.1.1`) that can be done through [github UI](https://github.com/opengovsg/postmangovsg/releases/new) easily with release notes 
- Ideally, we want `staging` env to be built from a `master`-commit also and triggered using release candidate tags (e.g. `v1.1.1-rc01`), but AWS Amplify can't deploy based off tags (only branch for now) and we are also using our `staging` like a `dev` environment to test changes in real infras => We will keep staging deployment to status quo `push to "staging"` 
- Wrt the risk of AWS Amplify deploying the incorrect commit caused by master being ahead of release tag, it's mitigated by the fact that we're still doing scheduled release with the latest commit from master being released
- Wrt concerns about being able to view version in deployed environment from code, build systems nowadays are pretty accurate about the artefacts so we can rely on the commit hash that we add to the artefact names.

**Side Note**: I'm also taking this chance to bump our node version in CD to 16 and get rid of the problematic npm cache

## Deployment Checklist
- [ ] Do a final release with the old way to cap off and align the `master` and `develop` history
- [ ] Immediately create a new release with this updated flow after the previous step:
  - [ ] Switch main branch to `master` instead of `develop` (with all protek rules)
  - [ ] Create a semver tag from master to trigger deployment
- [ ] Remove `develop` branch after the next release (just to be sure)