### PR TITLE
refactor: api key hash part 2

### DIFF
--- a/backend/src/core/models/user/user.ts
+++ b/backend/src/core/models/user/user.ts
@@ -37,7 +37,7 @@ export class User extends Model<User> {
   email: string
 
   @Column({ type: DataType.STRING, allowNull: true })
-  apiKey: string | null
+  apiKeyHash: string | null
 
   @HasMany(() => UserCredential)
   creds: UserCredential[]
@@ -150,7 +150,7 @@ export class User extends Model<User> {
   async regenerateAndSaveApiKey(): Promise<string> {
     const name = this.email.split('@')[0].replace(/[^a-zA-Z0-9]/g, '')
     const apiKeyPlainText = ApiKeyService.generateApiKeyFromName(name)
-    this.apiKey = await ApiKeyService.getApiKeyHash(apiKeyPlainText)
+    this.apiKeyHash = await ApiKeyService.getApiKeyHash(apiKeyPlainText)
     await this.save()
     return apiKeyPlainText
   }

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -180,7 +180,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     if (apiKey !== null) {
       const hash = await ApiKeyService.getApiKeyHash(apiKey)
       return await User.findOne({
-        where: { apiKey: hash },
+        where: { apiKeyHash: hash },
         attributes: ['id', 'email'],
       })
     }

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -297,7 +297,7 @@ export const InitCredentialService = (redisService: RedisService) => {
       where: {
         id: userId,
       },
-      attributes: ['apiKey'],
+      attributes: ['apiKeyHash'],
       // include as 'creds'
       include: [
         {
@@ -321,7 +321,7 @@ export const InitCredentialService = (redisService: RedisService) => {
     })
     if (user) {
       return {
-        hasApiKey: !!user.apiKey,
+        hasApiKey: !!user.apiKeyHash,
         creds: user.creds,
         demo: user.demo,
         userFeature: user.userFeature,
@@ -332,7 +332,7 @@ export const InitCredentialService = (redisService: RedisService) => {
   }
 
   /**
-   * Gnerates an api key for the specified user
+   * Generates an api key for the specified user
    * @param userId
    * @throws Error if user is not found
    */

--- a/backend/src/database/migrations/20220914082001-add-format-user-on-insert.js
+++ b/backend/src/database/migrations/20220914082001-add-format-user-on-insert.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, _) => {
-    // NB superseded by 20221012054742-remove-api-key-column-from-user-table.js
+    // NB superseded by 20221012051800-add-api-key-hash-column-to-user.js
     await queryInterface.createFunction(
       'format_user_on_insert', // actually a misnomer, since activates on UPDATE too, but stick to existing naming
       [],

--- a/backend/src/database/migrations/20220914082001-add-format-user-on-insert.js
+++ b/backend/src/database/migrations/20220914082001-add-format-user-on-insert.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, _) => {
+    // NB superseded by 20221012054742-remove-api-key-column-from-user-table.js
     await queryInterface.createFunction(
       'format_user_on_insert', // actually a misnomer, since activates on UPDATE too, but stick to existing naming
       [],

--- a/backend/src/database/migrations/20221012054742-remove-api-key-column-from-user-table.js
+++ b/backend/src/database/migrations/20221012054742-remove-api-key-column-from-user-table.js
@@ -1,0 +1,36 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, _) => {
+    await queryInterface.removeColumn('users', 'api_key')
+    await queryInterface.sequelize.query(
+      'DROP TRIGGER sync_api_key_with_api_key_hash_trigger ON users;'
+    )
+    await queryInterface.dropFunction('sync_api_key_with_api_key_hash', [])
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.createFunction(
+      'sync_api_key_with_api_key_hash',
+      [],
+      'trigger',
+      'plpgsql',
+      `
+      NEW.api_key_hash = NEW.api_key;
+      RETURN NEW;
+      `,
+      [],
+      { force: true }
+    )
+    await queryInterface.sequelize.query(
+      'CREATE TRIGGER sync_api_key_with_api_key_hash_trigger BEFORE INSERT OR UPDATE ON users FOR EACH ROW EXECUTE PROCEDURE sync_api_key_with_api_key_hash();'
+    )
+    await queryInterface.addColumn('users', 'api_key', {
+      type: Sequelize.DataTypes.STRING(255),
+      allowNull: true,
+    })
+    await queryInterface.sequelize.query(
+      'UPDATE users SET api_key = api_key_hash;'
+    )
+  },
+}


### PR DESCRIPTION
What this PR does:
- Change backend code to write to `api_key_hash` instead of `api_key`
- Drop previously created trigger that syncs `api_key` and `api_key_hash`
- Drop `format_user_on_insert` function and trigger


**Deployment notes**:
1. Deploy backend code 
2. Ensure backend is fully deployed before running db migration

See [here](https://github.com/opengovsg/postmangovsg/pull/1832#pullrequestreview-1136705832) for context