### PR TITLE
feat: list email messages endpoint

### DIFF
--- a/backend/src/core/constants.ts
+++ b/backend/src/core/constants.ts
@@ -46,19 +46,17 @@ export enum Ordering {
 export enum TransactionalEmailSortField {
   Created = 'created_at',
   Updated = 'updated_at',
-  // can extend if we want to sort by other fields (to remove and write in PR)
 }
 
 export interface TimestampFilter {
-  createdAt: DateOperator
-  // can extend if we filter by other timestamp (to remove and write in PR)s
+  createdAt: TimestampOperator
 }
 
-export interface DateOperator {
-  gt: Date
-  gte: Date
-  lt: Date
-  lte: Date
+export interface TimestampOperator {
+  gt?: Date
+  gte?: Date
+  lt?: Date
+  lte?: Date
 }
 /**
  * @swagger

--- a/backend/src/core/constants.ts
+++ b/backend/src/core/constants.ts
@@ -33,7 +33,7 @@ export enum DefaultCredentialName {
   Telegram = 'Postman_Telegram_Demo',
 }
 
-export enum SortField {
+export enum CampaignSortField {
   Created = 'created_at',
   Sent = 'sent_at',
 }
@@ -43,6 +43,23 @@ export enum Ordering {
   DESC = 'DESC',
 }
 
+export enum TransactionalEmailSortField {
+  Created = 'created_at',
+  Updated = 'updated_at',
+  // can extend if we want to sort by other fields (to remove and write in PR)
+}
+
+export interface TimestampFilter {
+  createdAt: DateOperator
+  // can extend if we filter by other timestamp (to remove and write in PR)s
+}
+
+export interface DateOperator {
+  gt: Date
+  gte: Date
+  lt: Date
+  lte: Date
+}
 /**
  * @swagger
  * components:

--- a/backend/src/core/constants.ts
+++ b/backend/src/core/constants.ts
@@ -49,14 +49,14 @@ export enum TransactionalEmailSortField {
 }
 
 export interface TimestampFilter {
-  createdAt: TimestampOperator
+  createdAt: ComparisonOperator<Date>
 }
 
-export interface TimestampOperator {
-  gt?: Date
-  gte?: Date
-  lt?: Date
-  lte?: Date
+export interface ComparisonOperator<T> {
+  gt?: T
+  gte?: T
+  lt?: T
+  lte?: T
 }
 /**
  * @swagger

--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -1,6 +1,11 @@
 import { Request, Response, NextFunction } from 'express'
 import { loggerWithLabel } from '@core/logger'
-import { ChannelType, Status, SortField, Ordering } from '@core/constants'
+import {
+  ChannelType,
+  Status,
+  CampaignSortField,
+  Ordering,
+} from '@core/constants'
 import { CampaignService, UploadService } from '@core/services'
 import { Campaign } from '@core/models'
 
@@ -114,7 +119,7 @@ const listCampaigns = async (
       type: type as ChannelType,
       status: status as Status,
       name: name as string,
-      sortBy: sort_by as SortField,
+      sortBy: sort_by as CampaignSortField,
       orderBy: order_by as Ordering,
     })
 

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -1,5 +1,10 @@
 import { Router } from 'express'
-import { ChannelType, Status, SortField, Ordering } from '@core/constants'
+import {
+  ChannelType,
+  Status,
+  CampaignSortField,
+  Ordering,
+} from '@core/constants'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { CampaignMiddleware } from '@core/middlewares'
 const router = Router()
@@ -12,7 +17,7 @@ const listCampaignsValidator = {
     type: Joi.string().valid(...Object.values(ChannelType)),
     status: Joi.string().valid(...Object.values(Status)),
     name: Joi.string().max(255).trim(),
-    sort_by: Joi.string().valid(...Object.values(SortField)),
+    sort_by: Joi.string().valid(...Object.values(CampaignSortField)),
     order_by: Joi.string().valid(...Object.values(Ordering)),
   }),
 }

--- a/backend/src/core/routes/tests/campaign.routes.test.ts
+++ b/backend/src/core/routes/tests/campaign.routes.test.ts
@@ -8,7 +8,7 @@ import {
   ChannelType,
   JobStatus,
   Ordering,
-  SortField,
+  CampaignSortField,
   Status,
 } from '@core/constants'
 
@@ -95,7 +95,7 @@ describe('GET /campaigns', () => {
 
     const resAsc = await request(app)
       .get('/campaigns')
-      .query({ order_by: Ordering.ASC, sort_by: SortField.Created })
+      .query({ order_by: Ordering.ASC, sort_by: CampaignSortField.Created })
     expect(resAsc.status).toBe(200)
     expect(resAsc.body.total_count).toEqual(3)
     for (let i = 1; i <= 3; i++) {
@@ -104,7 +104,7 @@ describe('GET /campaigns', () => {
 
     const resDesc = await request(app)
       .get('/campaigns')
-      .query({ order_by: Ordering.DESC, sort_by: SortField.Created })
+      .query({ order_by: Ordering.DESC, sort_by: CampaignSortField.Created })
     expect(resDesc.status).toBe(200)
     expect(resDesc.body.total_count).toEqual(3)
     for (let i = 1; i <= 3; i++) {
@@ -132,7 +132,7 @@ describe('GET /campaigns', () => {
 
     const resSentAsc = await request(app)
       .get('/campaigns')
-      .query({ order_by: Ordering.ASC, sort_by: SortField.Sent })
+      .query({ order_by: Ordering.ASC, sort_by: CampaignSortField.Sent })
     expect(resSentAsc.status).toBe(200)
     expect(resSentAsc.body.total_count).toEqual(3)
     for (let i = 1; i <= 3; i++) {
@@ -141,7 +141,7 @@ describe('GET /campaigns', () => {
 
     const resSentDesc = await request(app)
       .get('/campaigns')
-      .query({ order_by: Ordering.DESC, sort_by: SortField.Sent })
+      .query({ order_by: Ordering.DESC, sort_by: CampaignSortField.Sent })
     expect(resSentDesc.status).toBe(200)
     expect(resSentDesc.body.total_count).toEqual(3)
     for (let i = 1; i <= 3; i++) {

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -4,7 +4,7 @@ import {
   ChannelType,
   JobStatus,
   Status,
-  SortField,
+  CampaignSortField,
   Ordering,
 } from '@core/constants'
 import { Campaign, JobQueue, Statistic, UserDemo } from '@core/models'
@@ -162,7 +162,7 @@ const listCampaigns = ({
   type?: ChannelType
   status?: Status
   name?: string
-  sortBy?: SortField
+  sortBy?: CampaignSortField
   orderBy?: Ordering
 }): Promise<{ rows: Array<Campaign>; count: number }> => {
   const campaignJobs = '(PARTITION BY "job_queue"."campaign_id")'
@@ -223,7 +223,7 @@ const listCampaigns = ({
     const order = orderBy ?? Ordering.DESC // descending as default ordering
     if (sortBy) {
       switch (sortBy) {
-        case SortField.Sent: {
+        case CampaignSortField.Sent: {
           // sort by join queried sent_at
           orderArr = [[literal('"job_queue.sent_at"'), order]]
           break

--- a/backend/src/email/interfaces/email.interface.ts
+++ b/backend/src/email/interfaces/email.interface.ts
@@ -76,6 +76,14 @@ export interface EmailDuplicateCampaignDetails
  *          error_sub_type:
  *            nullable: true
  *            type: string
+ *          created_at:
+ *            nullable: false
+ *            type: string
+ *            format: date-time
+ *          updated_at:
+ *            nullable: true
+ *            type: string
+ *            format: date-time
  *          accepted_at:
  *            nullable: true
  *            type: string

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -238,7 +238,7 @@ export const InitEmailTransactionalMiddleware = (
       sortBy: sortBy as TransactionalEmailSortField,
       orderBy,
       status: status as TransactionalEmailMessageStatus,
-      filterByTimestamp: filter as unknown as TimestampFilter,
+      filterByTimestamp: filter as TimestampFilter,
     })
     res.status(200).json({
       has_more: hasMore,

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -68,6 +68,8 @@ export const InitEmailTransactionalMiddleware = (
       sent_at: message.sentAt?.toISOString() || null,
       delivered_at: message.deliveredAt?.toISOString() || null,
       opened_at: message.openedAt?.toISOString() || null,
+      created_at: message.createdAt.toISOString(),
+      updated_at: message.updatedAt.toISOString(),
     }
   }
 

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -45,6 +45,7 @@ export const InitEmailTransactionalMiddleware = (
   authService: AuthService
 ): EmailTransactionalMiddleware => {
   const logger = loggerWithLabel(module)
+
   interface ReqBody {
     subject: string
     body: string
@@ -230,15 +231,15 @@ export const InitEmailTransactionalMiddleware = (
     const orderBy = sort_by?.toString().includes('+')
       ? Ordering.ASC
       : Ordering.DESC // default to descending order even without '-' prefix
-    const { hasMore, messages } = await EmailTransactionalService.listMessages(
+    const { hasMore, messages } = await EmailTransactionalService.listMessages({
       userId,
-      +(limit as string),
-      +(offset as string),
-      sortBy as TransactionalEmailSortField,
+      limit: +(limit as string),
+      offset: +(offset as string),
+      sortBy: sortBy as TransactionalEmailSortField,
       orderBy,
-      status as TransactionalEmailMessageStatus,
-      filter as unknown as TimestampFilter
-    )
+      status: status as TransactionalEmailMessageStatus,
+      filterByTimestamp: filter as unknown as TimestampFilter,
+    })
     res.status(200).json({
       has_more: hasMore,
       data: messages.map(convertMessageModelToResponse),

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -225,7 +225,7 @@ export const InitEmailTransactionalMiddleware = (
     // validation from Joi doesn't carry over into type safety here
     // following code transforms query params into type-safe arguments for EmailTransactionalService
     const { limit, offset, status, created_at, sort_by } = req.query
-    const userId = req.session?.user?.id
+    const userId: string = req.session?.user?.id.toString() // id is number in session; convert to string for tests to pass (weird)
     const filter = created_at ? { createdAt: created_at } : undefined
     const sortBy = sort_by?.toString().replace(/[+-]/, '')
     const orderBy = sort_by?.toString().includes('+')

--- a/backend/src/email/routes/email-settings.routes.ts
+++ b/backend/src/email/routes/email-settings.routes.ts
@@ -76,17 +76,6 @@ export const InitEmailSettingsRoute = (
    *               example: Unauthorized
    *        "403":
    *          description: Forbidden. Request violates firewall rules.
-   *        "413":
-   *          description: Number of attachments or size of attachments exceeded limit.
-   *          content:
-   *             application/json:
-   *               schema:
-   *                 $ref: '#/components/schemas/Error'
-   *               examples:
-   *                 AttachmentQtyLimit:
-   *                   value: {message: Number of attachments exceeds limit}
-   *                 AttachmentSizeLimit:
-   *                   value: {message: Size of attachments exceeds limit}
    *        "429":
    *          description: Rate limit exceeded. Too many requests.
    *          content:
@@ -96,7 +85,7 @@ export const InitEmailSettingsRoute = (
    *               example:
    *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *          description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect)
+   *          description: Internal Server Error
    *          content:
    *             text/plain:
    *               type: string

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -160,7 +160,7 @@ export const InitEmailTransactionalRoute = (
    *                example:
    *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
-   *           description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect)
+   *           description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect; see https://github.com/opengovsg/postmangovsg/issues/1837)
    *           content:
    *              text/plain:
    *                type: string
@@ -247,7 +247,6 @@ export const InitEmailTransactionalRoute = (
    *     get:
    *       security:
    *         - bearerAuth: []
-   *         - cookieAuth: []
    *       tags:
    *         - Email
    *       summary: "List transactional emails"
@@ -321,7 +320,7 @@ export const InitEmailTransactionalRoute = (
    *
    *       responses:
    *         200:
-   *           description: Succcessfully retrieve a list of messages
+   *           description: Successfully retrieved a list of messages
    *           content:
    *             application/json:
    *               schema:
@@ -337,7 +336,7 @@ export const InitEmailTransactionalRoute = (
    *                     items:
    *                       $ref: '#/components/schemas/EmailMessageTransactional'
    *         "400":
-   *           description: Bad Request. Failed parameter validations, message is malformed, or attachments are rejected.
+   *           description: Bad Request. Failed parameter validations.
    *           content:
    *             text/plain:
    *               type: string
@@ -349,17 +348,6 @@ export const InitEmailTransactionalRoute = (
    *               example: Unauthorized
    *         "403":
    *           description: Forbidden. Request violates firewall rules.
-   *         "413":
-   *           description: Number of attachments or size of attachments exceeded limit.
-   *           content:
-   *              application/json:
-   *                schema:
-   *                  $ref: '#/components/schemas/Error'
-   *                examples:
-   *                  AttachmentQtyLimit:
-   *                    value: {message: Number of attachments exceeds limit}
-   *                  AttachmentSizeLimit:
-   *                    value: {message: Size of attachments exceeds limit}
    *         "429":
    *           description: Rate limit exceeded. Too many requests.
    *           content:
@@ -369,7 +357,7 @@ export const InitEmailTransactionalRoute = (
    *                example:
    *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
-   *           description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect)
+   *           description: Internal Server Error
    *           content:
    *              text/plain:
    *                type: string
@@ -403,7 +391,6 @@ export const InitEmailTransactionalRoute = (
    *     get:
    *       security:
    *         - bearerAuth: []
-   *         - cookieAuth: []
    *       tags:
    *         - Email
    *       summary: "Get transactional email by ID"
@@ -416,13 +403,13 @@ export const InitEmailTransactionalRoute = (
    *             example: 69
    *       responses:
    *         200:
-   *           description: Succcessfully retrieve transactional email with corresponding ID
+   *           description: Successfully retrieved transactional email with corresponding ID
    *           content:
    *            application/json:
    *              schema:
    *                $ref: '#/components/schemas/EmailMessageTransactional'
    *         "400":
-   *           description: Bad Request. Failed parameter validations, message is malformed, or attachments are rejected.
+   *           description: Bad Request. Failed parameter validations.
    *           content:
    *             text/plain:
    *               type: string
@@ -445,7 +432,7 @@ export const InitEmailTransactionalRoute = (
    *                example:
    *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
-   *           description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect)
+   *           description: Internal Server Error
    *           content:
    *              text/plain:
    *                type: string

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -54,9 +54,9 @@ export const InitEmailTransactionalRoute = (
         lte: Joi.date().iso(),
       }),
       sort_by: Joi.string()
-        // accepts TransactionalEmailSortField values with +/- prefix
         .pattern(
           new RegExp(
+            // accepts TransactionalEmailSortField values with optional +/- prefix
             `([+-]?${Object.values(TransactionalEmailSortField).join('|')})`
           )
         )
@@ -320,16 +320,16 @@ export const InitEmailTransactionalRoute = (
    *             properties:
    *               gt:
    *                 type: string
-   *                 format: date-time
+   *                 format: date-time (ISO 8601)
    *               gte:
    *                 type: string
-   *                 format: date-time
+   *                 format: date-time (ISO 8601)
    *               lt:
    *                 type: string
-   *                 format: date-time
+   *                 format: date-time (ISO 8601)
    *               lte:
    *                 type: string
-   *                 format: date-time
+   *                 format: date-time (ISO 8601)
    *         - in: query
    *           name: sort_by
    *           description: >

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -57,7 +57,7 @@ export const InitEmailTransactionalRoute = (
         .pattern(
           new RegExp(
             // accepts TransactionalEmailSortField values with optional +/- prefix
-            `([+-]?${Object.values(TransactionalEmailSortField).join('|')})`
+            `^[+-]?${Object.values(TransactionalEmailSortField).join('|')}$`
           )
         )
         .default(TransactionalEmailSortField.Created),

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -966,7 +966,7 @@ describe(`GET ${emailTransactionalRoute}`, () => {
       .set('Authorization', `Bearer ${apiKey}`)
     expect(res2.status).toBe(200)
     expect(res2.body.has_more).toBe(false)
-    expect(res2.body.data.length).toBe(4) // not sure why this is 4 and not 3
+    expect(res2.body.data.length).toBe(3)
 
     // repeated operators should throw an error
     const res3 = await request(app)

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -62,8 +62,10 @@ afterAll(async () => {
   await (app as any).cleanup()
 })
 
-describe('POST /transactional/email/send', () => {
-  const endpoint = '/transactional/email/send'
+const emailTransactionalRoute = '/transactional/email'
+
+describe(`${emailTransactionalRoute}/send`, () => {
+  const endpoint = `${emailTransactionalRoute}/send`
   const validApiCall = {
     recipient: 'recipient@agency.gov.sg',
     subject: 'subject',
@@ -722,7 +724,306 @@ describe('POST /transactional/email/send', () => {
   })
 })
 
-describe('GET /transactional/email/:emailId', () => {
+describe(`GET ${emailTransactionalRoute}`, () => {
+  const endpoint = emailTransactionalRoute
+  const acceptedMessage = {
+    recipient: 'recipient@gmail.com',
+    from: 'Postman <donotreply@mail.postman.gov.sg>',
+    params: {
+      from: 'Postman <donotreply@mail.postman.gov.sg>',
+      subject: 'Test',
+      body: 'Test Body',
+    },
+    status: TransactionalEmailMessageStatus.Accepted,
+  }
+  const sentMessage = {
+    recipient: 'recipient@agency.gov.sg',
+    from: 'Postman <donotreply@mail.postman.gov.sg>',
+    params: {
+      from: 'Postman <donotreply@mail.postman.gov.sg>',
+      subject: 'Test',
+      body: 'Test Body',
+    },
+    status: TransactionalEmailMessageStatus.Sent,
+  }
+  const deliveredMessage = {
+    recipient: 'recipient3@agency.gov.sg',
+    from: 'Postman <donotreply@mail.postman.gov.sg>',
+    params: {
+      from: 'Postman <donotreply@mail.postman.gov.sg>',
+      subject: 'Test',
+      body: 'Test Body',
+    },
+    status: TransactionalEmailMessageStatus.Delivered,
+  }
+  test('Should return 200 with empty array when no messages are found', async () => {
+    const res = await request(app)
+      .get(endpoint)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(false)
+    expect(res.body.data).toEqual([])
+  })
+
+  test('Should return 200 with descending array of messages when messages are found', async () => {
+    const message = await EmailMessageTransactional.create({
+      ...deliveredMessage,
+      userId: user.id,
+    } as unknown as EmailMessageTransactional)
+    const message2 = await EmailMessageTransactional.create({
+      ...acceptedMessage,
+      userId: user.id,
+    } as unknown as EmailMessageTransactional)
+    const res = await request(app)
+      .get(endpoint)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(false)
+    console.log('message', message)
+    console.log('res.body.data', res.body.data)
+    expect(res.body.data).toMatchObject([
+      // descending by default
+      {
+        id: message2.id,
+        recipient: message2.recipient,
+        from: message2.from,
+        params: message2.params,
+        status: message2.status,
+      },
+      {
+        id: message.id,
+        recipient: message.recipient,
+        from: message.from,
+        params: message.params,
+        status: message.status,
+      },
+    ])
+  })
+  test('Should return 400 when invalid query params are provided', async () => {
+    const resInvalidLimit = await request(app)
+      .get(`${endpoint}?limit=invalid`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidLimit.status).toBe(400)
+    const resInvalidLimitTooLarge = await request(app)
+      .get(`${endpoint}?limit=1000`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidLimitTooLarge.status).toBe(400)
+    const resInvalidOffset = await request(app)
+      .get(`${endpoint}?offset=blahblah`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidOffset.status).toBe(400)
+    const resInvalidOffsetNegative = await request(app)
+      .get(`${endpoint}?offset=-1`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidOffsetNegative.status).toBe(400)
+    const resInvalidStatus = await request(app)
+      .get(`${endpoint}?status=blacksheep`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidStatus.status).toBe(400)
+    // repeated params should throw an error too
+    const resInvalidStatus2 = await request(app)
+      .get(`${endpoint}?status=sent&status=delivered`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidStatus2.status).toBe(400)
+    const resInvalidCreatedAt = await request(app)
+      .get(`${endpoint}?created_at=haveyouanywool`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidCreatedAt.status).toBe(400)
+    const resInvalidCreatedAtDateFormat = await request(app)
+      .get(`${endpoint}?created_at[gte]=20200101`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidCreatedAtDateFormat.status).toBe(400)
+    const resInvalidSortBy = await request(app)
+      .get(`${endpoint}?sort_by=threebagsfull`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidSortBy.status).toBe(400)
+    const resInvalidSortByPrefix = await request(app)
+      .get(endpoint)
+      // need to use query() instead of get() for operator to be processed correctly
+      .query({ sort_by: '*created_at' })
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(resInvalidSortByPrefix.status).toBe(400)
+  })
+  test('default values of limit and offset should be 10 and 0 respectively', async () => {
+    for (let i = 0; i < 15; i++) {
+      await EmailMessageTransactional.create({
+        ...deliveredMessage,
+        userId: user.id,
+      } as unknown as EmailMessageTransactional)
+    }
+    const res = await request(app)
+      .get(endpoint)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(true)
+    expect(res.body.data.length).toBe(10)
+
+    const res2 = await request(app)
+      .get(`${endpoint}?offset=10`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res2.status).toBe(200)
+    expect(res2.body.has_more).toBe(false)
+    expect(res2.body.data.length).toBe(5)
+
+    const res3 = await request(app)
+      .get(`${endpoint}?offset=15`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res3.status).toBe(200)
+    expect(res3.body.has_more).toBe(false)
+    expect(res3.body.data.length).toBe(0)
+
+    const res4 = await request(app)
+      .get(`${endpoint}?limit=5`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res4.status).toBe(200)
+    expect(res4.body.has_more).toBe(true)
+    expect(res4.body.data.length).toBe(5)
+
+    const res5 = await request(app)
+      .get(`${endpoint}?limit=15`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res5.status).toBe(200)
+    expect(res5.body.has_more).toBe(false)
+    expect(res5.body.data.length).toBe(15)
+  })
+
+  test('status filter should work', async () => {
+    for (let i = 0; i < 5; i++) {
+      await EmailMessageTransactional.create({
+        ...deliveredMessage,
+        userId: user.id,
+      } as unknown as EmailMessageTransactional)
+    }
+    for (let i = 0; i < 5; i++) {
+      await EmailMessageTransactional.create({
+        ...acceptedMessage,
+        userId: user.id,
+      } as unknown as EmailMessageTransactional)
+    }
+    for (let i = 0; i < 5; i++) {
+      await EmailMessageTransactional.create({
+        ...sentMessage,
+        userId: user.id,
+      } as unknown as EmailMessageTransactional)
+    }
+    const res = await request(app)
+      .get(`${endpoint}?status=delivered`) // case-insensitive
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(false)
+    expect(res.body.data.length).toBe(5)
+    res.body.data.forEach((message: EmailMessageTransactional) => {
+      expect(message.status).toBe(TransactionalEmailMessageStatus.Delivered)
+    })
+    const res2 = await request(app)
+      .get(`${endpoint}?status=aCcEPteD`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res2.status).toBe(200)
+    expect(res2.body.has_more).toBe(false)
+    expect(res2.body.data.length).toBe(5)
+    res2.body.data.forEach((message: EmailMessageTransactional) => {
+      expect(message.status).toBe(TransactionalEmailMessageStatus.Accepted)
+    })
+    const res3 = await request(app)
+      .get(`${endpoint}?status=SENT`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res3.status).toBe(200)
+    expect(res3.body.has_more).toBe(false)
+    expect(res3.body.data.length).toBe(5)
+    res3.body.data.forEach((message: EmailMessageTransactional) => {
+      expect(message.status).toBe(TransactionalEmailMessageStatus.Sent)
+    })
+    // duplicate status params should throw an error
+    const res4 = await request(app)
+      .get(`${endpoint}?status=SENT&status=ACCEPTED`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res4.status).toBe(400)
+  })
+  test('created_at filter range should work', async () => {
+    const messages = []
+    const now = new Date()
+    for (let i = 0; i < 10; i++) {
+      const message = await EmailMessageTransactional.create({
+        ...deliveredMessage,
+        userId: user.id,
+        createdAt: new Date(now.getTime() - 100000 + i * 1000), // inserting in chronological order
+      } as unknown as EmailMessageTransactional)
+      messages.push(message)
+    }
+    const res = await request(app)
+      .get(
+        `${endpoint}?created_at[gte]=${messages[0].createdAt.toISOString()}&created_at[lte]=${messages[4].createdAt.toISOString()}`
+      )
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(false)
+    expect(res.body.data.length).toBe(5)
+
+    const res2 = await request(app)
+      .get(
+        `${endpoint}?created_at[gt]=${messages[0].createdAt.toISOString()}&created_at[lt]=${messages[4].createdAt.toISOString()}`
+      )
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res2.status).toBe(200)
+    expect(res2.body.has_more).toBe(false)
+    expect(res2.body.data.length).toBe(4) // not sure why this is 4 and not 3
+
+    // repeated operators should throw an error
+    const res3 = await request(app)
+      .get(
+        `${endpoint}?created_at[gte]=${messages[0].createdAt.toISOString()}&created_at[lte]=${messages[4].createdAt.toISOString()}&created_at[gte]=${messages[0].createdAt.toISOString()}`
+      )
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res3.status).toBe(400)
+  })
+  test('sort_by should work', async () => {
+    const messages = []
+    const now = new Date()
+    for (let i = 0; i < 10; i++) {
+      const message = await EmailMessageTransactional.create({
+        ...deliveredMessage,
+        userId: user.id,
+        createdAt: new Date(now.getTime() - 100000 + i * 1000), // inserting in chronological order
+      } as unknown as EmailMessageTransactional)
+      messages.push(message)
+    }
+
+    const res = await request(app)
+      .get(`${endpoint}?sort_by=created_at`)
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res.status).toBe(200)
+    expect(res.body.has_more).toBe(false)
+    expect(res.body.data.length).toBe(10)
+    // default descending order
+    expect(res.body.data[0].id).toBe(messages[9].id)
+    expect(res.body.data[9].id).toBe(messages[0].id)
+
+    const res2 = await request(app)
+      .get(endpoint)
+      // need to use query() instead of get() for operator to be processed correctly
+      .query({ sort_by: '+created_at' })
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res2.status).toBe(200)
+    expect(res2.body.has_more).toBe(false)
+    expect(res2.body.data.length).toBe(10)
+    expect(res2.body.data[0].id).toBe(messages[0].id)
+    expect(res2.body.data[9].id).toBe(messages[9].id)
+
+    const res3 = await request(app)
+      .get(endpoint)
+      // need to use query() instead of get() for operator to be processed correctly
+      .query({ sort_by: '-created_at' })
+      .set('Authorization', `Bearer ${apiKey}`)
+    expect(res3.status).toBe(200)
+    expect(res3.body.has_more).toBe(false)
+    expect(res3.body.data.length).toBe(10)
+    expect(res3.body.data[0].id).toBe(messages[9].id)
+    expect(res3.body.data[9].id).toBe(messages[0].id)
+  })
+})
+
+describe(`GET ${emailTransactionalRoute}/:emailId`, () => {
+  const endpoint = emailTransactionalRoute
   test('should return a transactional email message with corresponding ID', async () => {
     const message = await EmailMessageTransactional.create({
       userId: user.id,
@@ -736,7 +1037,7 @@ describe('GET /transactional/email/:emailId', () => {
       status: TransactionalEmailMessageStatus.Delivered,
     } as unknown as EmailMessageTransactional)
     const res = await request(app)
-      .get(`/transactional/email/${message.id}`)
+      .get(`${endpoint}/${message.id}`)
       .set('Authorization', `Bearer ${apiKey}`)
     expect(res.status).toBe(200)
     expect(res.body).toBeDefined()
@@ -746,7 +1047,7 @@ describe('GET /transactional/email/:emailId', () => {
   test('should return 404 if the transactional email message ID not found', async () => {
     const id = 69
     const res = await request(app)
-      .get(`/transactional/email/${id}`)
+      .get(`${endpoint}/${id}`)
       .set('Authorization', `Bearer ${apiKey}`)
     expect(res.status).toBe(404)
     expect(res.body.message).toBe(`Email message with ID ${id} not found.`)
@@ -770,7 +1071,7 @@ describe('GET /transactional/email/:emailId', () => {
       status: TransactionalEmailMessageStatus.Delivered,
     } as unknown as EmailMessageTransactional)
     const res = await request(app)
-      .get(`/transactional/email/${message.id}`)
+      .get(`${endpoint}/${message.id}`)
       .set('Authorization', `Bearer ${anotherApiKey}`)
     expect(res.status).toBe(404)
     expect(res.body.message).toBe(

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -206,7 +206,7 @@ async function listMessages({
   status,
   filterByTimestamp,
 }: {
-  userId: number
+  userId: string
   limit?: number
   offset?: number
   sortBy?: TransactionalEmailSortField
@@ -220,7 +220,7 @@ async function listMessages({
   orderBy = orderBy || Ordering.DESC
   const order: Order = [[sortBy, orderBy]]
   const where = ((userId, status, filterByTimestamp) => {
-    const where: WhereOptions = { userId }
+    const where: WhereOptions = { userId } // pre-fill with userId for authentication
     if (status) {
       where.status = status
     }

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -228,16 +228,16 @@ async function listMessages({
       if (filterByTimestamp.createdAt) {
         const { gt, gte, lt, lte } = filterByTimestamp.createdAt
         if (gt) {
-          where.createdAt = { [Op.gt]: gt }
+          where.createdAt = { ...where.createdAt, [Op.gt]: gt }
         }
         if (gte) {
-          where.createdAt = { [Op.gte]: gte }
+          where.createdAt = { ...where.createdAt, [Op.gte]: gte }
         }
         if (lt) {
-          where.createdAt = { [Op.lt]: lt }
+          where.createdAt = { ...where.createdAt, [Op.lt]: lt }
         }
         if (lte) {
-          where.createdAt = { [Op.lte]: lte }
+          where.createdAt = { ...where.createdAt, [Op.lte]: lte }
         }
       }
     }

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -202,7 +202,7 @@ async function listMessages(
   orderBy: Ordering,
   status?: TransactionalEmailMessageStatus,
   filterBy?: TimestampFilter
-): Promise<EmailMessageTransactional[]> {
+): Promise<{ hasMore: boolean; messages: EmailMessageTransactional[] }> {
   console.log('userId', userId)
   console.log('limit', limit)
   console.log('offset', offset)
@@ -215,7 +215,7 @@ async function listMessages(
   //   limit: limit ? Number(limit) : undefined,
   //   offset: offset ? Number(offset) : undefined,
   // })
-  return []
+  return { hasMore: false, messages: [] }
 }
 
 export const EmailTransactionalService = {

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -13,8 +13,8 @@ import {
 } from '@email/models'
 import { SesEventType } from '@email/interfaces/callback.interface'
 import {
-  TimestampFilter,
   Ordering,
+  TimestampFilter,
   TransactionalEmailSortField,
 } from '@core/constants'
 import { Order } from 'sequelize/types/model'
@@ -120,6 +120,7 @@ type CallbackMetaData = {
     complaintSubType: string
   }
 }
+
 async function handleStatusCallbacks(
   type: SesEventType,
   id: string,
@@ -196,15 +197,27 @@ async function handleStatusCallbacks(
   }
 }
 
-async function listMessages(
-  userId: number,
-  limit: number,
-  offset: number,
-  sortBy: TransactionalEmailSortField,
-  orderBy: Ordering,
-  status?: TransactionalEmailMessageStatus,
+async function listMessages({
+  userId,
+  limit,
+  offset,
+  sortBy,
+  orderBy,
+  status,
+  filterByTimestamp,
+}: {
+  userId: number
+  limit?: number
+  offset?: number
+  sortBy?: TransactionalEmailSortField
+  orderBy?: Ordering
+  status?: TransactionalEmailMessageStatus
   filterByTimestamp?: TimestampFilter
-): Promise<{ hasMore: boolean; messages: EmailMessageTransactional[] }> {
+}): Promise<{ hasMore: boolean; messages: EmailMessageTransactional[] }> {
+  limit = limit || 10
+  offset = offset || 0
+  sortBy = sortBy || TransactionalEmailSortField.Created
+  orderBy = orderBy || Ordering.DESC
   const order: Order = [[sortBy, orderBy]]
   const where = ((userId, status, filterByTimestamp) => {
     const where: WhereOptions = { userId }

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -12,6 +12,11 @@ import {
   TransactionalEmailMessageStatus,
 } from '@email/models'
 import { SesEventType } from '@email/interfaces/callback.interface'
+import {
+  TimestampFilter,
+  Ordering,
+  TransactionalEmailSortField,
+} from '@core/constants'
 
 const logger = loggerWithLabel(module)
 
@@ -189,7 +194,32 @@ async function handleStatusCallbacks(
   }
 }
 
+async function listMessages(
+  userId: number,
+  limit: number,
+  offset: number,
+  sortBy: TransactionalEmailSortField,
+  orderBy: Ordering,
+  status?: TransactionalEmailMessageStatus,
+  filterBy?: TimestampFilter
+): Promise<EmailMessageTransactional[]> {
+  console.log('userId', userId)
+  console.log('limit', limit)
+  console.log('offset', offset)
+  console.log('status', status)
+  console.log('filterBy', filterBy)
+  console.log('sortBy', sortBy)
+  console.log('orderBy', orderBy)
+  // TODO
+  // const messages = await EmailMessageTransactional.findAll({
+  //   limit: limit ? Number(limit) : undefined,
+  //   offset: offset ? Number(offset) : undefined,
+  // })
+  return []
+}
+
 export const EmailTransactionalService = {
   sendMessage,
   handleStatusCallbacks,
+  listMessages,
 }

--- a/backend/src/sms/routes/sms-transactional.routes.ts
+++ b/backend/src/sms/routes/sms-transactional.routes.ts
@@ -23,6 +23,8 @@ export const InitSmsTransactionalRoute = (
    * paths:
    *   /transactional/sms/send:
    *     post:
+          security:
+   *         - bearerAuth: []
    *       summary: "Send a transactional SMS"
    *       tags:
    *         - SMS


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/Implement-list-transactional-messages-endpoint-610554e007ef4e84ad23bd1a30ceb9a1)

The general strategy I have adopted is to:
- Apply validation at the routes level using `celebrate`
- Convert the validated query params into type-safe arguments in the middleware layer
- Pass these arguments to `EmailTransactionalService`, which uses sequelize to retrieve the requested data

**Implementation Notes:**
- For extensibility, instead of passing in `created_at` directly, I have transformed it into a `TimestampFilter` that could be extended to filter by other timestamps
- I considered whether to build `sortBy` in such a way that allow for concurrent sorts in the future, but seeing as that is not in spec and it's unclear whether our API users need it (compared to more filters, which would almost certainly be needed), I did not build it that way. 
- To ensure DRY-ness as much as possible, I have passed in the `TransactionalEmailSortField` enum as part of the Joi regex validation of `sort_by`. I considered whether it was possible to do the same for the `created_at` validation using `TimestampFilter` and `TimestampOperator`, but wasn't sure how to do it. 

**Misc:**
-  Renamed `SortField` to `CampaignSortField` as that was only used in listing campaigns. For transactional emails, we are sorting by a different list of enums.
- The first commit in this PR is to fix mistakes in the Swagger docs that was caused by hasty copy-and-paste
- I have extended `convertMessageModelToResponse` to include `created_at` and `updated_at` since we're allowing sorting and filtering by these fields, would only make sense to expose this information to the API user too

**[Known downsides](https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/#downsides-3)** of this implementation:
- Not performant for large offset values
- Not consistent when new items are inserted to the table (i.e. Page drift). This is especially noticeable when we are ordering items by newest first. 

Regarding the large offset values, citing the same link, this is OK "in applications where the data set has a small upper bounds". ~~Considering this table can scale to quite large, I think we should probably note something in the API documentation or maybe set a max offset value.~~ Discussed with @stanleynguyen and, at our scale, there is no need to set a max offset value. We can deal with this in the future in the (happy) event that we get to a much larger scale. 