### PR TITLE
style: apply no extraneous deps

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -96,7 +96,7 @@ module.exports = {
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
-    // 'import/no-extraneous-dependencies': 'error',
+    'import/no-extraneous-dependencies': 'error',
   },
   overrides: [
     // disable rules specifically for JavaScript files

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -96,7 +96,9 @@ module.exports = {
     'simple-import-sort/exports': 'error',
     'import/first': 'error',
     'import/newline-after-import': 'error',
-    'import/no-duplicates': 'error',
-    // 'import/no-extraneous-dependencies': 'error',
+    'import/no-duplicates': 'error', 
+    // fixed errors flagged by import/no-extraneous-dependencies, but keep getting 
+    // 'shared' should be listed in the project's dependencies
+    // 'import/no-extraneous-dependencies': 'error'*,
   },
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "@lingui/core": "^3.14.0",
         "@lingui/react": "3.14.0",
         "@sentry/browser": "5.27.6",
         "@types/bcryptjs": "2.4.2",
@@ -23,8 +24,10 @@
         "escape-html": "1.0.3",
         "eslint-plugin-simple-import-sort": "^8.0.0",
         "html-to-draftjs": "1.5.0",
+        "immutable": "^3.8.2",
         "lodash": "4.17.21",
         "lottie-react": "2.3.0",
+        "make-plural": "^7.1.0",
         "moment": "2.29.4",
         "papaparse": "5.2.0",
         "querystring": "0.2.1",
@@ -3825,6 +3828,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@lingui/cli/node_modules/make-plural": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA==",
+      "dev": true
+    },
     "node_modules/@lingui/cli/node_modules/papaparse": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
@@ -3942,6 +3951,11 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@lingui/core/node_modules/make-plural": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
     },
     "node_modules/@lingui/macro": {
       "version": "3.14.0",
@@ -8950,19 +8964,6 @@
         "react-dom": ">=0.14.0"
       }
     },
-    "node_modules/draft-js-import-element": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz",
-      "integrity": "sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==",
-      "dependencies": {
-        "draft-js-utils": "^1.4.0",
-        "synthetic-dom": "^1.4.0"
-      },
-      "peerDependencies": {
-        "draft-js": ">=0.10.0",
-        "immutable": "3.x.x"
-      }
-    },
     "node_modules/draft-js-import-html": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/draft-js-import-html/-/draft-js-import-html-1.4.1.tgz",
@@ -8975,7 +8976,20 @@
         "immutable": "3.x.x"
       }
     },
-    "node_modules/draft-js-utils": {
+    "node_modules/draft-js-import-html/node_modules/draft-js-import-element": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz",
+      "integrity": "sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==",
+      "dependencies": {
+        "draft-js-utils": "^1.4.0",
+        "synthetic-dom": "^1.4.0"
+      },
+      "peerDependencies": {
+        "draft-js": ">=0.10.0",
+        "immutable": "3.x.x"
+      }
+    },
+    "node_modules/draft-js-import-html/node_modules/draft-js-import-element/node_modules/draft-js-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.1.tgz",
       "integrity": "sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==",
@@ -11687,7 +11701,6 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
       "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16604,9 +16617,9 @@
       "dev": true
     },
     "node_modules/make-plural": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
-      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.1.0.tgz",
+      "integrity": "sha512-PKkwVlAxYVo98NrbclaQIT4F5Oy+X58PZM5r2IwUSCe3syya6PXkIRCn2XCdz7p58Scgpp50PBeHmepXVDG3hg=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -26114,6 +26127,12 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "make-plural": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+          "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA==",
+          "dev": true
+        },
         "papaparse": {
           "version": "5.3.2",
           "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
@@ -26204,6 +26223,13 @@
         "@babel/runtime": "^7.11.2",
         "make-plural": "^6.2.2",
         "messageformat-parser": "^4.1.3"
+      },
+      "dependencies": {
+        "make-plural": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+          "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
+        }
       }
     },
     "@lingui/macro": {
@@ -30032,28 +30058,32 @@
         }
       }
     },
