### PR TITLE
feat: whitelist for.sg as allowedImageSources

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -29,7 +29,7 @@ customHeaders:
           default-src 'self' https://*.postman.gov.sg;
           object-src 'none';
           script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
-          img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg;
+          img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg https://file.for.sg;
           media-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
           child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/"
       - key: "Content-Security-Policy-Report-Only"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -87,7 +87,7 @@ msgstr "Verifying OTP..."
 
 #: config.ts:90
 msgid "allowedImageSources"
-msgstr "file.go.gov.sg"
+msgstr "file.go.gov.sg;file.for.sg"
 
 #: config.ts:106
 msgid "announcement.mediaUrl"


### PR DESCRIPTION
## Problem

- `for.sg` file links are not showing up in preview

## Solution

- whitelist `file.for.sg` links 

Tested, works on staging
