### PR TITLE
feat: whitelist for.edu.sg as allowedImageSources

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -29,7 +29,7 @@ customHeaders:
           default-src 'self' https://*.postman.gov.sg;
           object-src 'none';
           script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
-          img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg https://file.for.sg;
+          img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg https://file.for.sg https://file.for.edu.sg;
           media-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
           child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/"
       - key: "Content-Security-Policy-Report-Only"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -87,7 +87,7 @@ msgstr "Verifying OTP..."
 
 #: config.ts:90
 msgid "allowedImageSources"
-msgstr "file.go.gov.sg;file.for.sg"
+msgstr "file.go.gov.sg;file.for.sg;file.for.edu.sg"
 
 #: config.ts:106
 msgid "announcement.mediaUrl"


### PR DESCRIPTION
Identical to https://github.com/opengovsg/postmangovsg/pull/1776, just for `for.edu.sg` as well