### PR TITLE
Fix/xss options

### DIFF
--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -1,4 +1,9 @@
-import { IFilterXSSOptions, cssFilter, safeAttrValue } from 'xss'
+import {
+  IFilterXSSOptions,
+  cssFilter,
+  safeAttrValue,
+  getDefaultCSSWhiteList,
+} from 'xss'
 import { TemplateError } from './errors'
 
 const URL =
@@ -77,6 +82,14 @@ export const XSS_EMAIL_OPTION = {
     return safeAttrValue(tag, name, value, cssFilter)
   },
   stripIgnoreTag: true,
+  // Allow CSS style attributes filtering
+  // https://github.com/leizongmin/js-xss#customize-css-filter
+  css: {
+    whiteList: {
+      ...getDefaultCSSWhiteList(),
+      'white-space': true,
+    },
+  },
 }
 
 export const XSS_SMS_OPTION = {

--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -1,5 +1,6 @@
 import {
   IFilterXSSOptions,
+  ICSSFilter,
   cssFilter,
   safeAttrValue,
   getDefaultCSSWhiteList,
@@ -65,7 +66,12 @@ export const XSS_EMAIL_OPTION = {
     sup: DEFAULT_EMAIL_ATTRS,
     caption: DEFAULT_EMAIL_ATTRS,
   },
-  safeAttrValue: (tag: string, name: string, value: string): string => {
+  safeAttrValue: (
+    tag: string,
+    name: string,
+    value: string,
+    cssFilter: ICSSFilter
+  ): string => {
     // Note: value has already been auto-trimmed of whitespaces
 
     // Do not sanitize keyword when it's a href link, eg: <a href="{{protectedlink}}">link</a>
@@ -110,7 +116,12 @@ export const XSS_TELEGRAM_OPTION = {
     pre: [],
     a: ['href'],
   },
-  safeAttrValue: (tag: string, name: string, value: string): string => {
+  safeAttrValue: (
+    tag: string,
+    name: string,
+    value: string,
+    cssFilter: ICSSFilter
+  ): string => {
     // Handle Telegram mention as xss-js does not recognize it as a valid url.
     if (
       tag === 'a' &&

--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -33,7 +33,7 @@ export const XSS_EMAIL_OPTION = {
     br: DEFAULT_EMAIL_ATTRS,
     p: DEFAULT_EMAIL_ATTRS,
     ul: DEFAULT_EMAIL_ATTRS,
-    ol: DEFAULT_EMAIL_ATTRS,
+    ol: ['start', 'type', ...DEFAULT_EMAIL_ATTRS],
     li: DEFAULT_EMAIL_ATTRS,
     h1: DEFAULT_EMAIL_ATTRS,
     h2: DEFAULT_EMAIL_ATTRS,
@@ -55,7 +55,10 @@ export const XSS_EMAIL_OPTION = {
     tbody: [],
     table: DEFAULT_EMAIL_ATTRS,
     tr: DEFAULT_EMAIL_ATTRS,
-    td: DEFAULT_EMAIL_ATTRS,
+    td: ['colspan', 'rowspan', ...DEFAULT_EMAIL_ATTRS],
+    th: DEFAULT_EMAIL_ATTRS,
+    sup: DEFAULT_EMAIL_ATTRS,
+    caption: DEFAULT_EMAIL_ATTRS,
   },
   safeAttrValue: (tag: string, name: string, value: string): string => {
     // Note: value has already been auto-trimmed of whitespaces


### PR DESCRIPTION
## Problem

There are a number of common html tags and attributes that are not allowed by our XSS filter, such as captions, superscript text and table cell styling. 

## Solution

We add these attributes to our whitelist. 

We also modified the customised escape function `safeAttrValue` to use the module-initiated cssFilter, instead of replacing it with a default CSS filter so that our custom css whitelist options can be applied. 
