### PR TITLE
Fix/cypress add assertions

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress');
 const path = require('path');
 const gmail = require('gmail-tester');
+const fs = require('fs')
 
 require('dotenv').config();
 
@@ -10,6 +11,7 @@ module.exports = defineConfig({
     video: false,
     defaultCommandTimeout: 20000,
     retries: 2,
+    trashAssetsBeforeRuns: true,
     env: {
       MSG_TO_VERIFY: 'Dear postman',
       MSG_CONTENT: 'Dear {{}{{}name{}}{}}',
@@ -18,6 +20,7 @@ module.exports = defineConfig({
       OTP_SUBJECT: 'One-Time Password (OTP) for Postman.gov.sg',
       DUMMY_ENC: 'hello',
       WAIT_TIME: 10000,
+      REPORT_WAIT_TIME: 70000,
       MAIL_SENDER: 'donotreply@mail.postman.gov.sg',
       EMAIL: process.env.CYPRESS_EMAIL,
       SMS_NUMBER: process.env.CYPRESS_SMS_NUMBER,
@@ -41,6 +44,9 @@ module.exports = defineConfig({
             }, // Maximum poll interval (in seconds). If reached, return null, indicating the completion of the task().
           );
           return email;
+        },
+        'findDownloaded': async (path) => {
+          return fs.readdirSync(path)
         },
       });
       return config;

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,7 +7,8 @@ require('dotenv').config();
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: process.env.CYPRESS_BASE_URL || 'https://staging.postman.gov.sg/',
+    //baseUrl: process.env.CYPRESS_BASE_URL || 'https://staging.postman.gov.sg/',
+    baseUrl: 'https://postman.gov.sg/',
     video: false,
     defaultCommandTimeout: 20000,
     retries: 2,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,7 +8,8 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: process.env.CYPRESS_BASE_URL || 'https://staging.postman.gov.sg/',
     video: false,
-    defaultCommandTimeout: 100000,
+    defaultCommandTimeout: 20000,
+    retries: 2,
     env: {
       MSG_TO_VERIFY: 'Dear postman',
       MSG_CONTENT: 'Dear {{}{{}name{}}{}}',

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,4 +16,10 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+Cypress.on('uncaught:exception', (err, runnable) => {
+    // returning false here prevents Cypress from
+    // failing the test
+    return false
+})
+
 // Alternatively you can use CommonJS syntax:

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,10 +16,10 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
-Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from
-    // failing the test
-    return false
-})
+// Cypress.on('uncaught:exception', (err, runnable) => {
+//     // returning false here prevents Cypress from
+//     // failing the test
+//     return false
+// })
 
 // Alternatively you can use CommonJS syntax:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "postmangovsg",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "concurrently": "^7.2.1",
-        "cypress": "^10.0.3",
+        "cypress": "^10.2.0",
         "cypress-file-upload": "^5.0.8",
         "dotenv": "^16.0.1",
         "gmail-tester": "^1.3.5",
@@ -704,11 +703,12 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.3.tgz",
-      "integrity": "sha512-8C82XTybsEmJC9POYSNITGUhMLCRwB9LadP0x33H+52QVoBjhsWvIzrI+ybCe0+TyxaF0D5/9IL2kSTgjqCB9A==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.5.0.tgz",
+      "integrity": "sha512-m1oP/2Au+81moyHGg6Mxro8wo5F5rXjtea9SPXn7ezUT3qNHk43bif3K/6Wz7nuaNUiN9/UM+B4c03kCp8vniw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -3581,9 +3581,9 @@
       }
     },
     "cypress": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.3.tgz",
-      "integrity": "sha512-8C82XTybsEmJC9POYSNITGUhMLCRwB9LadP0x33H+52QVoBjhsWvIzrI+ybCe0+TyxaF0D5/9IL2kSTgjqCB9A==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.5.0.tgz",
+      "integrity": "sha512-m1oP/2Au+81moyHGg6Mxro8wo5F5rXjtea9SPXn7ezUT3qNHk43bif3K/6Wz7nuaNUiN9/UM+B4c03kCp8vniw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/datagovsg/postmangovsg#readme",
   "devDependencies": {
     "concurrently": "^7.2.1",
-    "cypress": "^10.0.3",
+    "cypress": "^10.2.0",
     "cypress-file-upload": "^5.0.8",
     "dotenv": "^16.0.1",
     "gmail-tester": "^1.3.5",


### PR DESCRIPTION
## Problem 1

Cypress test was flaky, can't find DOM elements sometimes

## Solution 1

Allow cypress to retry the tests and only fail if all 3 attempts fail.
Note: assertions don't help as methods are alr retrying by default

## Problem 2
Cypress test does not check the report generated

## Solution 2
load the tracking pixel in gmail to mark email as read
download the report and check for READ status
for sms test, check for SUCCESS status 

## Note
This increases the time taken for cypress test to run as we need to wait for the report to be generated.

## Problem 3

Fixing cypress error: Type error thrown from node library is causing cypress runs to fail on github action
`[gmail] Error: TypeError: Cannot read properties of undefined (reading 'id')`
https://github.com/opengovsg/postmangovsg/actions/runs/2865506531

## Solution 3

Get cypress to ignore exception errors from code base since we can't change the node library

## Note
Run cypress action from this branch before merging to test if it works
Apologies for the two merges before this

