### PR TITLE
fix(frontend): fix auto-scrolling of protected page

### DIFF
--- a/frontend/src/components/common/text-input-with-button/TextInputWithButton.module.scss
+++ b/frontend/src/components/common/text-input-with-button/TextInputWithButton.module.scss
@@ -15,6 +15,10 @@ $button-width: 7rem;
     input {
       margin-right: 0px;
       padding-right: $button-height + 0.5rem;
+
+      // explicity set the font-size to 16px (which is the default value) to prevent
+      // iOS from zooming in
+      font-size: 16px;
     }
   }
 

--- a/frontend/src/components/protected/Protected.tsx
+++ b/frontend/src/components/protected/Protected.tsx
@@ -13,6 +13,10 @@ import Banner from 'components/landing/banner'
 
 import { fetchMessage } from 'services/decrypt-mail.service'
 
+interface CSSStylesWithZoom extends CSSStyleDeclaration {
+  zoom: number
+}
+
 const Protected = () => {
   const { id } = useParams<{ id: string }>()
   const [password, setPassword] = useState('')
@@ -24,6 +28,10 @@ const Protected = () => {
     try {
       const data = await fetchMessage(id, password)
       setDecryptedMessage(data)
+      // reset possible zooming in on iOS
+      ;(window.parent.document.body.style as CSSStylesWithZoom).zoom = 1
+      // reset page position caused by text input field focusing on mobiles
+      window.scrollTo(0, 0)
     } catch (err) {
       setErrorMsg((err as Error).message)
     }


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Bug-on-password-protect-page-491d1060ac2e475f8aa5664a70eac23f)

## Solution

- Setting font of input field to `16px` explicitly which is the same as the default value (i.e. not affecting anything) to prevent iOS from zooming in
- Scroll to top after protected content is loaded
- Reset zoom to 1 after protected content is loaded

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- N/A
