### PR TITLE
refactor: fix issue with new migration ending up in build folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ npm run db:migrate # run all pending migrations
 npm run db:seed # seed database with dummy data
 ```
 
+If you run into errors at the `db:migrate` step, this is likely because you have created a new model in TypeScript that has not been compiled to JavaScript. Run `npm run build` to fix this error.
+
 If you need to undo any database migrations:
 
 ```zsh

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ npm run db:undo # undo most recent migration
 
 You can find more info on undoing migrations using Sequelize [here](https://sequelize.org/docs/v6/other-topics/migrations/#undoing-migrations).
 
+If you wish to create a new migration, run:
+
+```zsh
+cd backend
+npx sequelize-cli migration:create --name migration-name-in-kebab-case
+```
+
 ### Compile frontend translations
 
 [lingui](https://lingui.js.org/) is used for internationalization. Read [this](frontend/src/locales/README.md) for more info.

--- a/backend/.sequelizerc
+++ b/backend/.sequelizerc
@@ -2,9 +2,11 @@ const path = require('path')
 
 const BASE_PATH = './build/database'
 
+const SRC_BASE_PATH = './src/database'
+
 module.exports = {
 	config: path.resolve(BASE_PATH, 'config.js'),
 	'models-path': path.resolve(BASE_PATH, 'models'),
 	'seeders-path': path.resolve(BASE_PATH, 'seeders'),
-	'migrations-path': path.resolve(BASE_PATH, 'migrations'),
+	'migrations-path': path.resolve(SRC_BASE_PATH, 'migrations'),
 }

--- a/backend/.sequelizerc
+++ b/backend/.sequelizerc
@@ -8,5 +8,6 @@ module.exports = {
 	config: path.resolve(BASE_PATH, 'config.js'),
 	'models-path': path.resolve(BASE_PATH, 'models'),
 	'seeders-path': path.resolve(BASE_PATH, 'seeders'),
+	// this works as migrations are already written in JS
 	'migrations-path': path.resolve(SRC_BASE_PATH, 'migrations'),
 }


### PR DESCRIPTION
Tested commands; works as intended

Another benefit of this PR is, while testing migrations, there is no need to run `npm run build` in order to run the migration with the latest changes.

Actually the `npx sequelize-cli model:generate --name XXX` command is quite useless:
- it generates a `.js` file that is quite different from how the rest of the data models are written. 
- but at least it helps to create a reasonably named migration file (though still need to manually edit the migration file, which is more of a hassle compared to my experience with TypeORM)

One problem I encountered is that, sometimes when I run a migration, if the migration relies on a model that doesn't exist, I need to run `npm run build` before the migration can tun properly.

I feel like this PR is only putting band-aid — it works for now, but ideally the migration should be automatically generated based on the data model defined and should be written in TypeScript rather than JavaScript.