### PR TITLE
feat(report): increase retention of delivery reports to 30 days

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -459,7 +459,7 @@ const config = convict({
   redaction: {
     maxAge: {
       doc: 'Maximum age before campaign is redacted',
-      default: 14,
+      default: 30,
       env: 'REDACTION_MAXIMUM_AGE',
       format: Number,
     },

--- a/serverless/redaction-digest/src/config.ts
+++ b/serverless/redaction-digest/src/config.ts
@@ -176,7 +176,7 @@ const config = convict({
   },
   retentionPeriod: {
     doc: 'Number of days to keep campaign before redacting',
-    default: 14,
+    default: 30,
     format: Number,
     env: 'RETENTION_PERIOD',
   },


### PR DESCRIPTION
## Problem

Increase the expiry period for delivery report to 30 days and include that in the redaction reminder

- [Ticket](https://www.notion.so/opengov/Increase-expiry-period-of-both-reports-delivery-unsub-to-30-days-1a909a8153154f41ac5ac2a15c076953)
- [Ticket](https://www.notion.so/opengov/update-reminder-to-campaign-expiry-copy-65bb41839f0a49168afcb3db2616e802)

## Solution

Update the default config to 30 days

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

N/A
