### PR TITLE
feat(backend): handle status callbacks for transactional emails

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -81,6 +81,7 @@ interface ConfigSchema {
     workerHost: string
   }
   mailFrom: string
+  mailConfigurationSet: string
   mailVia: string
   mailDefaultRate: number
   transactionalEmail: {
@@ -432,6 +433,11 @@ const config: Config<ConfigSchema> = convict({
     doc: 'The email address that appears in the From field of an email',
     default: '',
     env: 'BACKEND_SES_FROM',
+  },
+  mailConfigurationSet: {
+    doc: 'The configuration set specified when sending an email',
+    default: 'postman-email-open',
+    env: 'BACKEND_SES_CONFIGURATION_SET',
   },
   mailVia: {
     doc: 'Text to appended to custom sender name',

--- a/backend/src/core/services/mail.service.ts
+++ b/backend/src/core/services/mail.service.ts
@@ -4,7 +4,8 @@ import config from '@core/config'
 const mailClient = new MailClient(
   config.get('mailOptions'),
   config.get('emailCallback.hashSecret'),
-  config.get('emailFallback.activate') ? config.get('mailFrom') : undefined
+  config.get('emailFallback.activate') ? config.get('mailFrom') : undefined,
+  config.get('mailConfigurationSet')
 )
 
 export const MailService = {

--- a/backend/src/database/migrations/20221005075027-add-error-sub-type-to-transactional-email.js
+++ b/backend/src/database/migrations/20221005075027-add-error-sub-type-to-transactional-email.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+      'email_messages_transactional',
+      'error_sub_type',
+      {
+        type: Sequelize.DataTypes.STRING,
+        allowNull: true,
+      }
+    )
+  },
+
+  down: async (queryInterface, _) => {
+    await queryInterface.removeColumn(
+      'email_messages_transactional',
+      'error_sub_type'
+    )
+  },
+}

--- a/backend/src/email/interfaces/callback.interface.ts
+++ b/backend/src/email/interfaces/callback.interface.ts
@@ -20,3 +20,11 @@ export interface UpdateMessageWithErrorMetadata extends Metadata {
   errorCode: string
   errorSubType?: string
 }
+
+export enum SesEventType {
+  Delivery = 'Delivery',
+  Bounce = 'Bounce',
+  Complaint = 'Complaint',
+  Open = 'Open',
+  Send = 'Send',
+}

--- a/backend/src/email/models/email-message-transactional.ts
+++ b/backend/src/email/models/email-message-transactional.ts
@@ -44,7 +44,7 @@ export class EmailMessageTransactional extends Model<EmailMessageTransactional> 
   userId: string
 
   @Column({ type: DataType.STRING, allowNull: true })
-  from: string
+  from: string | null
 
   @Column({ type: DataType.STRING, allowNull: false })
   recipient: string
@@ -64,20 +64,13 @@ export class EmailMessageTransactional extends Model<EmailMessageTransactional> 
   })
   status: TransactionalEmailMessageStatus
 
-  /*
-   * see https://www.notion.so/opengov/23-Sep-2022-RFC-for-Saving-Emails-Sent-via-API-e4d29e9488004bcbb430ab15c9ef589f#bae59004a81846618552922e3751e012 for detailed discussion on errorCode and errorSubType
-   * */
-
-  // will only handle the non-callback error codes for now
   @Column({ type: DataType.STRING, allowNull: true })
   errorCode: string | null
 
-  // this is the error type returned by AWS SES; to be handled when callback is supported
-  // @Column({ type: DataType.STRING, allowNull: true })
-  // errorSubType: string | null
+  @Column({ type: DataType.STRING, allowNull: true })
+  errorSubType: string | null
 
   /*
-   * TODO: capture key timestamps in email's lifecycle and align with email_messages table
    * https://www.notion.so/opengov/Support-callbacks-in-transactional-emails-cade9647b2264a28a9a4d7eca301846a
    * */
   // this is equivalent to `sent_at` from `email_messages` table

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -8,6 +8,7 @@ import {
   EmailMessageTransactional,
   TransactionalEmailMessageStatus,
 } from '@email/models'
+import { SesEventType } from '@email/interfaces/callback.interface'
 
 const logger = loggerWithLabel(module)
 
