### PR TITLE
ci(deploy): restrict deployment concurrency to max 1 at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - develop
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-eb-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: backend

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-frontend-${{ github.ref }}
 jobs:
   deploy-frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-worker-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: worker

--- a/.github/workflows/deploy.serverless.database-backup.yml
+++ b/.github/workflows/deploy.serverless.database-backup.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-serverless-database-backup-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: serverless/database-backup

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-serverless-eb-env-update-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: serverless/eb-env-update

--- a/.github/workflows/deploy.serverless.redaction-digest.yml
+++ b/.github/workflows/deploy.serverless.redaction-digest.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-serverless-redaction-digest-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: serverless/redaction-digest

--- a/.github/workflows/deploy.serverless.unsubscribe-digest.yml
+++ b/.github/workflows/deploy.serverless.unsubscribe-digest.yml
@@ -5,6 +5,8 @@ on:
       - staging
       - master
 
+# Making sure that the current deployment is completed before the next one
+concurrency: deploy-serverless-unsubscribe-digest-${{ github.ref }}
 env:
   # Update this common config
   DIRECTORY: serverless/unsubscribe-digest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,7 +131,7 @@
         "filename": ".github/workflows/deploy-eb.yml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 36
       }
     ],
     "backend/.env-example": [
@@ -354,5 +354,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-22T03:26:47Z"
+  "generated_at": "2022-06-23T03:54:12Z"
 }


### PR DESCRIPTION
## Problem

Currently multiple deployments can be started at the same time and renders latest deployments failed because infrastructures might be in an `update` state

## Solution

Set max concurrency for deploy workflows to 1

## Deployment Checklist

N/A
