### PR TITLE
fix: parsing error cannot read tsconfig.json

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   parserOptions: {
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
   env: {

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   parserOptions: {
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
   ignorePatterns: [

--- a/shared/.eslintrc.js
+++ b/shared/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   parserOptions: {
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
   env: {

--- a/worker/.eslintrc.js
+++ b/worker/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   ],
   parserOptions: {
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
     project: ['./tsconfig.json'],
   },
   ignorePatterns: [


### PR DESCRIPTION
## Problem

Noticed this error while on VSCode

## Solution

This PR makes the error go away. See [here](https://bobbyhadz.com/blog/typescript-parsing-error-cannot-read-file).
