### PR TITLE
chore: upgrade sequelize to 6.21.2

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -37,7 +37,7 @@
         "rate-limit-redis": "2.1.0",
         "redis": "3.1.2",
         "reflect-metadata": "0.1.13",
-        "sequelize": "6.17.0",
+        "sequelize": "6.21.2",
         "sequelize-typescript": "2.1.3",
         "source-map-support": "0.5.19",
         "starkbank-ecdsa": "1.1.4",
@@ -9644,9 +9644,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "node_modules/sequelize": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.17.0.tgz",
-      "integrity": "sha512-AZus+0YZDq91Zg0hzDaO5atTzHgJruI23V8nBlAhkLuI81Z53nSRdAe/4R1A6vGOZ/RfCLP9idF4tfQnoAsM5A==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
+      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -19127,9 +19127,9 @@
       }
     },
     "sequelize": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.17.0.tgz",
-      "integrity": "sha512-AZus+0YZDq91Zg0hzDaO5atTzHgJruI23V8nBlAhkLuI81Z53nSRdAe/4R1A6vGOZ/RfCLP9idF4tfQnoAsM5A==",
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
+      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -50,7 +50,7 @@
     "rate-limit-redis": "2.1.0",
     "redis": "3.1.2",
     "reflect-metadata": "0.1.13",
-    "sequelize": "6.17.0",
+    "sequelize": "6.21.2",
     "sequelize-typescript": "2.1.3",
     "source-map-support": "0.5.19",
     "starkbank-ecdsa": "1.1.4",

--- a/backend/src/core/services/job.service.ts
+++ b/backend/src/core/services/job.service.ts
@@ -37,8 +37,8 @@ const canSendCampaign = async (campaignId: number): Promise<boolean> => {
     where: {
       id: campaignId,
       valid: true,
-      credName: { [Op.ne]: null },
-      [Op.or]: [{ halted: { [Op.eq]: null } }, { halted: false }],
+      credName: { [Op.ne]: undefined },
+      [Op.or]: [{ halted: { [Op.eq]: undefined } }, { halted: false }],
     },
   })
   return campaign !== null

--- a/backend/src/email/utils/callback/query.ts
+++ b/backend/src/email/utils/callback/query.ts
@@ -52,7 +52,7 @@ export const updateMessageWithError = async (
           { id },
           {
             [Op.or]: [
-              { receivedAt: null },
+              { receivedAt: undefined },
               { receivedAt: { [Op.lt]: timestamp } },
             ],
           },
@@ -90,12 +90,12 @@ export const updateMessageWithSuccess = async (
           { id },
           {
             [Op.or]: [
-              { receivedAt: null },
+              { receivedAt: undefined },
               { receivedAt: { [Op.lt]: timestamp } },
             ],
           },
           {
-            [Op.or]: [{ status: null }, { status: { [Op.ne]: 'READ' } }],
+            [Op.or]: [{ status: undefined }, { status: { [Op.ne]: 'READ' } }],
           },
         ],
       },
@@ -143,7 +143,7 @@ export const haltCampaignIfThresholdExceeded = async (
   // Source: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/faqs-enforcement.html#e-faq-bn
   const [result] = (await EmailMessage.findAll({
     raw: true,
-    where: { campaignId, status: { [Op.ne]: null } },
+    where: { campaignId, status: { [Op.ne]: undefined } },
     attributes: [
       [fn('sum', cast({ error_code: 'Hard bounce' }, 'int')), 'invalid'],
       [fn('count', 1), 'running_total'],

--- a/backend/src/sms/services/sms-callback.service.ts
+++ b/backend/src/sms/services/sms-callback.service.ts
@@ -88,7 +88,7 @@ const parseEvent = async (req: Request): Promise<void> => {
         where: {
           id: messageId,
           campaignId,
-          errorCode: { [Op.eq]: null },
+          errorCode: { [Op.eq]: undefined },
         },
       }
     )


### PR DESCRIPTION
Closes https://github.com/opengovsg/postmangovsg/pull/1631

- need to upgrade because there is a security issue (see https://github.com/sequelize/sequelize/issues/14519)
- preliminary assessment: this security issue doesn't affect us since we don't use the replacement
- [sequelize v6.19](https://github.com/sequelize/sequelize/releases/tag/v6.19.0 ) has made typing of `WhereOptions` more stringent, necessitating some fixes