### PR TITLE
fix(unsub): fix db constraint error because of soft delete

### DIFF
--- a/backend/src/core/models/unsubscriber.ts
+++ b/backend/src/core/models/unsubscriber.ts
@@ -38,4 +38,7 @@ export class Unsubscriber extends Model<Unsubscriber> {
     type: DataType.STRING,
   })
   reason?: string
+
+  @Column(DataType.DATE)
+  deletedAt?: Date | null
 }

--- a/backend/src/core/services/unsubscriber.service.ts
+++ b/backend/src/core/services/unsubscriber.service.ts
@@ -44,16 +44,13 @@ const findOrCreateUnsubscriber = ({
   campaignId: number
   recipient: string
   reason: string
-}): Promise<[Unsubscriber, boolean]> => {
-  return Unsubscriber.findOrCreate({
-    defaults: {
-      reason,
-    } as Unsubscriber,
-    where: {
-      campaignId,
-      recipient,
-    },
-  })
+}): Promise<[Unsubscriber, boolean | null]> => {
+  return Unsubscriber.upsert({
+    reason,
+    deletedAt: null,
+    campaignId,
+    recipient,
+  } as Unsubscriber)
 }
 
 const deleteUnsubscriber = async ({


### PR DESCRIPTION
## Problem

Currently re-unsubscribe will result in unique constraint error in sql as `findAndCreate` will try to insert again.

## Solution

Switch to upsert

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

N/A