### PR TITLE
fix: do not encode unsub link

### DIFF
--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -203,7 +203,7 @@
           agency or organisation that sent this to you.
           <br />
           <br />          
-          If you wish to unsubscribe from similar emails, please click <a href="{{unsubLink}}">here</a> to inform the sender of your email preference.
+          If you wish to unsubscribe from similar emails, please click <a href="{{{unsubLink}}}">here</a> to inform the sender of your email preference.
           Alternatively, you may also contact the sender agency or organisation directly through their public contact channels.
           <br />
           <br />


### PR DESCRIPTION
## Problem

Unsub link was not clickable for yahoo mail recipients.
This is because `Mustache.render()` encodes the unsub link when filling in the footer template:

> `please click <a href="{{unsubLink}}">here</a> `

Yahoo mail can't decode the link properly and hence has it greyed out.

Closes [#1645]

## Solution

Surround the variable with triple brackets so that Mustache does not encode the link.

> `please click <a href="{{{unsubLink}}}">here</a> `

Note: this does not break anything.
Encoding of the link is unnecessary, the embedded Postman link in the footer was not encoded.

> `Powered by <a href="https://postman.gov.sg">Postman</a>`


## Deployment Checklist

N/A