@@ -103,12 +104,12 @@ type CallbackMetaData = {
   }
 }
 async function handleStatusCallbacks(
-  type: string,
+  type: SesEventType,
   id: string,
   metadata: CallbackMetaData
 ): Promise<void> {
   switch (type) {
-    case 'Delivery':
+    case SesEventType.Delivery:
       await EmailMessageTransactional.update(
         {
           status: TransactionalEmailMessageStatus.Delivered,
@@ -119,7 +120,7 @@ async function handleStatusCallbacks(
         }
       )
       break
-    case 'Bounce':
+    case SesEventType.Bounce:
       await EmailMessageTransactional.update(
         {
           status: TransactionalEmailMessageStatus.Bounced,
@@ -134,7 +135,7 @@ async function handleStatusCallbacks(
         }
       )
       break
-    case 'Complaint':
+    case SesEventType.Complaint:
       await EmailMessageTransactional.update(
         {
           status: TransactionalEmailMessageStatus.Complaint,
@@ -146,7 +147,7 @@ async function handleStatusCallbacks(
         }
       )
       break
-    case 'Open':
+    case SesEventType.Open:
       await EmailMessageTransactional.update(
         {
           status: TransactionalEmailMessageStatus.Opened,
@@ -157,7 +158,7 @@ async function handleStatusCallbacks(
         }
       )
       break
-    case 'Send':
+    case SesEventType.Send:
       await EmailMessageTransactional.update(
         {
           status: TransactionalEmailMessageStatus.Sent,

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -4,7 +4,10 @@ import { loggerWithLabel } from '@core/logger'
 import { isBlacklisted } from '@email/utils/query'
 import { InvalidMessageError, InvalidRecipientError } from '@core/errors'
 import { FileAttachmentService } from '@core/services'
-import { EmailMessageTransactional } from '@email/models'
+import {
+  EmailMessageTransactional,
+  TransactionalEmailMessageStatus,
+} from '@email/models'
 
 const logger = loggerWithLabel(module)
 
@@ -74,17 +77,108 @@ async function sendMessage({
     recipients: [recipient],
     replyTo,
     attachments: sanitizedAttachments,
+    referenceId: emailMessageTransactionalId.toString(),
   }
   logger.info({
     message: 'Sending transactional email',
     action: 'sendMessage',
   })
-  const messageId = await EmailService.sendEmail(mailToSend)
+  const messageId = await EmailService.sendEmail(mailToSend, {
+    extraSmtpHeaders: { isTransactional: true },
+  })
   if (!messageId) {
     throw new Error('Failed to send transactional email')
   }
 }
 
+type CallbackMetaData = {
+  timestamp: Date
+  bounce?: {
+    bounceType: string
+    bounceSubType: string
+  }
+  complaint?: {
+    complaintFeedbackType: string
+    complaintSubType: string
+  }
+}
+async function handleStatusCallbacks(
+  type: string,
+  id: string,
+  metadata: CallbackMetaData
+): Promise<void> {
+  switch (type) {
+    case 'Delivery':
+      await EmailMessageTransactional.update(
+        {
+          status: TransactionalEmailMessageStatus.Delivered,
+          deliveredAt: metadata.timestamp,
+        },
+        {
+          where: { id },
+        }
+      )
+      break
+    case 'Bounce':
+      await EmailMessageTransactional.update(
+        {
+          status: TransactionalEmailMessageStatus.Bounced,
+          errorCode:
+            metadata.bounce?.bounceType === 'Permanent'
+              ? 'Hard bounce'
+              : 'Soft bounce',
+          errorSubType: metadata.bounce?.bounceSubType,
+        },
+        {
+          where: { id },
+        }
+      )
+      break
+    case 'Complaint':
+      await EmailMessageTransactional.update(
+        {
+          status: TransactionalEmailMessageStatus.Complaint,
+          errorCode: metadata.complaint?.complaintFeedbackType,
+          errorSubType: metadata.complaint?.complaintSubType,
+        },
+        {
+          where: { id },
+        }
+      )
+      break
+    case 'Open':
+      await EmailMessageTransactional.update(
+        {
+          status: TransactionalEmailMessageStatus.Opened,
+          openedAt: metadata.timestamp,
+        },
+        {
+          where: { id },
+        }
+      )
+      break
+    case 'Send':
+      await EmailMessageTransactional.update(
+        {
+          status: TransactionalEmailMessageStatus.Sent,
+          sentAt: metadata.timestamp,
+        },
+        {
+          where: { id },
+        }
+      )
+      break
+    default:
+      logger.error({
+        message: 'Unable to handle messages with this type',
+        type,
+        id,
+        metadata,
+      })
+  }
+}
+
 export const EmailTransactionalService = {
   sendMessage,
+  handleStatusCallbacks,
 }

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -12,7 +12,7 @@ import {
   UnsubscriberService,
 } from '@core/services'
 import { CampaignDetails } from '@core/interfaces'
-import { MailToSend } from '@shared/clients/mail-client.class'
+import { MailToSend, SendEmailOpts } from '@shared/clients/mail-client.class'
 
 import { EmailTemplate, EmailMessage } from '@email/models'
 import { EmailTemplateService } from '@email/services'
@@ -151,9 +151,12 @@ const getCampaignMessage = async (
  * Sends message
  * @param mail
  */
-const sendEmail = async (mail: MailToSend): Promise<string | void> => {
+const sendEmail = async (
+  mail: MailToSend,
+  opts?: SendEmailOpts
+): Promise<string | void> => {
   try {
-    return MailService.mailClient.sendMail(mail)
+    return MailService.mailClient.sendMail(mail, opts)
   } catch (e) {
     logger.error({
       message: 'Error while sending test email',

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -13,6 +13,7 @@ import { addToBlacklist } from '@email/utils/callback/query'
 import config from '@core/config'
 import { compareSha256Hash } from '@shared/utils/crypto'
 import { EmailTransactionalService } from '@email/services/email-transactional.service'
+import { SesEventType } from '@email/interfaces/callback.interface'
 
 const logger = loggerWithLabel(module)
 const REFERENCE_ID_HEADER_V2 = 'X-SMTPAPI' // Case sensitive
@@ -128,7 +129,7 @@ const shouldBlacklist = ({
 }
 
 const parseNotificationAndEvent = async (
-  type: string,
+  type: SesEventType,
   message: any,
   metadata: any
 ): Promise<void> => {
@@ -136,10 +137,10 @@ const parseNotificationAndEvent = async (
   const logMeta = { messageId, action: 'parseNotification' }
 
   switch (type) {
-    case 'Delivery':
+    case SesEventType.Delivery:
       await updateDeliveredStatus(metadata)
       break
-    case 'Bounce':
+    case SesEventType.Bounce:
       await updateBouncedStatus({
         ...metadata,
         bounceType: message?.bounce?.bounceType,
@@ -147,7 +148,7 @@ const parseNotificationAndEvent = async (
         to: message?.mail?.commonHeaders?.to,
       })
       break
-    case 'Complaint':
+    case SesEventType.Complaint:
       await updateComplaintStatus({
         ...metadata,
         complaintType: message?.complaint?.complaintFeedbackType,
@@ -155,7 +156,7 @@ const parseNotificationAndEvent = async (
         to: message?.mail?.commonHeaders?.to,
       })
       break
-    case 'Open':
+    case SesEventType.Open:
       await updateReadStatus(metadata)
       break
     default:

--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -8,6 +8,10 @@ const CONFIGURATION_SET_HEADER = 'X-SES-CONFIGURATION-SET' // Case sensitive
 
 export * from './interfaces'
 
+export type SendEmailOpts = {
+  extraSmtpHeaders: Record<string, any>
+}
+
 export default class MailClient {
   private mailer: nodemailer.Transporter
   private email: string
@@ -34,7 +38,10 @@ export default class MailClient {
     this.configSet = configSet
   }
 
-  public sendMail(input: MailToSend): Promise<string | void> {
+  public sendMail(
+    input: MailToSend,
+    option?: SendEmailOpts
+  ): Promise<string | void> {
     return new Promise<string | void>((resolve, reject) => {
       const username = Math.random().toString(36).substring(2, 15) // random string
       const xSmtpHeader: { [key: string]: any } = {
@@ -42,6 +49,7 @@ export default class MailClient {
           username,
           hash: getSha256Hash(this.hashSecret, username),
         },
+        ...(option?.extraSmtpHeaders || {}), // guard against undefined extraSmtpHeaders value
       } as { [key: string]: any }
       if (input.referenceId !== undefined) {
         // Signature expected by Sendgrid


### PR DESCRIPTION
## Problem

Enable and handle callbacks for status update of transactional emails

## Solution

Implement transactional callbacks handling on the same endpoint as campaign-sent
- Add `mailConfigurationSet` as a backend env var. 
  - For context, we use different AWS SES regions for campaigns (prod: N. Virignia, staging: Frankfurt) and for transactional emails (prod: Sydney, staging: Frankfurt) but they are all named `postman-email-open`.
  - We are not distinguishing between the production and staging ones and are using a single env var on the backend (for transactional emails) and a single env var [on the worker](https://github.com/opengovsg/postmangovsg/blob/915f7152a58085d0ba82be61d250e0754897153d/worker/src/core/config.ts#L205) (for campaign emails) to refer to both config sets. This works because they're all named the same.
- Add extra SMTP header to indicate whether a given email is a transactional email one. This will be included in the callback AWS SES sends us, which we then parse to know to update `email_messages_transactional` table

Some notes:
- We decided to take the simple approach to email statuses by simply updating statuses based on what the AWS SES event is. 
  - We considered a more complex approach that would impose a certain order (e.g. preventing updating an email with a `Delivery` status to `Sent`, or an email with `Bounced` to `Delivery`), but decided against it. 
  - This is because AWS SES events typically arrive in the right order and, if we discover this to be an issue in the future, we can fix it then.
- We considered renaming `postman-email-open` to a more accurate name. 
  - For context, it was originally named `open` because the other events (`Sent`, `Bounced`, `Delivery`) were handled at the config set of the specific *verified identity* rather than at the AWS SES level. 
  - `Open`, however, could only be handled at the AWS SES level (because it required embedding a pixel to tell whether an email has been opened), which was why the config set was created and named thus. We decided to move all the config set to the AWS SES level so that there is a single source of truth. 
  - However, renaming the config set would be very troublesome if we wanted to ensure there is no downtime. Therefore we decided against it. 
- We considered whether to log the update status the way it is done in the [callbacks of campaign emails](https://github.com/opengovsg/postmangovsg/blob/31f023304ced17d0f79c178b7e15a8b519e68ee8/backend/src/email/utils/callback/query.ts), but we ultimately decided against as we didn't think it was useful for debugging. 

## Deployment Checklist

- [x] Migrate callbacks to use config set only
- [x] Migrate db