### PR TITLE
hotfix(sms-callback-auth): catch errors from timingSafeEuqual and eval as not equal

### DIFF
--- a/shared/src/utils/crypto.ts
+++ b/shared/src/utils/crypto.ts
@@ -11,5 +11,14 @@ export const compareSha256Hash = (
 ): boolean => {
   const generatedHashBuffer = Buffer.from(getSha256Hash(secret, text))
   const hashBuffer = Buffer.from(hash)
-  return timingSafeEqual(generatedHashBuffer, hashBuffer)
+  try {
+    return timingSafeEqual(generatedHashBuffer, hashBuffer)
+  } catch (e) {
+    // Why we're doing this?
+    // If the hashBuffers don't have the same length, `timingSafeEqual` will throw
+    // an error 🙄  instead of returning false, hence this catch.
+    // Extra implication: if there're other errors thrown from timingSafeEqual,
+    // we will return false as well
+    return false
+  }
 }


### PR DESCRIPTION
We expected the [crypto.timingSafeEqual(a,b)](https://nodejs.org/api/crypto.html#cryptotimingsafeequala-b) method to only return a boolean - however, we discovered post-hoc that it also throws an error if the two params are not the same length.
> An error is thrown if a and b have different byte lengths.

This hotfix accounts for that behavior by wrapping the method in a try/catch handler.