### PR TITLE
feat(backend): show presence of authorization header in request log instead of blacklisting

### DIFF
--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -103,7 +103,14 @@ const expressApp = ({ app }: { app: express.Application }): void => {
       ignoredRoutes: ['/'],
       requestWhitelist: ['method', 'url', 'body', 'headers'],
       responseWhitelist: ['body', 'statusCode'],
-      headerBlacklist: ['authorization'],
+      requestFilter: (req: Request, propName: string) => {
+        if (propName === 'headers' && req.headers.authorization) {
+          // we do this instead of adding it to `headerBlacklist` so we can view
+          // if this `authorization` header was present
+          req.headers.authorization = '[REDACTED]'
+        }
+        return (req as any)[propName]
+      },
       metaField: null, // flatten this log to root instead of nesting under `meta`
     })
   )


### PR DESCRIPTION

## Problem

[Ticket](https://www.notion.so/opengov/Combine-log-statements-and-include-cookie-API-key-user-info-82c71a7b32884cdd83e4c9778169f841)

## Solution

Instead of blacklisting, we will just redact the value of `authorization` header

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A
