### PR TITLE
feat(frontend): introduce feedback modal after sending campaign

### DIFF
--- a/backend/src/core/loaders/security-headers.loader.ts
+++ b/backend/src/core/loaders/security-headers.loader.ts
@@ -30,6 +30,7 @@ const securityHeadersLoader = ({ app }: { app: express.Application }): void => {
         fontSrc: ["'none'"],
         objectSrc: ["'none'"],
         scriptSrc: ["'self'"],
+        frameSrc: ["'self', 'https://form.gov.sg/*'"],
       },
     })
   )

--- a/backend/src/core/loaders/security-headers.loader.ts
+++ b/backend/src/core/loaders/security-headers.loader.ts
@@ -30,7 +30,6 @@ const securityHeadersLoader = ({ app }: { app: express.Application }): void => {
         fontSrc: ["'none'"],
         objectSrc: ["'none'"],
         scriptSrc: ["'self'"],
-        frameSrc: ["'self', 'https://form.gov.sg/*'"],
       },
     })
   )

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -31,7 +31,8 @@ customHeaders:
           script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
           img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg https://file.for.sg https://file.for.edu.sg;
           media-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
-          child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/ https://form.gov.sg/"
+          child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
+          frame-src 'self' https://form.gov.sg/;"
       - key: "Content-Security-Policy-Report-Only"
         value: report-uri https://b7b979b458ee470a86efff9ef1653b50@o399364.ingest.sentry.io/5261024;
   - pattern: "/static/**/*"

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -31,7 +31,7 @@ customHeaders:
           script-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://ssl.google-analytics.com;
           img-src 'self' https://*.postman.gov.sg https://www.google-analytics.com https://file.go.gov.sg https://file.for.sg https://file.for.edu.sg;
           media-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/;
