### PR TITLE
feat: use jsonb instead of json throughout codebase

### DIFF
--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -64,7 +64,7 @@ export class Campaign extends Model<Campaign> {
   @BelongsTo(() => Credential)
   credential?: Credential
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   s3Object?: CampaignS3ObjectInterface
 
   @Column({

--- a/backend/src/database/migrations/20210422073013-create-campaigns.js
+++ b/backend/src/database/migrations/20210422073013-create-campaigns.js
@@ -35,6 +35,7 @@ module.exports = {
         },
         onUpdate: 'CASCADE',
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       s3_object: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20210422073931-create-sms-messages.js
+++ b/backend/src/database/migrations/20210422073931-create-sms-messages.js
@@ -22,6 +22,7 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20210422081912-create-email-messages.js
+++ b/backend/src/database/migrations/20210422081912-create-email-messages.js
@@ -22,6 +22,7 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20210422082154-create-telegram-messages.js
+++ b/backend/src/database/migrations/20210422082154-create-telegram-messages.js
@@ -23,6 +23,7 @@ module.exports = {
         allowNull: false,
       },
       params: {
+        // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
         type: Sequelize.DataTypes.JSON,
         allowNull: true,
       },

--- a/backend/src/database/migrations/20210422083045-create-sms-ops.js
+++ b/backend/src/database/migrations/20210422083045-create-sms-ops.js
@@ -22,6 +22,7 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20210422083254-create-telegram-ops.js
+++ b/backend/src/database/migrations/20210422083254-create-telegram-ops.js
@@ -23,6 +23,7 @@ module.exports = {
         type: Sequelize.DataTypes.BIGINT,
         allowNull: false,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20210422083258-create-email-ops.js
+++ b/backend/src/database/migrations/20210422083258-create-email-ops.js
@@ -22,6 +22,7 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: true,

--- a/backend/src/database/migrations/20220915123536-create-email-messages-transactional.js
+++ b/backend/src/database/migrations/20220915123536-create-email-messages-transactional.js
@@ -32,6 +32,7 @@ module.exports = {
         allowNull: false,
         type: Sequelize.DataTypes.STRING(255),
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       params: {
         type: Sequelize.DataTypes.JSON,
         allowNull: false,
@@ -40,6 +41,7 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      // superseded by 20221009141317-change-json-to-jsonb-everywhere.js
       attachments_metadata: {
         type: Sequelize.DataTypes.ARRAY(Sequelize.DataTypes.JSON),
         allowNull: true,

--- a/backend/src/database/migrations/20221009141317-change-json-to-jsonb-everywhere.js
+++ b/backend/src/database/migrations/20221009141317-change-json-to-jsonb-everywhere.js
@@ -1,0 +1,97 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn(
+      'email_messages_transactional',
+      'attachments_metadata',
+      {
+        type: Sequelize.DataTypes.ARRAY(Sequelize.DataTypes.JSONB),
+        allowNull: true,
+      }
+    )
+    await queryInterface.changeColumn(
+      'email_messages_transactional',
+      'params',
+      {
+        type: Sequelize.DataTypes.JSONB,
+        allowNull: true,
+      }
+    )
+    await queryInterface.changeColumn('email_messages', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('sms_messages', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('telegram_messages', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('email_ops', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('sms_ops', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('telegram_ops', 'params', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('campaigns', 's3_object', {
+      type: Sequelize.DataTypes.JSONB,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn(
+      'email_messages_transactional',
+      'attachments_metadata',
+      {
+        type: Sequelize.DataTypes.ARRAY(Sequelize.DataTypes.JSON),
+        allowNull: true,
+      }
+    )
+    await queryInterface.changeColumn(
+      'email_messages_transactional',
+      'params',
+      {
+        type: Sequelize.DataTypes.JSON,
+        allowNull: true,
+      }
+    )
+    await queryInterface.changeColumn('email_messages', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('sms_messages', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('telegram_messages', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('email_ops', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('sms_ops', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('telegram_ops', 'params', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+    await queryInterface.changeColumn('campaigns', 's3_object', {
+      type: Sequelize.DataTypes.JSON,
+      allowNull: true,
+    })
+  },
+}

--- a/backend/src/email/models/email-message-transactional.ts
+++ b/backend/src/email/models/email-message-transactional.ts
@@ -49,13 +49,13 @@ export class EmailMessageTransactional extends Model<EmailMessageTransactional> 
   @Column({ type: DataType.STRING, allowNull: false })
   recipient: string
 
-  @Column({ type: DataType.JSON, allowNull: false })
+  @Column({ type: DataType.JSONB, allowNull: false })
   params: Record<string, string>
 
   @Column({ type: DataType.STRING, allowNull: true })
   messageId: string | null
 
-  @Column({ type: DataType.ARRAY(DataType.JSON), allowNull: true })
+  @Column({ type: DataType.ARRAY(DataType.JSONB), allowNull: true })
   attachmentsMetadata: AttachmentsMetadata | null
 
   @Column({

--- a/backend/src/email/models/email-message.ts
+++ b/backend/src/email/models/email-message.ts
@@ -34,8 +34,8 @@ export class EmailMessage extends Model<EmailMessage> {
   @BelongsTo(() => Unsubscriber)
   unsubscriber?: Unsubscriber
 
-  @Column(DataType.JSON)
-  params: object
+  @Column(DataType.JSONB)
+  params!: object
 
   @Column({ type: DataType.STRING, allowNull: true })
   messageId: string | null

--- a/backend/src/email/models/email-op.ts
+++ b/backend/src/email/models/email-op.ts
@@ -28,7 +28,7 @@ export class EmailOp extends Model<EmailOp> {
   @Column(DataType.STRING)
   recipient!: string
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   params!: object
 
   @Column(DataType.STRING)

--- a/backend/src/sms/models/sms-message.ts
+++ b/backend/src/sms/models/sms-message.ts
@@ -28,7 +28,7 @@ export class SmsMessage extends Model<SmsMessage> {
   @Column(DataType.STRING)
   recipient!: string
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   params!: object
 
   @Column(DataType.STRING)

--- a/backend/src/sms/models/sms-op.ts
+++ b/backend/src/sms/models/sms-op.ts
@@ -28,7 +28,7 @@ export class SmsOp extends Model<SmsOp> {
   @Column(DataType.STRING)
   recipient!: string
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   params!: object
 
   @Column(DataType.STRING)

--- a/backend/src/telegram/models/telegram-message.ts
+++ b/backend/src/telegram/models/telegram-message.ts
@@ -35,7 +35,7 @@ export class TelegramMessage extends Model<TelegramMessage> {
   })
   recipient!: string
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   params!: object
 
   @Column(DataType.STRING)

--- a/backend/src/telegram/models/telegram-op.ts
+++ b/backend/src/telegram/models/telegram-op.ts
@@ -34,7 +34,7 @@ export class TelegramOp extends Model<TelegramOp> {
   })
   recipient!: number
 
-  @Column(DataType.JSON)
+  @Column(DataType.JSONB)
   params!: object
 
   @Column(DataType.STRING)


### PR DESCRIPTION
### Background

 I was more exploring why the metadata is stored so weirdly, `{"{\"hash\": \"ebc2628a3fa93f210d783ce645edcaf1\", \"fileName\": \"zx.csv\", \"fileSize\": 31}"}`

But I have since concluded that it doesn't matter since both Sequelize and PostgreSQL recognise and can manipulate the data nicely. As such, this PR is not strictly necessary, but might be good-to-have nonetheless.

### Change

This PR converts `attachments_metadata` from `json[]` to `jsonb[]`. 

Some advantages of `jsonb` (basically better processing) from [here](https://stackoverflow.com/questions/22654170/explanation-of-jsonb-introduced-by-postgresql)
<img width="681" alt="image" src="https://user-images.githubusercontent.com/67887489/194765598-067f8236-1ffd-4628-9e6d-380821f88581.png">

### SQL commands to run to check for length of array:

E.g. to find all emails with 2 attachments:
```SQL
SELECT *
FROM email_messages_transactional
WHERE array_length(attachments_metadata, 1) = 2;
```

## Deployment Checklist
- [ ] Run db migration (order doesn't matter)

Tested on staging (CI [here](https://github.com/opengovsg/postmangovsg/actions/runs/3239692198))