### PR TITLE
fix: editor preview styles

### DIFF
--- a/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
+++ b/frontend/src/components/common/rich-text-editor/RichTextEditor.module.scss
@@ -248,6 +248,14 @@
     }
   }
 
+  &.hidePlaceholder {
+    :global {
+      .public-DraftEditorPlaceholder-root {
+        display: none;
+      }
+    }
+  }
+
   .link {
     display: inline-block;
     position: relative;
@@ -295,18 +303,22 @@
 
   :global {
     .rdw-center-aligned-block .public-DraftStyleDefault-block {
+      display: block;
       text-align: center;
     }
 
     .rdw-left-aligned-block .public-DraftStyleDefault-block {
+      display: block;
       text-align: left;
     }
 
     .rdw-right-aligned-block .public-DraftStyleDefault-block {
+      display: block;
       text-align: right;
     }
 
     .rdw-justify-aligned-block .public-DraftStyleDefault-block {
+      display: block;
       text-align: justify;
     }
   }


### PR DESCRIPTION
## Problem

Bug fixes

Bug 1: list bullet appears on top of preview, preview failed to be hidden before characters are typed
Bug 2: list bullet can't be deleted on backspace if it is the first block
<img width="767" alt="Screenshot 2022-08-06 at 12 26 52 AM" src="https://user-images.githubusercontent.com/33883582/183123391-4a7bcd50-9a12-4efe-8b3d-d5fe64dd50c8.png">

Bug 3: alignment of cursor and preview is off when text-alignment is selected
<img width="757" alt="Screenshot 2022-08-06 at 12 27 27 AM" src="https://user-images.githubusercontent.com/33883582/183123466-be715870-aae9-4979-9fcc-cf650252ef10.png">


## Solution

Bug 1 --> hide preview when block type is not normal text
Bug 2 --> manually handle backspace on empty list bullet on the very top of the content
Bug 3 --> hide preview when text-alignment is not left, changed css style to `display:block` for cursor to align vertically with preview (prevent screen from jumping)

## Deployment Checklist
NIL
