### PR TITLE
fix: cypress to check report

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress');
 const path = require('path');
 const gmail = require('gmail-tester');
+const fs = require('fs')
 
 require('dotenv').config();
 
@@ -10,6 +11,7 @@ module.exports = defineConfig({
     video: false,
     defaultCommandTimeout: 20000,
     retries: 2,
+    trashAssetsBeforeRuns: true,
     env: {
       MSG_TO_VERIFY: 'Dear postman',
       MSG_CONTENT: 'Dear {{}{{}name{}}{}}',
@@ -18,6 +20,7 @@ module.exports = defineConfig({
       OTP_SUBJECT: 'One-Time Password (OTP) for Postman.gov.sg',
       DUMMY_ENC: 'hello',
       WAIT_TIME: 10000,
+      REPORT_WAIT_TIME: 70000,
       MAIL_SENDER: 'donotreply@mail.postman.gov.sg',
       EMAIL: process.env.CYPRESS_EMAIL,
       SMS_NUMBER: process.env.CYPRESS_SMS_NUMBER,
@@ -41,6 +44,9 @@ module.exports = defineConfig({
             }, // Maximum poll interval (in seconds). If reached, return null, indicating the completion of the task().
           );
           return email;
+        },
+        'findDownloaded': async (path) => {
+          return fs.readdirSync(path)
         },
       });
       return config;

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,7 +8,8 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: process.env.CYPRESS_BASE_URL || 'https://staging.postman.gov.sg/',
     video: false,
-    defaultCommandTimeout: 100000,
+    defaultCommandTimeout: 20000,
+    retries: 2,
     env: {
       MSG_TO_VERIFY: 'Dear postman',
       MSG_CONTENT: 'Dear {{}{{}name{}}{}}',


### PR DESCRIPTION
## Problem 1

Cypress test was flaky, can't find DOM elements sometimes

## Solution 1

Allow cypress to retry the tests and only fail if all 3 attempts fail.
Note: assertions don't help as methods are alr retrying by default

## Problem 2
Cypress test does not check the report generated

## Solution 2
load the tracking pixel in gmail to mark email as read
download the report and check for READ status
for sms test, check for SUCCESS status 

## Note
This increases the time taken for cypress test to run as we need to wait for the report to be generated.

## Deployment Checklist

NIL
