### PR TITLE
feat: monitor sending speed

### DIFF
--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@core/interfaces'
 import { MessageStatus, JobStatus } from '@core/constants'
 import { Writable } from 'stream'
-import { waitForMs } from '@shared/utils/wait-for-ms'
+import { waitForMs } from '@shared/utils/time'
 
 /**
  * Helper method to get precomputed number of errored , sent, and unsent from statistic table.

--- a/shared/src/utils/time.ts
+++ b/shared/src/utils/time.ts
@@ -5,6 +5,6 @@ export const waitForMs = (ms: number): Promise<void> => {
 
 export const millisecondsToMinSecString = (milliseconds: number): string => {
   const minutes = Math.floor(milliseconds / 60000)
-  const seconds = ((milliseconds % 60000) / 1000).toFixed(0)
+  const seconds = ((milliseconds % 60000) / 1000).toFixed(2)
   return `${minutes > 0 ? `${minutes} min ` : ''}${seconds} s`
 }

--- a/shared/src/utils/time.ts
+++ b/shared/src/utils/time.ts
@@ -1,0 +1,10 @@
+export const waitForMs = (ms: number): Promise<void> => {
+  if (ms > 0) return new Promise((resolve) => setTimeout(resolve, ms))
+  return Promise.resolve()
+}
+
+export const millisecondsToMinSecString = (milliseconds: number): string => {
+  const minutes = Math.floor(milliseconds / 60000)
+  const seconds = ((milliseconds % 60000) / 1000).toFixed(0)
+  return `${minutes}:${seconds.length === 1 ? '0' : ''}${seconds}`
+}

--- a/shared/src/utils/time.ts
+++ b/shared/src/utils/time.ts
@@ -6,5 +6,5 @@ export const waitForMs = (ms: number): Promise<void> => {
 export const millisecondsToMinSecString = (milliseconds: number): string => {
   const minutes = Math.floor(milliseconds / 60000)
   const seconds = ((milliseconds % 60000) / 1000).toFixed(0)
-  return `${minutes}:${seconds.length === 1 ? '0' : ''}${seconds}`
+  return `${minutes > 0 ? `${minutes} min ` : ''}${seconds} s`
 }

--- a/shared/src/utils/wait-for-ms.ts
+++ b/shared/src/utils/wait-for-ms.ts
@@ -1,4 +1,0 @@
-export const waitForMs = (ms: number): Promise<void> => {
-  if (ms > 0) return new Promise((resolve) => setTimeout(resolve, ms))
-  return Promise.resolve()
-}

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -221,6 +221,14 @@ const enqueueAndSend = async (): Promise<void> => {
             jobId,
           })
         }
+        const whileLoopTimeTaken = Math.floor((Date.now() - start) / 1000) // in seconds
+        logger.info({
+          message: 'Logging sending while loop duration',
+          action: 'enqueueAndSend',
+          whileLoopTimeTaken,
+          workerId,
+          jobId,
+        })
       }
     }
     await service().destroySendingService()

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -228,6 +228,7 @@ const enqueueAndSend = async (): Promise<void> => {
           )}`,
           action: 'enqueueAndSend',
           whileLoopTimeTaken,
+          rate,
           currentCampaignType,
           campaignId,
           workerId,

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -221,14 +221,15 @@ const enqueueAndSend = async (): Promise<void> => {
             jobId,
           })
         }
-        const whileLoopTimeTaken = Math.floor(Date.now() - start) // in milliseconds
+        const whileLoopTimeTakenMs = Date.now() - start
+        const numMessages = messages.length
+        const numMessagesPerSecond = (numMessages / whileLoopTimeTakenMs) * 1000
         logger.info({
           message: `Logging sending while loop duration: ${millisecondsToMinSecString(
-            whileLoopTimeTaken
+            whileLoopTimeTakenMs
           )}`,
           action: 'enqueueAndSend',
-          whileLoopTimeTaken,
-          rate,
+          numMessagesPerSecond,
           currentCampaignType,
           campaignId,
           workerId,

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -230,6 +230,7 @@ const enqueueAndSend = async (): Promise<void> => {
           )}`,
           action: 'enqueueAndSend',
           numMessagesPerSecond,
+          numMessages,
           currentCampaignType,
           campaignId,
           workerId,

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -6,7 +6,7 @@ require('module-alias/register') // to resolve aliased paths like @core, @sms, @
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { MutableConfig, generateRdsIamAuthToken } from '@core/utils/rds-iam'
-import { waitForMs } from '@shared/utils/wait-for-ms'
+import { millisecondsToMinSecString, waitForMs } from '@shared/utils/time'
 import Email from './email.class'
 import SMS from './sms.class'
 import Telegram from './telegram.class'
@@ -221,11 +221,15 @@ const enqueueAndSend = async (): Promise<void> => {
             jobId,
           })
         }
-        const whileLoopTimeTaken = Math.floor((Date.now() - start) / 1000) // in seconds
+        const whileLoopTimeTaken = Math.floor(Date.now() - start) // in milliseconds
         logger.info({
-          message: 'Logging sending while loop duration',
+          message: `Logging sending while loop duration: ${millisecondsToMinSecString(
+            whileLoopTimeTaken
+          )}`,
           action: 'enqueueAndSend',
           whileLoopTimeTaken,
+          currentCampaignType,
+          campaignId,
           workerId,
           jobId,
         })


### PR DESCRIPTION
## Problem

See https://github.com/opengovsg/postmangovsg/issues/1622

## Solution

- Trace code to understand how workers send messages
- Each run of the `while` loop, where `rate` no. of messages would be sent, is a good place to monitor sending speed
- Set up logs that print out the time taken for each `while` loop
- Set up Datadog custom metrics + monitor that sends message to Slack channel if time taken exceeds a certain threshold (warning + alert)

Currently just a proof-of-concept; to refine this further as necessary before merging in. 

To discuss further:
- How to present the alerts in a way that is helpful (include `campaignId`, `currentCampaignType` etc.)? How to distinguish among them? (Should it be on a per-worker basis?)
- `postman-worker` on Datadog seems to not distinguish between `staging` vs `production`? Think need to refine Datadog setup further
- Set different thresholds for different services (SMS, email, telegram) and measure it based on rate too

## Deployment

Replicate Datadog setup to `production` before merging in

## For Future Extension

- To adjust thresholds on Datadog for warning + alert based on actual usage