### PR TITLE
fix: logo rendering in footer on SGMail

### DIFF
--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -213,11 +213,13 @@
           <br />    
           <a href="{{{unsubLink}}}">Unsubscribe</a>
           <div class="footer-vertical-spacer-top" style="line-height: 16px; height: 16px;">&#8202;</div>
-          <div>
-            <img src="https://file.go.gov.sg/postman-logo-color.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px;">
-            <div style="margin: 0 10px; border-left: 1px solid #B5C4FF; height: 24px; display: inline-block;width: 0;"></div>
-            <img src="https://file.go.gov.sg/ogp-logo-rect.png" alt="Open Government Products Logo" height="24" style="height:24px; width:91.5px;">
-          </div>
+          <table role="presentation" style="margin:auto;height: 28px"><tbody>
+            <tr>
+              <td align="center" width="45%"><img src="https://file.go.gov.sg/postman-logo-color.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px; vertical-align: middle"></td>
+              <td><div style="margin: 0 10px; border-left: 1px solid #B5C4FF; height: 24px; display: inline-block;width: 0; vertical-align: middle"></div></td>
+              <td align="center" width="45%"><img src="https://file.go.gov.sg/ogp-logo-rect.png" alt="Open Government Products Logo" height="24" style="height:24px; width:91.5px;vertical-align: middle;"></td>
+            </tr>
+          </tbody></table>
         </div>
         <div class="footer-vertical-spacer-bottom" style="line-height: 24px; height: 24px;">&#8202;</div>
       </div>

--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -216,7 +216,7 @@
           <table role="presentation" style="margin:auto;height: 28px"><tbody>
             <tr>
               <td align="center" width="45%"><img src="https://file.go.gov.sg/postman-logo-color.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px; vertical-align: middle"></td>
-              <td><div style="margin: 0 10px; border-left: 1px solid #B5C4FF; height: 24px; display: inline-block;width: 0; vertical-align: middle"></div></td>
+              <td><div style="margin: 0 10px; border-left: 1px solid #B5C4FF; height: 24px; display: inline-block;width: 0; vertical-align: middle">&nbsp;</div></td>
               <td align="center" width="45%"><img src="https://file.go.gov.sg/ogp-logo-rect.png" alt="Open Government Products Logo" height="24" style="height:24px; width:91.5px;vertical-align: middle;"></td>
             </tr>
           </tbody></table>

--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -216,15 +216,16 @@
           <div>
             <img src="https://file.go.gov.sg/postman-logo-color.png" alt="Postman.gov.sg Logo" height="24" style="height: 24px; width: 109.55px;">
             <div style="margin: 0 10px; border-left: 1px solid #B5C4FF; height: 24px; display: inline-block;width: 0;"></div>
-            <img src="https://file.go.gov.sg/ogp-logo-rect.png" alt="Open Government Products Logo" style="height:24px; width:91.5px;">
+            <img src="https://file.go.gov.sg/ogp-logo-rect.png" alt="Open Government Products Logo" height="24" style="height:24px; width:91.5px;">
           </div>
         </div>
         <div class="footer-vertical-spacer-bottom" style="line-height: 24px; height: 24px;">&#8202;</div>
       </div>
     </div>
-  <!--[if true]>
-  </td></tr></table>
-  <![endif]-->
+    <!--[if true]>
+    </td></tr></table>
+    <![endif]-->
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/Postman-footer-not-rendering-properly-on-SGMail-6bb4b499f2e34f67b954e614e63b1682)

## Issue

- Fundamentally, Microsoft Outlook renders email HTML differently, so hacky workarounds in our mustache template are needed. 
- Proximately, this issue was introduced by [this PR](https://github.com/opengovsg/postmangovsg/pull/1743), specifically this change:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/67887489/200514101-cf43471a-d198-4e4a-91d6-80be4c93c9a3.png">

## Solution

To see the HTML of the email, forward the email to Gmail, click "Show original", change `view=om` to `view=lg`. Now you can save it as a `.html`. [Source](https://webapps.stackexchange.com/a/117154)

Changes made:
- The first change is to add a missing closing `</div>` tag. This was picked up by my IDE though ostensibly it didn't make any difference.
- The second change is to add `height="24"` to the OGP logo `<img>` tag. While duplicative of what's alr in `style`, this is necessary in order for the logo to render at a correct size. Without this, the logo is 4x the size of what it should be. (See screenshots below).
- The third change is to fix the logos' relative position, which are vertically instead of horizontally side-by-side. To do so, I tried to follow the style of the existing `mustache` file and not make significant changes (since I'm not very familiar with Mustache). I tested every change made to make sure that it is absolutely necessary. At a high level, the idea is to use `table` instead of `div` for Outlook to render the email properly.
- The fourth change is to add `&nbsp;` into the `div` that was previously being ignored by Outlook. [Source](https://stackoverflow.com/a/71293011).

## Screenshots

Before:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/67887489/200513317-ba57c574-a866-4501-be22-9433f42adaf0.png">


After:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/67887489/200531403-4bd06f87-9537-449e-8846-3c13413dee58.png">
