### PR TITLE
feat: indent(4 spaces) on tab

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
@@ -9,6 +9,7 @@ import {
   Modifier,
   SelectionState,
   KeyBindingUtil,
+  getDefaultKeyBinding,
 } from 'draft-js'
 import Immutable from 'immutable'
 import { createContext, useContext, useEffect, useState } from 'react'
@@ -40,6 +41,8 @@ import { Converter } from './utils'
 
 import 'draft-js/dist/Draft.css'
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
+
+const MAX_LIST_DEPTH = 4
 
 const ExtendedEditor = (props: any) => <Editor {...props} />
 
@@ -167,7 +170,45 @@ const RichTextEditor = ({
     }
   }
 
+  // customise command from key press
+  function myKeyBindingFn(e: any): string | null {
+    if (e.keyCode === 9) {
+      // tab key
+      const selection = editorState.getSelection()
+      const startKey = selection.getStartKey()
+      const block = editorState.getCurrentContent().getBlockForKey(startKey)
+      const blockType = block.getType()
+
+      // handle indent on list separately
+      if (['unordered-list-item', 'ordered-list-item'].includes(blockType)) {
+        const blockBefore = editorState
+          .getCurrentContent()
+          .getBlockBefore(startKey)
+        let MAX_DEPTH = 0
+        if (blockBefore && blockBefore.getType() === blockType) {
+          MAX_DEPTH = Math.min(blockBefore.getDepth() + 1, MAX_LIST_DEPTH)
+        }
+        setEditorState(RichUtils.onTab(e, editorState, MAX_DEPTH))
+        return null
+      }
+      return 'indent'
+    }
+    return getDefaultKeyBinding(e)
+  }
+
   function handleKeyCommand(command: string): 'handled' | 'not-handled' {
+    if (command === 'indent') {
+      const newContentState = Modifier.replaceText(
+        editorState.getCurrentContent(),
+        editorState.getSelection(),
+        '\t'
+      )
+      setEditorState(
+        EditorState.push(editorState, newContentState, 'insert-characters')
+      )
+      return 'handled'
+    }
+
     if (command === 'backspace') {
       const selection = editorState.getSelection()
       const anchorKey = selection.getAnchorKey()
@@ -321,6 +362,7 @@ const RichTextEditor = ({
       customBlockRenderFunc={renderBlock}
       blockRenderMap={extendedBlockRenderMap}
       handleKeyCommand={handleKeyCommand}
+      keyBindingFn={myKeyBindingFn}
       handleReturn={handleReturn}
       handlePastedText={handlePastedText}
       stripPastedStyles

--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.tsx
@@ -171,7 +171,7 @@ const RichTextEditor = ({
   }
 
   // customise command from key press
-  function myKeyBindingFn(e: any): string | null {
+  function keyBindingFn(e: any): string | null {
     if (e.keyCode === 9) {
       // tab key
       const selection = editorState.getSelection()
@@ -362,7 +362,7 @@ const RichTextEditor = ({
       customBlockRenderFunc={renderBlock}
       blockRenderMap={extendedBlockRenderMap}
       handleKeyCommand={handleKeyCommand}
-      keyBindingFn={myKeyBindingFn}
+      keyBindingFn={keyBindingFn}
       handleReturn={handleReturn}
       handlePastedText={handlePastedText}
       stripPastedStyles

--- a/frontend/src/components/common/rich-text-editor/utils/Converter.ts
+++ b/frontend/src/components/common/rich-text-editor/utils/Converter.ts
@@ -481,7 +481,11 @@ const convertToHTML = (contentState: RawDraftContentState): string => {
     prevBlock = currBlock
   }
 
-  return tree.toHTML()
+  let html = tree.toHTML()
+
+  // replace tab with 4 white spaces
+  html = html.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;')
+  return html
 }
 
 const TAG_BLOCK_TYPE_MAPPING: Record<string, string> = {


### PR DESCRIPTION
## Problem

Add indent on tab
Closes #1650 

## Solution

insert `\t` on tab, converts to 4 white spaces in html.
tab on list items is treated differently to enable nested list

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

N/A
