### PR TITLE
feat: add contact us link to navbar

### DIFF
--- a/frontend/src/components/common/nav-bar/NavBar.tsx
+++ b/frontend/src/components/common/nav-bar/NavBar.tsx
@@ -97,6 +97,14 @@ const NavBar = () => {
         >
           Feature Request
         </OutboundLink>
+        <OutboundLink
+          className={styles.link}
+          eventLabel={i18n._(LINKS.contactUsUrl)}
+          to={i18n._(LINKS.contactUsUrl)}
+          target="_blank"
+        >
+          Contact Us
+        </OutboundLink>
 
         <div className={styles.separator}></div>
 


### PR DESCRIPTION
## Problem

Add `Contact Us` link to the navbar
<img width="1624" alt="Screenshot 2022-10-11 at 6 01 54 PM" src="https://user-images.githubusercontent.com/19917616/195061290-f8a6205d-0ae4-4f9e-8c63-a0eb0522a122.png">
