### PR TITLE
chore: upgrade docker to node 16

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/l6t0w2g1/node:12-alpine 
+FROM public.ecr.aws/docker/library/node:16-alpine
 # postman public ecr
 
 # required for node-gyp

--- a/serverless/verify-backup/Dockerfile
+++ b/serverless/verify-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM public.ecr.aws/docker/library/node:16-alpine
 
 RUN apk update && apk upgrade
 RUN apk add postgresql

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/l6t0w2g1/node:12-alpine
+FROM public.ecr.aws/docker/library/node:16-alpine
 
 # required for node-gyp
 RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-base \


### PR DESCRIPTION
## Problem

Upgrade to node16 from node12 in docker images as node 12 is no longer on LTS.

## Solution

Use public.ecr.aws/docker/library/node:16-alpine

## Deployment Checklist

N/A
