### PR TITLE
chore: upgrade to vm2@3.9.11 because of security vulnerability

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -56,6 +56,7 @@
         "twilio": "3.77.3",
         "uuid": "7.0.3",
         "validator": "13.7.0",
+        "vm2": "^3.9.11",
         "winston": "3.8.1",
         "winston-cloudwatch": "6.0.1"
       },
@@ -12357,9 +12358,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.10.tgz",
-      "integrity": "sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
+      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -22516,9 +22517,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vm2": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.10.tgz",
-      "integrity": "sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==",
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
+      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"


### PR DESCRIPTION
upgrade vm2 version because of vulnerability