-          child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/"
+          child-src 'self' https://s3-ap-southeast-1.amazonaws.com/public.postman.gov.sg/ https://form.gov.sg/"
       - key: "Content-Security-Policy-Report-Only"
         value: report-uri https://b7b979b458ee470a86efff9ef1653b50@o399364.ingest.sentry.io/5261024;
   - pattern: "/static/**/*"

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -89,7 +89,7 @@ describe("Email Test", () => {
     cy.contains(":button", "Confirm").click();
 
     //step 5 : dismiss feedback form
-    cy.contains(":button", "Close").click();
+    cy.get('button[title="Close modal"]').click();
 
     //check stats for success
     cy.contains("Sending completed");

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -88,6 +88,9 @@ describe("Email Test", () => {
     cy.contains(":button", "Send").click();
     cy.contains(":button", "Confirm").click();
 
+    //step 5 : dismiss feedback form
+    cy.contains(":button", "Close").click();
+
     //check stats for success
     cy.contains("Sending completed");
     cy.contains("Sent to recipient").siblings().contains(NUM_RECIPIENTS);

--- a/cypress/e2e/email_encrypted.cy.js
+++ b/cypress/e2e/email_encrypted.cy.js
@@ -1,47 +1,47 @@
-describe('Encrypted Email Test', () => {
-  it('initiate email campaign', () => {
+describe("Encrypted Email Test", () => {
+  it("initiate email campaign", () => {
     // have these vars here so it won't affect retry results
     // (e.g. emails received from previous try being counted in the latest one
     // as they share the same subject line)
-    const MODE = 'encrypted';
-    const CSV_FILENAME = 'testfile_encrypted.csv';
-    const NUM_RECIPIENTS = '1';
+    const MODE = "encrypted";
+    const CSV_FILENAME = "testfile_encrypted.csv";
+    const NUM_RECIPIENTS = "1";
 
     const CUR_DATE = new Date();
     const DATETIME =
       CUR_DATE.getDate() +
-      '/' +
+      "/" +
       (CUR_DATE.getMonth() + 1) +
-      '/' +
+      "/" +
       CUR_DATE.getFullYear() +
-      '@' +
+      "@" +
       CUR_DATE.getHours() +
-      ':' +
+      ":" +
       CUR_DATE.getMinutes() +
-      ':' +
+      ":" +
       CUR_DATE.getSeconds();
-    const CAMPAIGN_NAME = MODE.concat('_').concat(DATETIME);
-    const RANDOM_STRING = '_'.concat(
-      Math.floor(Math.random() * 1000000 + 1).toString(),
+    const CAMPAIGN_NAME = MODE.concat("_").concat(DATETIME);
+    const RANDOM_STRING = "_".concat(
+      Math.floor(Math.random() * 1000000 + 1).toString()
     );
-    const SUBJECT_NAME = 'sub_enc_'.concat(DATETIME).concat(RANDOM_STRING);
-    const MSG_CONTENT = Cypress.env('MSG_CONTENT').concat(RANDOM_STRING);
-    const MSG_TO_VERIFY = Cypress.env('MSG_TO_VERIFY').concat(RANDOM_STRING);
+    const SUBJECT_NAME = "sub_enc_".concat(DATETIME).concat(RANDOM_STRING);
+    const MSG_CONTENT = Cypress.env("MSG_CONTENT").concat(RANDOM_STRING);
+    const MSG_TO_VERIFY = Cypress.env("MSG_TO_VERIFY").concat(RANDOM_STRING);
 
-    const OTP_SUBJECT = Cypress.env('OTP_SUBJECT');
-    const EMAIL = Cypress.env('EMAIL');
-    const MAIL_SENDER = Cypress.env('MAIL_SENDER');
-    const REDIRECTION_MSG = Cypress.env('REDIRECTION_MSG');
-    const DUMMY_ENC = Cypress.env('DUMMY_ENC');
-    const WAIT_TIME = Cypress.env('WAIT_TIME');
-    const REPORT_WAIT_TIME = Cypress.env('REPORT_WAIT_TIME');
+    const OTP_SUBJECT = Cypress.env("OTP_SUBJECT");
+    const EMAIL = Cypress.env("EMAIL");
+    const MAIL_SENDER = Cypress.env("MAIL_SENDER");
+    const REDIRECTION_MSG = Cypress.env("REDIRECTION_MSG");
+    const DUMMY_ENC = Cypress.env("DUMMY_ENC");
+    const WAIT_TIME = Cypress.env("WAIT_TIME");
+    const REPORT_WAIT_TIME = Cypress.env("REPORT_WAIT_TIME");
 
     const EMAIL_TO_EXPECT = 2; //both test and actual emails
 
     //function to check content of protected emails
-    Cypress.Commands.add('checkProtectedMails', (links) => {
+    Cypress.Commands.add("checkProtectedMails", (links) => {
       links.forEach((link) => {
-        cy.visit('/'.concat(link));
+        cy.visit("/".concat(link));
         cy.get('input[type="password"]').type(DUMMY_ENC);
         cy.get('button[type="submit"]').click();
         cy.contains(MSG_TO_VERIFY);
@@ -49,77 +49,80 @@ describe('Encrypted Email Test', () => {
     });
 
     //write csv test file
-    const CSV_CONTENT = 'recipient,password,name\n' + EMAIL + ',hello,postman';
-    cy.writeFile('cypress/fixtures/'.concat(CSV_FILENAME), CSV_CONTENT);
+    const CSV_CONTENT = "recipient,password,name\n" + EMAIL + ",hello,postman";
+    cy.writeFile("cypress/fixtures/".concat(CSV_FILENAME), CSV_CONTENT);
 
     //log in via OTP
-    cy.visit('/login');
-    cy.get('input[type=email]').type(EMAIL);
-    cy.get('button[type=submit]').click();
+    cy.visit("/login");
+    cy.get("input[type=email]").type(EMAIL);
+    cy.get("button[type=submit]").click();
     cy.wait(WAIT_TIME);
 
-    cy.task('gmail:check', {
+    cy.task("gmail:check", {
       from: MAIL_SENDER,
       to: EMAIL,
       subject: OTP_SUBJECT,
     }).then((email) => {
-      assert.isNotNull(email, 'OTP email was not found');
+      assert.isNotNull(email, "OTP email was not found");
       const LOGIN_EMAIL_CONTENT = email[0].body.html;
       const OTP_RE = /\<b\>([^)]+)\<\/b\>/;
       const OTP = LOGIN_EMAIL_CONTENT.match(OTP_RE)[1];
-      cy.get('input[type=tel]').type(OTP);
-      cy.get('button[type=submit]').click();
+      cy.get("input[type=tel]").type(OTP);
+      cy.get("button[type=submit]").click();
     });
 
     //initiate campaign
-    cy.contains(':button', 'Create').click();
+    cy.contains(":button", "Create").click();
     cy.get('input[id="nameCampaign"]').type(CAMPAIGN_NAME);
-    cy.contains(':button', 'Email').click();
+    cy.contains(":button", "Email").click();
     cy.get('i[class*="checkbox"]').click();
-    cy.contains(':button', 'Create').click();
+    cy.contains(":button", "Create").click();
 
     //step 1 : enter subject and redirection message template
     cy.get('textarea[id="subject"]').type(SUBJECT_NAME);
     cy.get('div[aria-label="rdw-editor"]').type(REDIRECTION_MSG);
-    cy.contains(':button', 'Next').click();
+    cy.contains(":button", "Next").click();
 
     //step 2 : enter message template for encryption and upload csv file
     // somehow we gotta wait for a bit here before the rich text editor is typeable
     cy.wait(1000);
     cy.get('div[aria-label="rdw-editor"]').type(MSG_CONTENT);
     cy.get('input[type="file"]').attachFile(CSV_FILENAME);
-    cy.contains('Message B');
+    cy.contains("Message B");
     cy.contains(CSV_FILENAME);
-    cy.contains(NUM_RECIPIENTS.concat(' recipients'));
-    cy.contains(':button', 'Confirm').click();
-    cy.contains('Message preview');
-    cy.contains(':button', 'Next').click();
+    cy.contains(NUM_RECIPIENTS.concat(" recipients"));
+    cy.contains(":button", "Confirm").click();
+    cy.contains("Message preview");
+    cy.contains(":button", "Next").click();
 
     //step 3 : send test email
     cy.get('input[type="email"]').type(EMAIL);
     cy.get('button[type="submit"]').click();
-    cy.contains('validated');
-    cy.contains(':button', 'Next').click();
+    cy.contains("validated");
+    cy.contains(":button", "Next").click();
 
     //step 4 : send campaign
-    cy.contains(':button', 'Send').click();
-    cy.contains(':button', 'Confirm').click();
+    cy.contains(":button", "Send").click();
+    cy.contains(":button", "Confirm").click();
+
+    // step 5 : dismiss feedback modal
+    cy.contains(":button", "Close").click();
 
     //check stats for success
-    cy.contains('Sending completed');
-    cy.contains('Sent to recipient').siblings().contains(NUM_RECIPIENTS);
+    cy.contains("Sending completed");
+    cy.contains("Sent to recipient").siblings().contains(NUM_RECIPIENTS);
     cy.wait(WAIT_TIME);
 
     //Verify that email is being received
     var links = [];
-    cy.task('gmail:check', {
+    cy.task("gmail:check", {
       from: MAIL_SENDER,
       to: EMAIL,
       subject: SUBJECT_NAME,
     }).then((email) => {
       assert(
         email.length == EMAIL_TO_EXPECT,
-        `test and/or actual email was not found, expected ${EMAIL_TO_EXPECT}, got ${email.length}`,
+        `test and/or actual email was not found, expected ${EMAIL_TO_EXPECT}, got ${email.length}`
       );
 
       const LINK_RE = /postman\.gov\.sg\/([^\<]+)/;
@@ -139,15 +142,15 @@ describe('Encrypted Email Test', () => {
 
     //wait for report to be generated and download it
     cy.wait(REPORT_WAIT_TIME);
-    cy.contains(':button', 'Report').click();
+    cy.contains(":button", "Report").click();
 
     //check report, status should be READ
     cy.wait(WAIT_TIME);
-    const downloadPath = Cypress.config('downloadsFolder');
-    cy.task('findDownloaded', downloadPath).then((file_names) => {
+    const downloadPath = Cypress.config("downloadsFolder");
+    cy.task("findDownloaded", downloadPath).then((file_names) => {
       file_names.forEach((name) => {
         if (name.startsWith(MODE)) {
-          cy.readFile(downloadPath + '/' + name).should('contain', 'READ');
+          cy.readFile(downloadPath + "/" + name).should("contain", "READ");
         }
       });
     });

--- a/cypress/e2e/email_encrypted.cy.js
+++ b/cypress/e2e/email_encrypted.cy.js
@@ -106,7 +106,7 @@ describe("Encrypted Email Test", () => {
     cy.contains(":button", "Confirm").click();
 
     // step 5 : dismiss feedback modal
-    cy.contains(":button", "Close").click();
+    cy.get('button[title="Close modal"]').click();
 
     //check stats for success
     cy.contains("Sending completed");

--- a/cypress/e2e/sms.cy.js
+++ b/cypress/e2e/sms.cy.js
@@ -93,7 +93,7 @@ describe("SMS Test", () => {
     cy.contains(":button", "Confirm").click();
 
     // step 5 : dismiss feedback modal
-    cy.contains(":button", "Close").click();
+    cy.get('button[title="Close modal"]').click();
 
     //check feedback for success
     cy.contains("Sending completed");

--- a/cypress/e2e/sms.cy.js
+++ b/cypress/e2e/sms.cy.js
@@ -92,6 +92,9 @@ describe("SMS Test", () => {
     cy.contains(":button", "Send").click();
     cy.contains(":button", "Confirm").click();
 
+    // step 5 : dismiss feedback modal
+    cy.contains(":button", "Close").click();
+
     //check feedback for success
     cy.contains("Sending completed");
     cy.contains("Sent to recipient").siblings().contains(NUM_RECIPIENTS);

--- a/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
@@ -8,6 +8,7 @@ import ConfirmImage from 'assets/img/confirm-modal.svg'
 
 import { PrimaryButton, TextButton, ErrorBlock } from 'components/common'
 import FeedbackModal from 'components/common/feedback-modal'
+import { AuthContext } from 'contexts/auth.context'
 import { ModalContext } from 'contexts/modal.context'
 
 const ConfirmModal = ({
@@ -36,13 +37,15 @@ const ConfirmModal = ({
   feedbackUrl?: string
 }) => {
   const modalContext = useContext(ModalContext)
+  const { email } = useContext(AuthContext)
   const [errorMessage, setErrorMessage] = useState('')
 
   // feedback modal is built directly into confirm modal as confirm modal is the component that is commonly used across the campaigns
   const openFeedbackModal = () => {
     if (feedbackUrl !== null && needFeedback) {
       const mustExistUrl = String(feedbackUrl)
-      modalContext.setModalContent(<FeedbackModal url={mustExistUrl} />)
+      // just append email at the back
+      modalContext.setModalContent(<FeedbackModal url={mustExistUrl + email} />)
     } else {
       // dismiss cuz the url is invalid / malformed
       modalContext.close()

--- a/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
@@ -21,7 +21,6 @@ const ConfirmModal = ({
   onConfirm,
   onCancel,
   disableImage,
-  needFeedback,
   feedbackUrl,
 }: {
   title: string
@@ -33,7 +32,6 @@ const ConfirmModal = ({
   onConfirm: () => Promise<any> | any
   onCancel?: () => Promise<any> | any
   disableImage?: boolean
-  needFeedback?: boolean
   feedbackUrl?: string
 }) => {
   const modalContext = useContext(ModalContext)
@@ -42,21 +40,15 @@ const ConfirmModal = ({
 
   // feedback modal is built directly into confirm modal as confirm modal is the component that is commonly used across the campaigns
   const openFeedbackModal = () => {
-    if (feedbackUrl !== null && needFeedback) {
-      const mustExistUrl = String(feedbackUrl)
-      // just append email at the back
-      modalContext.setModalContent(<FeedbackModal url={mustExistUrl + email} />)
-    } else {
-      // dismiss cuz the url is invalid / malformed
-      modalContext.close()
-    }
+    // just append email at the back
+    modalContext.setModalContent(<FeedbackModal url={feedbackUrl + email} />)
   }
 
   async function onConfirmedClicked(): Promise<void> {
     try {
       await onConfirm()
       // Closes the modal
-      if (needFeedback) {
+      if (feedbackUrl) {
         openFeedbackModal()
       } else {
         modalContext.close()

--- a/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
+++ b/frontend/src/components/common/confirm-modal/ConfirmModal.tsx
@@ -7,6 +7,7 @@ import styles from './ConfirmModal.module.scss'
 import ConfirmImage from 'assets/img/confirm-modal.svg'
 
 import { PrimaryButton, TextButton, ErrorBlock } from 'components/common'
+import FeedbackModal from 'components/common/feedback-modal'
 import { ModalContext } from 'contexts/modal.context'
 
 const ConfirmModal = ({
@@ -19,6 +20,8 @@ const ConfirmModal = ({
   onConfirm,
   onCancel,
   disableImage,
+  needFeedback,
+  feedbackUrl,
 }: {
   title: string
   subtitle: string
@@ -29,15 +32,32 @@ const ConfirmModal = ({
   onConfirm: () => Promise<any> | any
   onCancel?: () => Promise<any> | any
   disableImage?: boolean
+  needFeedback?: boolean
+  feedbackUrl?: string
 }) => {
   const modalContext = useContext(ModalContext)
   const [errorMessage, setErrorMessage] = useState('')
+
+  // feedback modal is built directly into confirm modal as confirm modal is the component that is commonly used across the campaigns
+  const openFeedbackModal = () => {
+    if (feedbackUrl !== null && needFeedback) {
+      const mustExistUrl = String(feedbackUrl)
+      modalContext.setModalContent(<FeedbackModal url={mustExistUrl} />)
+    } else {
+      // dismiss cuz the url is invalid / malformed
+      modalContext.close()
+    }
+  }
 
   async function onConfirmedClicked(): Promise<void> {
     try {
       await onConfirm()
       // Closes the modal
-      modalContext.close()
+      if (needFeedback) {
+        openFeedbackModal()
+      } else {
+        modalContext.close()
+      }
     } catch (err) {
       setErrorMessage((err as Error).message)
     }

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
@@ -1,27 +1,27 @@
 @import 'styles/_mixins';
 
 .disclaimer {
-  font-family: SansSerif, serif;
-  font-size: 15px;
-  color: white;
   opacity: 0.9;
   padding-top: 5px;
   padding-bottom: 8px;
 }
 
+.disclaimer_url {
+  font-size: unset;
+}
+
 .frame {
   width: 100%;
   height: 500px;
+  border-radius: 16px;
 }
 
 .footer {
   font-family: Sans-Serif, serif;
   font-size: 12px;
-  color: #999;
   opacity: 0.5;
   padding-top: 5px;
 }
 
 .url {
-  color: #999;
 }

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
@@ -13,7 +13,7 @@
 .frame {
   width: 100%;
   height: 500px;
-  border-radius: 16px;
+  border-radius: 8px;
 }
 
 .footer {

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
@@ -13,7 +13,7 @@
 .frame {
   width: 100%;
   height: 500px;
-  border-radius: 8px;
+  border: 0;
 }
 
 .footer {

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.module.scss
@@ -1,0 +1,27 @@
+@import 'styles/_mixins';
+
+.disclaimer {
+  font-family: SansSerif, serif;
+  font-size: 15px;
+  color: white;
+  opacity: 0.9;
+  padding-top: 5px;
+  padding-bottom: 8px;
+}
+
+.frame {
+  width: 100%;
+  height: 500px;
+}
+
+.footer {
+  font-family: Sans-Serif, serif;
+  font-size: 12px;
+  color: #999;
+  opacity: 0.5;
+  padding-top: 5px;
+}
+
+.url {
+  color: #999;
+}

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
@@ -5,7 +5,12 @@ const FeedbackModal = ({ url }: { url: string }) => {
     <>
       <div className={styles.disclaimer}>
         If the form below is not loaded, you can also fill it in{' '}
-        <a className={styles.disclaimer_url} href={url}>
+        <a
+          className={styles.disclaimer_url}
+          href={url}
+          target={'_blank'}
+          rel="noreferrer"
+        >
           here
         </a>
         .

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
@@ -1,0 +1,24 @@
+import styles from './FeedbackModal.module.scss'
+
+const FeedbackModal = () => {
+  return (
+    <>
+      <div className={styles.disclaimer}>
+        If the form below is not loaded, you can also fill it in at{' '}
+        <a href="https://form.gov.sg/6344cf65bb320400137b59dc">here</a>.
+      </div>
+      <iframe
+        className={styles.frame}
+        id="iframe"
+        src="https://form.gov.sg/6344cf65bb320400137b59dc"
+      ></iframe>
+      <div className={styles.footer}>
+        Powered by{' '}
+        <a className={styles.url} href="https://form.gov.sg">
+          FormSG
+        </a>
+      </div>
+    </>
+  )
+}
+export default FeedbackModal

--- a/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
+++ b/frontend/src/components/common/feedback-modal/FeedbackModal.tsx
@@ -1,20 +1,24 @@
 import styles from './FeedbackModal.module.scss'
 
-const FeedbackModal = () => {
+const FeedbackModal = ({ url }: { url: string }) => {
   return (
     <>
       <div className={styles.disclaimer}>
-        If the form below is not loaded, you can also fill it in at{' '}
-        <a href="https://form.gov.sg/6344cf65bb320400137b59dc">here</a>.
+        If the form below is not loaded, you can also fill it in{' '}
+        <a className={styles.disclaimer_url} href={url}>
+          here
+        </a>
+        .
       </div>
-      <iframe
-        className={styles.frame}
-        id="iframe"
-        src="https://form.gov.sg/6344cf65bb320400137b59dc"
-      ></iframe>
+      <iframe className={styles.frame} id="iframe" src={url}></iframe>
       <div className={styles.footer}>
         Powered by{' '}
-        <a className={styles.url} href="https://form.gov.sg">
+        <a
+          className={styles.url}
+          href="https://form.gov.sg"
+          target={'_blank'}
+          rel="noreferrer"
+        >
           FormSG
         </a>
       </div>

--- a/frontend/src/components/common/feedback-modal/index.ts
+++ b/frontend/src/components/common/feedback-modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FeedbackModal'

--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom'
 
 import styles from '../Create.module.scss'
 
-import { confirmSendCampaign } from '../util'
+import { campaignFeedbackUrl, confirmSendCampaign } from '../util'
 
 import { ChannelType, EmailProgress } from 'classes'
 import {
@@ -82,6 +82,8 @@ const EmailSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
+        needFeedback={true}
+        feedbackUrl={campaignFeedbackUrl}
       />
     )
   }

--- a/frontend/src/components/dashboard/create/email/EmailSend.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailSend.tsx
@@ -82,7 +82,6 @@ const EmailSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
-        needFeedback={true}
         feedbackUrl={campaignFeedbackUrl}
       />
     )

--- a/frontend/src/components/dashboard/create/sms/SMSSend.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSSend.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom'
 
 import styles from '../Create.module.scss'
 
-import { confirmSendCampaign } from '../util'
+import { campaignFeedbackUrl, confirmSendCampaign } from '../util'
 
 import { ChannelType } from 'classes'
 import type { SMSProgress } from 'classes'
@@ -73,6 +73,8 @@ const SMSSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
+        needFeedback={true}
+        feedbackUrl={campaignFeedbackUrl}
       />
     )
   }

--- a/frontend/src/components/dashboard/create/sms/SMSSend.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSSend.tsx
@@ -73,7 +73,6 @@ const SMSSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
-        needFeedback={true}
         feedbackUrl={campaignFeedbackUrl}
       />
     )

--- a/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom'
 
 import styles from '../Create.module.scss'
 
-import { confirmSendCampaign } from '../util'
+import { campaignFeedbackUrl, confirmSendCampaign } from '../util'
 
 import { ChannelType } from 'classes'
 import type { TelegramProgress } from 'classes'
@@ -73,6 +73,8 @@ const TelegramSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
+        needFeedback={true}
+        feedbackUrl={campaignFeedbackUrl}
       />
     )
   }

--- a/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramSend.tsx
@@ -73,7 +73,6 @@ const TelegramSend = ({
         buttonText="Confirm send now"
         buttonIcon="bx-send"
         onConfirm={onModalConfirm}
-        needFeedback={true}
         feedbackUrl={campaignFeedbackUrl}
       />
     )

--- a/frontend/src/components/dashboard/create/util.ts
+++ b/frontend/src/components/dashboard/create/util.ts
@@ -21,4 +21,4 @@ export const confirmSendCampaign = async ({
 }
 
 export const campaignFeedbackUrl =
-  'https://form.gov.sg/6344cf65bb320400137b59dc'
+  'https://form.gov.sg/6344cf65bb320400137b59dc?6357af36c23cd700125f9d7c='

--- a/frontend/src/components/dashboard/create/util.ts
+++ b/frontend/src/components/dashboard/create/util.ts
@@ -19,3 +19,6 @@ export const confirmSendCampaign = async ({
   }
   updateCampaign({ status: Status.Sending })
 }
+
+export const campaignFeedbackUrl =
+  'https://form.gov.sg/6344cf65bb320400137b59dc'


### PR DESCRIPTION
## Problem

To enable users to submit feedback via embedded formsg link

## Solution

- Create new FeedbackModal component to allow more modular use in case any other component needs to embed feedback form in other areas, with url as props
- Built feedbackmodal directly into ConfirmModal instead of the 3 separate campaign triggers, so that the modal logic only needs to be written once
- Control the feedbackmodal behavior with props from confirm modal to reduce dependancy.
 