-    "draft-js-import-element": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz",
-      "integrity": "sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==",
-      "requires": {
-        "draft-js-utils": "^1.4.0",
-        "synthetic-dom": "^1.4.0"
-      }
-    },
     "draft-js-import-html": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/draft-js-import-html/-/draft-js-import-html-1.4.1.tgz",
       "integrity": "sha512-KOZmtgxZriCDgg5Smr3Y09TjubvXe7rHPy/2fuLSsL+aSzwUDwH/aHDA/k47U+WfpmL4qgyg4oZhqx9TYJV0tg==",
       "requires": {
         "draft-js-import-element": "^1.4.0"
+      },
+      "dependencies": {
+        "draft-js-import-element": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/draft-js-import-element/-/draft-js-import-element-1.4.0.tgz",
+          "integrity": "sha512-WmYT5PrCm47lGL5FkH6sRO3TTAcn7qNHsD3igiPqLG/RXrqyKrqN4+wBgbcT2lhna/yfWTRtgzAbQsSJoS1Meg==",
+          "requires": {
+            "draft-js-utils": "^1.4.0",
+            "synthetic-dom": "^1.4.0"
+          },
+          "dependencies": {
+            "draft-js-utils": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.1.tgz",
+              "integrity": "sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==",
+              "requires": {}
+            }
+          }
+        }
       }
-    },
-    "draft-js-utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.1.tgz",
-      "integrity": "sha512-xE81Y+z/muC5D5z9qWmKfxEW1XyXfsBzSbSBk2JRsoD0yzMGGHQm/0MtuqHl/EUDkaBJJLjJ2EACycoDMY/OOg==",
-      "requires": {}
     },
     "draftjs-filters": {
       "version": "3.0.1",
@@ -32049,8 +32079,7 @@
     "immutable": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
-      "peer": true
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -35754,9 +35783,9 @@
       "dev": true
     },
     "make-plural": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
-      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.1.0.tgz",
+      "integrity": "sha512-PKkwVlAxYVo98NrbclaQIT4F5Oy+X58PZM5r2IwUSCe3syya6PXkIRCn2XCdz7p58Scgpp50PBeHmepXVDG3hg=="
     },
     "makeerror": {
       "version": "1.0.12",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "test": "react-app-rewired test --passWithNoTests"
   },
   "dependencies": {
+    "@lingui/core": "^3.14.0",
     "@lingui/react": "3.14.0",
     "@sentry/browser": "5.27.6",
     "@types/bcryptjs": "2.4.2",
@@ -36,8 +37,10 @@
     "escape-html": "1.0.3",
     "eslint-plugin-simple-import-sort": "^8.0.0",
     "html-to-draftjs": "1.5.0",
+    "immutable": "^3.8.2",
     "lodash": "4.17.21",
     "lottie-react": "2.3.0",
+    "make-plural": "^7.1.0",
     "moment": "2.29.4",
     "papaparse": "5.2.0",
     "querystring": "0.2.1",

--- a/shared/.eslintrc.js
+++ b/shared/.eslintrc.js
@@ -95,6 +95,6 @@ module.exports = {
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
-    // 'import/no-extraneous-dependencies': 'error',
+    'import/no-extraneous-dependencies': 'error',
   },
 }

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -15,6 +15,7 @@
         "lodash": "4.17.21",
         "mustache": "4.2.0",
         "nodemailer": "6.6.2",
+        "opentracing": "^0.14.7",
         "xss": "1.0.13"
       },
       "devDependencies": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -51,6 +51,7 @@
     "lodash": "4.17.21",
     "mustache": "4.2.0",
     "nodemailer": "6.6.2",
+    "opentracing": "^0.14.7",
     "xss": "1.0.13"
   },
   "lint-staged": {

--- a/worker/.eslintrc.js
+++ b/worker/.eslintrc.js
@@ -91,6 +91,6 @@ module.exports = {
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-duplicates': 'error',
-    // 'import/no-extraneous-dependencies': 'error',
+    'import/no-extraneous-dependencies': 'error',
   },
 }

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -30,6 +30,7 @@
         "source-map-support": "0.5.19",
         "telegraf": "3.38.0",
         "twilio": "3.77.3",
+        "validator": "^13.7.0",
         "winston": "3.3.3"
       },
       "devDependencies": {

--- a/worker/package.json
+++ b/worker/package.json
@@ -39,6 +39,7 @@
     "source-map-support": "0.5.19",
     "telegraf": "3.38.0",
     "twilio": "3.77.3",
+    "validator": "^13.7.0",
     "winston": "3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
turned on the `import/no-extraneous-dependencies` rule in ESLint in `shared`, `backend`, `frontend`, and `worker`.

Got this error for frontend, so while I fixed the errors flagged by installing the dependencies, I turned the rule off.
![image](https://user-images.githubusercontent.com/67887489/197534837-7e5558a9-f1ba-4db5-86ec-d73ab64c8d37.png)

based on my research, the solutions are to:
- drop the `@` from `@shared`
- install another dependency (`eslint-import-resolver-custom-alias` or `eslint-import-resolver-alias`) and configure to fix it

both solution seem too troublesome, so I turned off the rule instead.

I don't really understand — how were we able to import dependencies that we had not explicitly installed? were they installed as part of peer dependencies? so weird.