### PR TITLE
fix(backend): fix nonnullable from name error in txn email saving

### DIFF
--- a/backend/src/database/migrations/20221005070028-email-messages-transactional-make-from-nullable.js
+++ b/backend/src/database/migrations/20221005070028-email-messages-transactional-make-from-nullable.js
@@ -1,0 +1,41 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn(
+      'email_messages_transactional',
+      'from_name'
+    )
+    await queryInterface.removeColumn(
+      'email_messages_transactional',
+      'from_address'
+    )
+    await queryInterface.addColumn('email_messages_transactional', 'from', {
+      type: Sequelize.DataTypes.STRING,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('email_messages_transactional', 'from')
+
+    // not possible to revert these 2 columns to the exact equivalents as the up
+    // migration is lossy
+    await queryInterface.addColumn(
+      'email_messages_transactional',
+      'from_name',
+      {
+        type: Sequelize.DataTypes.STRING,
+        allowNull: true,
+      }
+    )
+    await queryInterface.addColumn(
+      'email_messages_transactional',
+      'from_address',
+      {
+        type: Sequelize.DataTypes.STRING,
+        allowNull: true,
+      }
+    )
+  },
+}

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -16,7 +16,6 @@ import {
   EmailMessageTransactional,
   TransactionalEmailMessageStatus,
 } from '@email/models'
-import { parseFromAddress } from '@shared/utils/from-address'
 
 import crypto from 'crypto'
 
@@ -56,11 +55,9 @@ export const InitEmailTransactionalMiddleware = (
       attachments,
     }: ReqBody = req.body
 
-    const { fromName, fromAddress } = parseFromAddress(from)
     const emailMessageTransactional = await EmailMessageTransactional.create({
       userId: req.session?.user?.id,
-      fromName,
-      fromAddress,
+      from,
       recipient,
       params: {
         subject,

--- a/backend/src/email/models/email-message-transactional.ts
+++ b/backend/src/email/models/email-message-transactional.ts
@@ -43,11 +43,8 @@ export class EmailMessageTransactional extends Model<EmailMessageTransactional> 
   @Column({ type: DataType.STRING, allowNull: false })
   userId: string
 
-  @Column({ type: DataType.STRING, allowNull: false })
-  fromName: string
-
-  @Column({ type: DataType.STRING, allowNull: false })
-  fromAddress: string
+  @Column({ type: DataType.STRING, allowNull: true })
+  from: string
 
   @Column({ type: DataType.STRING, allowNull: false })
   recipient: string


### PR DESCRIPTION
## Problem

https://sentry.io/organizations/open-government-products-re/issues/3643069534/?project=5272357&referrer=slack

## Solution

Make the field nullable as it should be

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] Run db migration
