### PR TITLE
fix: use logger.warn instead of logger.error for unhandled events

### DIFF
--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -180,7 +180,7 @@ async function handleStatusCallbacks(
       )
       break
     default:
-      logger.error({
+      logger.warn({
         message: 'Unable to handle messages with this type',
         type,
         id,

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -160,7 +160,7 @@ const parseNotificationAndEvent = async (
       await updateReadStatus(metadata)
       break
     default:
-      logger.error({
+      logger.warn({
         message: 'Unable to handle messages with this type',
         type,
         ...logMeta,


### PR DESCRIPTION
Use `warn` so it won't clutter up our error logs

We choose to do this (instead of simply disabling these events on AWS) because these events could be helpful if we ever want to get more info that is not shown in our database. (@stanleynguyen is this correct?)