### PR TITLE
fix: email verification can succeed if domain is verified

### DIFF
--- a/backend/src/email/services/custom-domain.service.ts
+++ b/backend/src/email/services/custom-domain.service.ts
@@ -6,7 +6,10 @@ import config from '@core/config'
 import { EmailFromAddress } from '@email/models'
 import { MailService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
-import { formatFromAddress } from '@shared/utils/from-address'
+import {
+  extractDomainFromEmail,
+  formatFromAddress,
+} from '@shared/utils/from-address'
 
 const logger = loggerWithLabel(module)
 const [, region] = config.get('mailOptions.host').split('.')
@@ -48,30 +51,42 @@ const verifyCnames = async (
  * @throws Error if the domain's dns do not have the cname records
  */
 const verifyEmailWithAWS = async (email: string): Promise<Array<string>> => {
-  // Get the dkim attributes for the email address
+  // Get the dkim attributes for the email address and domain
+  const emailDomain = extractDomainFromEmail(email)
   const params = {
-    Identities: [email],
+    Identities: [email, emailDomain],
   }
   const { DkimAttributes } = await ses
     .getIdentityDkimAttributes(params)
     .promise()
 
-  const verificationStatus = DkimAttributes[email]?.DkimVerificationStatus
-  const dkimTokens = DkimAttributes[email]?.DkimTokens
+  if (
+    !DkimAttributes ||
+    (!DkimAttributes[email] && !DkimAttributes[emailDomain])
+  ) {
+    return logVerificationAWSFailureAndThrowError(email)
+  }
+
+  // prioritize email address over domain
+  const { DkimVerificationStatus: verificationStatus, DkimTokens: dkimTokens } =
+    DkimAttributes[email] || DkimAttributes[emailDomain]
 
   // Check verification status & make sure dkim tokens are present
-  if (!verificationStatus || verificationStatus !== 'Success' || !dkimTokens) {
-    logger.error({
-      message: 'Verification on AWS failed',
-      email,
-      action: 'verifyEmailWithAWS',
-    })
-    throw new Error(
-      `This From Address cannot be used to send emails. Select another email address to send from, or contact us to investigate.`
-    )
+  if (verificationStatus !== 'Success' || !dkimTokens) {
+    return logVerificationAWSFailureAndThrowError(email)
   }
-  // Make sure the dkim tokens are there.
   return dkimTokens
+}
+
+const logVerificationAWSFailureAndThrowError = (email: string) => {
+  logger.error({
+    message: 'Verification on AWS failed',
+    email,
+    action: 'verifyEmailWithAWS',
+  })
+  throw new Error(
+    `This From Address cannot be used to send emails. Select another email address to send from, or contact us to investigate.`
+  )
 }
 
 /**

--- a/shared/src/utils/from-address.ts
+++ b/shared/src/utils/from-address.ts
@@ -36,3 +36,12 @@ export const escapeFromAddress = (from: string): string => {
   if (fromName) return `"${fromName}" <${normalisedFromAddress}>`
   return normalisedFromAddress
 }
+
+/**
+ * Extract domain from email address
+ */
+
+export const extractDomainFromEmail = (email: string): string => {
+  const [, domain] = email.split('@')
+  return domain
+}


### PR DESCRIPTION
## Problem

Context: we are trying to add an agency whose domain has been previously verified (but not the exact email address), so that they can send out using a custom domain using this email address

However, the current email verification process verifies the exact email with AWS SES, leading the verification process to fail. This is overly narrow — if the domain has been verified, the verification process should succeed.

## Solution

Modify the `verifyEmailWithAWS` method to check the domain of the email, and not just the email itself. 

## Deployment Checklist

N/A