### PR TITLE
fix(rich-editor): convert empty paragraphs to line breaks

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
@@ -146,7 +146,12 @@ const RichTextEditor = ({
   useEffect(() => {
     // Normalise HTML whenever editor state is initialised or updated
     const currentContent = editorState.getCurrentContent()
-    const html = Converter.convertToHTML(convertToRaw(currentContent))
+    const html = Converter.convertToHTML(
+      convertToRaw(currentContent)
+      // Empty lines are converted to <p></p> as it's considered a text block
+      // however, the actual intention is probably an extra line break.
+      // Converting empty paragraphs in the html to make them line breaks
+    ).replaceAll('<p></p>', '<br>')
     onChange(html)
   }, [editorState, onChange])
 


### PR DESCRIPTION
## Problem

Extra line breaks in the rich text editors are detected as empty blocks of text hence converted to `<p></p>` instead of `<br />`

Closes #1508 

## Solution

Convert empty paragraphs `<p></p>` into actual linebreaks

## Deploy Checklist

N/A