### PR TITLE
feat: allow use of postman template in transactional email

### DIFF
--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -113,8 +113,10 @@ export const InitEmailTransactionalMiddleware = (
       reply_to: replyTo,
       attachments,
       emailMessageTransactionalId, // added by saveMessage
+      use_template: useTemplate,
     }: ReqBody & {
       emailMessageTransactionalId: number
+      use_template?: boolean
     } = req.body
 
     try {
@@ -127,6 +129,7 @@ export const InitEmailTransactionalMiddleware = (
           replyTo ?? (await authService.findUser(req.session?.user?.id))?.email,
         attachments,
         emailMessageTransactionalId,
+        useTemplate,
       })
       await EmailMessageTransactional.update(
         {

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -30,6 +30,7 @@ export const InitEmailTransactionalRoute = (
         .options({ convert: true })
         .lowercase(),
       attachments: Joi.array().items(Joi.object().keys().required()),
+      use_template: Joi.boolean().default(false).optional(),
     }),
   }
 

--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -211,7 +211,9 @@
           Powered by <a href="https://postman.gov.sg">Postman</a>, the official communication tool trusted by government agencies.
           <br />
           <br />    
+          {{#unsubLink}}
           <a href="{{{unsubLink}}}">Unsubscribe</a>
+          {{/unsubLink}}
           <div class="footer-vertical-spacer-top" style="line-height: 16px; height: 16px;">&#8202;</div>
           <div>
             <img src="https://file.go.gov.sg/postman-logo-color.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px;">

--- a/shared/src/theme/index.ts
+++ b/shared/src/theme/index.ts
@@ -7,7 +7,7 @@ type EmailThemeFields = {
   body: string
   agencyName?: string
   agencyLogoURI?: string
-  unsubLink: string
+  unsubLink?: string
   showMasthead?: boolean
 }
 


### PR DESCRIPTION
## Problem

Plain text emails often look phishy. Postman has spent quite a bit of effort in developing a template that can help improve legitimacy of the emails sent. This feature should be available for transactional emails also.

## Solution
- Add `use_template` flag to allow for the user of template in transactional email.