### PR TITLE
refactor(backend): revise authentication for endpoints

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -194,6 +194,15 @@
         "line_number": 67
       }
     ],
+    "backend/src/core/middlewares/auth.middleware.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/src/core/middlewares/auth.middleware.ts",
+        "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
     "backend/src/email/services/tests/email-template.service.test.ts": [
       {
         "type": "Secret Keyword",
@@ -363,5 +372,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-13T15:39:41Z"
+  "generated_at": "2022-11-09T08:09:41Z"
 }

--- a/backend/src/core/constants.ts
+++ b/backend/src/core/constants.ts
@@ -75,12 +75,36 @@ export enum Ordering {
  *           type: boolean
  *         redacted:
  *           type: boolean
+ *         should_save_list:
+ *           type: boolean
  *         type:
  *           $ref: '#/components/schemas/ChannelType'
  *         job_queue:
  *           type: array
  *           items:
  *            $ref: '#/components/schemas/JobQueue'
+ *
+ *     CampaignDuplicateMeta:
+ *       type: object
+ *       required:
+ *         - name
+ *         - id
+ *         - created_at
+ *         - type
+ *         - protect
+ *       properties:
+ *         id:
+ *           type: number
+ *         name:
+ *           type: string
+ *         type:
+ *           $ref: '#/components/schemas/ChannelType'
+ *         created_at:
+ *           type: string
+ *           format: date-time
+ *         protect:
+ *           type: boolean
+ *           example: false
  *
  *     JobQueue:
  *        type: object

--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -115,8 +115,8 @@ export const InitAuthMiddleware = (authService: AuthService) => {
     return res.json({})
   }
 
-  type AuthenticatorType = (req: Request) => Promise<boolean>
-  const authenticators: Record<AuthType, AuthenticatorType> = {
+  type Authenticator = (req: Request) => Promise<boolean>
+  const authenticators: Record<AuthType, Authenticator> = {
     [AuthType.Cookie]: async (req: Request) => {
       const authenticated = authService.checkCookie(req)
       if (!authenticated) {

--- a/backend/src/core/routes/auth.routes.ts
+++ b/backend/src/core/routes/auth.routes.ts
@@ -33,7 +33,6 @@ export const InitAuthRoutes = (authMiddleware: AuthMiddleware): Router => {
   // actual routes here
 
   /**
-   * @swagger
    * paths:
    *  /auth/otp:
    *    post:
@@ -64,7 +63,6 @@ export const InitAuthRoutes = (authMiddleware: AuthMiddleware): Router => {
   router.post('/otp', celebrate(getOtpValidator), authMiddleware.getOtp)
 
   /**
-   * @swagger
    * paths:
    *  /auth/login:
    *    post:
@@ -103,7 +101,6 @@ export const InitAuthRoutes = (authMiddleware: AuthMiddleware): Router => {
   router.post('/login', celebrate(verifyOtpValidator), authMiddleware.verifyOtp)
 
   /**
-   * @swagger
    * paths:
    *  /auth/userinfo:
    *    get:
@@ -125,7 +122,6 @@ export const InitAuthRoutes = (authMiddleware: AuthMiddleware): Router => {
   router.get('/userinfo', authMiddleware.getUser)
 
   /**
-   * @swagger
    * paths:
    *  /auth/logout:
    *    get:

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -48,6 +48,8 @@ const updateCampaignValidator = {
  * paths:
  *  /campaigns:
  *    get:
+ *      security:
+ *        - bearerAuth: []
  *      tags:
  *        - Campaigns
  *      summary: List all campaigns for user
@@ -169,6 +171,8 @@ router.get(
  * paths:
  *  /campaigns:
  *    post:
+ *      security:
+ *        - bearerAuth: []
  *      summary: Create a new campaign
  *      tags:
  *        - Campaigns
@@ -243,6 +247,8 @@ router.post(
  * paths:
  *  /campaigns/{campaignId}:
  *    delete:
+ *      security:
+ *        - bearerAuth: []
  *      tags:
  *        - Campaigns
  *      summary: Delete a campaign using its ID
@@ -312,6 +318,8 @@ router.delete(
  * paths:
  *  /campaigns/{campaignId}:
  *   put:
+ *    security:
+ *      - bearerAuth: []
  *    summary: Rename campaign
  *    tags:
  *      - Campaigns

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -120,9 +120,43 @@ const updateCampaignValidator = {
  *                    type: integer
  *
  *        "401":
- *           description: Unauthorized
+ *          description: Unauthorized
+ *        "403":
+ *          description: Forbidden. Request violates firewall rules.
+ *        "429":
+ *          description: Rate limit exceeded. Too many requests.
+ *          content:
+ *             application/json:
+ *               schema:
+ *                 $ref: '#/components/schemas/ErrorStatus'
+ *               example:
+ *                 {status: 429, message: Too many requests. Please try again later.}
  *        "500":
- *           description: Internal Server Error
+ *          description: Internal Server Error
+ *          content:
+ *             text/plain:
+ *               type: string
+ *               example: Internal Server Error
+ *        "502":
+ *          description: Bad Gateway
+ *        "504":
+ *          description: Gateway Timeout
+ *        "503":
+ *          description: Service Temporarily Unavailable
+ *        "520":
+ *          description: Web Server Returns An Unknown Error
+ *        "521":
+ *          description: Web Server Is Down
+ *        "522":
+ *          description: Connection Timed Out
+ *        "523":
+ *          description: Origin Is Unreachable
+ *        "524":
+ *          description: A Timeout occurred
+ *        "525":
+ *          description: SSL handshake failed
+ *        "526":
+ *          description: Invalid SSL certificate
  */
 router.get(
   '/',
@@ -133,7 +167,7 @@ router.get(
 /**
  * @swagger
  * paths:
- *  /campaigns/{campaignId}:
+ *  /campaigns:
  *    post:
  *      summary: Create a new campaign
  *      tags:
@@ -158,21 +192,45 @@ router.get(
  *          content:
  *            application/json:
  *              schema:
- *                type: object
- *                properties:
- *                 id:
- *                  type: number
- *                 name:
- *                  type: string
- *                 created_at:
- *                  type: string
- *                  format: date-time
- *                 type:
- *                  $ref: '#/components/schemas/ChannelType'
+ *                $ref: '#/components/schemas/CampaignMeta'
  *        "401":
  *           description: Unauthorized
+ *        "403":
+ *          description: Forbidden. Request violates firewall rules.
+ *        "429":
+ *          description: Rate limit exceeded. Too many requests.
+ *          content:
+ *             application/json:
+ *               schema:
+ *                 $ref: '#/components/schemas/ErrorStatus'
+ *               example:
+ *                 {status: 429, message: Too many requests. Please try again later.}
  *        "500":
- *           description: Internal Server Error
+ *          description: Internal Server Error
+ *          content:
+ *             text/plain:
+ *               type: string
+ *               example: Internal Server Error
+ *        "502":
+ *          description: Bad Gateway
+ *        "504":
+ *          description: Gateway Timeout
+ *        "503":
+ *          description: Service Temporarily Unavailable
+ *        "520":
+ *          description: Web Server Returns An Unknown Error
+ *        "521":
+ *          description: Web Server Is Down
+ *        "522":
+ *          description: Connection Timed Out
+ *        "523":
+ *          description: Origin Is Unreachable
+ *        "524":
+ *          description: A Timeout occurred
+ *        "525":
+ *          description: SSL handshake failed
+ *        "526":
+ *          description: Invalid SSL certificate
  */
 router.post(
   '/',
@@ -206,8 +264,42 @@ router.post(
  *          description: Unauthorized
  *        "404":
  *          description: Campaign not found
+ *        "403":
+ *          description: Forbidden. Request violates firewall rules.
+ *        "429":
+ *          description: Rate limit exceeded. Too many requests.
+ *          content:
+ *             application/json:
+ *               schema:
+ *                 $ref: '#/components/schemas/ErrorStatus'
+ *               example:
+ *                 {status: 429, message: Too many requests. Please try again later.}
  *        "500":
  *          description: Internal Server Error
+ *          content:
+ *             text/plain:
+ *               type: string
+ *               example: Internal Server Error
+ *        "502":
+ *          description: Bad Gateway
+ *        "504":
+ *          description: Gateway Timeout
+ *        "503":
+ *          description: Service Temporarily Unavailable
+ *        "520":
+ *          description: Web Server Returns An Unknown Error
+ *        "521":
+ *          description: Web Server Is Down
+ *        "522":
+ *          description: Connection Timed Out
+ *        "523":
+ *          description: Origin Is Unreachable
+ *        "524":
+ *          description: A Timeout occurred
+ *        "525":
+ *          description: SSL handshake failed
+ *        "526":
+ *          description: Invalid SSL certificate
  */
 router.delete(
   '/:campaignId',
@@ -216,6 +308,7 @@ router.delete(
 )
 
 /**
+ * @swagger
  * paths:
  *  /campaigns/{campaignId}:
  *   put:
@@ -234,11 +327,7 @@ router.delete(
  *        application/json:
  *          schema:
  *            type: object
- *            required:
- *              - id
  *            properties:
- *              id:
- *                type: number
  *              name:
  *                type: string
  *              should_save_list:
@@ -248,13 +337,47 @@ router.delete(
  *        content:
  *          application/json:
  *            schema:
- *             type: object
+ *              $ref: '#/components/schemas/CampaignMeta'
  *      "401":
  *        description: Unauthorized
  *      "404":
  *        description: Not found
+ *      "403":
+ *        description: Forbidden. Request violates firewall rules.
+ *      "429":
+ *        description: Rate limit exceeded. Too many requests.
+ *        content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorStatus'
+ *             example:
+ *               {status: 429, message: Too many requests. Please try again later.}
  *      "500":
  *        description: Internal Server Error
+ *        content:
+ *           text/plain:
+ *             type: string
+ *             example: Internal Server Error
+ *      "502":
+ *        description: Bad Gateway
+ *      "504":
+ *        description: Gateway Timeout
+ *      "503":
+ *        description: Service Temporarily Unavailable
+ *      "520":
+ *        description: Web Server Returns An Unknown Error
+ *      "521":
+ *        description: Web Server Is Down
+ *      "522":
+ *        description: Connection Timed Out
+ *      "523":
+ *        description: Origin Is Unreachable
+ *      "524":
+ *        description: A Timeout occurred
+ *      "525":
+ *        description: SSL handshake failed
+ *      "526":
+ *        description: Invalid SSL certificate
  */
 router.put(
   '/:campaignId',

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -167,7 +167,6 @@ export const InitV1Route = (app: Application): Router => {
   router.use('/stats', statsRoutes)
   router.use('/protect', protectedMailRoutes)
   router.use('/unsubscribe', unsubscriberRoutes)
-  router.use('/lists', listRoutes)
 
   /**
    * @swagger
@@ -247,5 +246,11 @@ export const InitV1Route = (app: Application): Router => {
   router.use('/callback/sms', smsCallbackRoutes)
 
   router.use('/callback/telegram', telegramCallbackRoutes)
+
+  router.use(
+    '/lists',
+    authMiddleware.getAuthMiddleware([AuthType.Cookie]),
+    listRoutes
+  )
   return router
 }

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -2,7 +2,11 @@ import { Router, Request, Response, NextFunction, Application } from 'express'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { ChannelType } from '@core/constants'
 import { Campaign } from '@core/models'
-import { InitAuthMiddleware, InitSettingsMiddleware } from '@core/middlewares'
+import {
+  AuthType,
+  InitAuthMiddleware,
+  InitSettingsMiddleware,
+} from '@core/middlewares'
 import { loggerWithLabel } from '@core/logger'
 
 // Core routes
@@ -177,64 +181,64 @@ export const InitV1Route = (app: Application): Router => {
 
   router.use(
     '/campaigns',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     campaignRoutes
   )
   router.use(
     '/campaign/:campaignId/sms',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     celebrate(campaignIdValidator),
     smsCampaignRoutes
   )
   router.use(
     '/campaign/:campaignId/email',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     celebrate(campaignIdValidator),
     emailCampaignRoutes
   )
   router.use(
     '/campaign/:campaignId/telegram',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     celebrate(campaignIdValidator),
     telegramCampaignRoutes
   )
   router.use(
     '/campaign/:campaignId',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     celebrate(campaignIdValidator),
     redirectToChannelRoute
   )
 
   router.use(
     '/settings/email',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     emailSettingsRoutes
   )
   router.use(
     '/settings/sms',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     smsSettingsRoutes
   )
   router.use(
     '/settings/telegram',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     telegramSettingsRoutes
   )
   router.use(
     '/settings',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     settingsRoutes
   )
 
   router.use(
     '/transactional/sms',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     smsTransactionalRoutes
   )
 
   router.use(
     '/transactional/email',
-    authMiddleware.isCookieOrApiKeyAuthenticated,
+    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
     emailTransactionalRoutes
   )
 

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -211,22 +211,22 @@ export const InitV1Route = (app: Application): Router => {
 
   router.use(
     '/settings/email',
-    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
+    authMiddleware.getAuthMiddleware([AuthType.Cookie]),
     emailSettingsRoutes
   )
   router.use(
     '/settings/sms',
-    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
+    authMiddleware.getAuthMiddleware([AuthType.Cookie]),
     smsSettingsRoutes
   )
   router.use(
     '/settings/telegram',
-    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
+    authMiddleware.getAuthMiddleware([AuthType.Cookie]),
     telegramSettingsRoutes
   )
   router.use(
     '/settings',
-    authMiddleware.getAuthMiddleware([AuthType.Cookie, AuthType.ApiKey]),
+    authMiddleware.getAuthMiddleware([AuthType.Cookie]),
     settingsRoutes
   )
 

--- a/backend/src/core/routes/list.routes.ts
+++ b/backend/src/core/routes/list.routes.ts
@@ -13,7 +13,6 @@ const listByChannelValidator = {
   }),
 }
 /**
- * @swagger
  * paths:
  *   /lists/{channel}:
  *     get:

--- a/backend/src/core/routes/protected.routes.ts
+++ b/backend/src/core/routes/protected.routes.ts
@@ -11,7 +11,6 @@ const protectVerifyValidator = {
 }
 
 /**
- * @swagger
  * paths:
  *   /protect/{id}:
  *     post:

--- a/backend/src/core/routes/settings.routes.ts
+++ b/backend/src/core/routes/settings.routes.ts
@@ -38,7 +38,6 @@ export const InitSettingsRoute = (
   }
 
   /**
-   * @swagger
    * paths:
    *  /settings:
    *    get:
@@ -69,7 +68,6 @@ export const InitSettingsRoute = (
   router.get('/', settingsMiddleware.getUserSettings)
 
   /**
-   * @swagger
    * paths:
    *  /settings/regen:
    *    post:
@@ -92,7 +90,6 @@ export const InitSettingsRoute = (
   router.post('/regen', settingsMiddleware.regenerateApiKey)
 
   /**
-   * @swagger
    * paths:
    *  /settings/credentials:
    *    delete:
@@ -123,7 +120,6 @@ export const InitSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/{channelType}/credentials:
    *    get:
@@ -155,7 +151,6 @@ export const InitSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/demo:
    *    put:
@@ -195,7 +190,6 @@ export const InitSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/announcement-version:
    *    put:

--- a/backend/src/core/routes/stats.routes.ts
+++ b/backend/src/core/routes/stats.routes.ts
@@ -4,7 +4,6 @@ import { StatsMiddleware } from '@core/middlewares'
 const router = Router()
 
 /**
- * @swagger
  * paths:
  *  /stats:
  *    get:

--- a/backend/src/core/routes/unsubscriber.routes.ts
+++ b/backend/src/core/routes/unsubscriber.routes.ts
@@ -24,7 +24,6 @@ const subscribeAgainValidator = {
 }
 
 /**
- * @swagger
  * paths:
  *  /unsubscribe/{campaignId}/{recipient}:
  *    put:
@@ -79,7 +78,6 @@ router.put(
 )
 
 /**
- * @swagger
  * paths:
  *  /unsubscribe/{campaignId}/{recipient}:
  *    delete:

--- a/backend/src/email/routes/email-callback.routes.ts
+++ b/backend/src/email/routes/email-callback.routes.ts
@@ -2,7 +2,6 @@ import { Router } from 'express'
 import { EmailCallbackMiddleware } from '@email/middlewares'
 const router = Router()
 /**
- * @swagger
  * paths:
  *   /callback/email:
  *    post:

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -99,6 +99,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Get email campaign details
@@ -164,6 +166,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/template:
    *     put:
+   *       security:
+   *         - bearerAuth: []
    *       tags:
    *         - Email
    *       summary: Stores body template for email campaign
@@ -295,6 +299,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/upload/start:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get a presigned URL for upload with Content-MD5 header"
    *       tags:
    *         - Email
@@ -382,6 +388,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/upload/complete:
    *     post:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Complete upload session with ETag verification"
    *       tags:
    *         - Email
@@ -461,6 +469,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/upload/status:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get csv processing status"
    *       tags:
    *         - Email
@@ -562,6 +572,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/upload/status:
    *     delete:
+   *       security:
+   *         - bearerAuth: []
    *       description: "Deletes error status from previous failed upload"
    *       tags:
    *         - Email
@@ -624,6 +636,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/credentials:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Sends a test message and defaults to Postman's credentials for the campaign
@@ -695,6 +709,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/preview:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Preview templated message
@@ -777,6 +793,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/send:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Start sending campaign
@@ -846,6 +864,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/stop:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Stop sending campaign
@@ -905,6 +925,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/retry:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Retry sending campaign
@@ -968,6 +990,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/stats:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Get email campaign stats
@@ -1037,6 +1061,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/refresh-stats:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Get email campaign stats
@@ -1106,6 +1132,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/export:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Get recipients of campaign
@@ -1183,6 +1211,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/protect/upload/start:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Start multipart upload
@@ -1273,6 +1303,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/email/protect/upload/complete:
    *     post:
+   *       security:
+   *         - bearerAuth: []
    *       summary: Complete multipart upload
    *       tags:
    *         - Email
@@ -1366,6 +1398,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/duplicate:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Duplicate the campaign and its template
@@ -1444,6 +1478,8 @@ export const InitEmailCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/email/select-list:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Email
    *      summary: Select the list of recipients from an existing managed list

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -120,8 +120,42 @@ export const InitEmailCampaignRoute = (
    *           description: Invalid campaign type or not owned by user
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/', emailMiddleware.getCampaignDetails)
 
@@ -145,6 +179,11 @@ export const InitEmailCampaignRoute = (
    *           application/json:
    *             schema:
    *               type: object
+   *               required:
+   *                 - subject
+   *                 - body
+   *                 - reply_to
+   *                 - from
    *               properties:
    *                 subject:
    *                   type: string
@@ -157,6 +196,9 @@ export const InitEmailCampaignRoute = (
    *                   nullable: true
    *                 from:
    *                   type: string
+   *                 show_logo:
+   *                   type: boolean
+   *                   default: true
    *       responses:
    *         200:
    *           description: Success
@@ -200,11 +242,41 @@ export const InitEmailCampaignRoute = (
    *         "401":
    *           description: Unauthorized
    *         "403":
-   *           description: Forbidden as there is a job in progress
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
    *         "503":
-   *           description: Service Unavailable. Try using the default from address instead.
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.put(
     '/template',
@@ -249,6 +321,9 @@ export const InitEmailCampaignRoute = (
    *             application/json:
    *               schema:
    *                 type: object
+   *                 required:
+   *                   - presigned_url
+   *                   - transaction_id
    *                 properties:
    *                   presigned_url:
    *                     type: string
@@ -259,9 +334,41 @@ export const InitEmailCampaignRoute = (
    *         "401":
    *           description: Unauthorized
    *         "403":
-   *           description: Forbidden as there is a job in progress
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.get(
     '/upload/start',
@@ -306,9 +413,41 @@ export const InitEmailCampaignRoute = (
    *         "401":
    *           description: Unauthorized
    *         "403":
-   *           description: Forbidden as there is a job in progress
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.post(
     '/upload/complete',
@@ -350,28 +489,77 @@ export const InitEmailCampaignRoute = (
    *                     type: number
    *                   preview:
    *                     type: object
+   *                     required:
+   *                       - subject
+   *                       - body
+   *                       - from
    *                     properties:
    *                       subject:
    *                         type: string
    *                       body:
    *                         type: string
-   *                       reply_to:
+   *                       replyTo:
    *                         type: string
    *                         nullable: true
+   *                       from:
+   *                         type: string
+   *                         example: 'Postman <donotreply@mail.postman.gov.sg>'
+   *                       showMasthead:
+   *                         type: boolean
+   *                       agencyLogoURI:
+   *                         type: string
+   *                         example: "https://file.go.gov.sg/postman-ogp.png"
+   *                       agencyName:
+   *                         type: string
+   *                         example: Open Government Products
+   *                       themedBody:
+   *                         type: string
    *         "400" :
    *           description: Bad Request
    *         "401":
    *           description: Unauthorized
    *         "403":
-   *           description: Forbidden as there is a job in progress
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.get('/upload/status', emailTemplateMiddleware.pollCsvStatusHandler)
 
   /**
    * @swagger
-   * post:
+   * paths:
    *   /campaign/{campaignId}/email/upload/status:
    *     delete:
    *       description: "Deletes error status from previous failed upload"
@@ -389,9 +577,41 @@ export const InitEmailCampaignRoute = (
    *         "401":
    *           description: Unauthorized
    *         "403":
-   *           description: Forbidden as there is a job in progress
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.delete(
     '/upload/status',
@@ -427,9 +647,41 @@ export const InitEmailCampaignRoute = (
    *        "401":
    *           description: Unauthorized
    *        "403":
-   *           description: Forbidden as there is a job in progress
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/credentials',
@@ -462,6 +714,10 @@ export const InitEmailCampaignRoute = (
    *                properties:
    *                  preview:
    *                    type: object
+   *                    required:
+   *                      - body
+   *                      - subject
+   *                      - from
    *                    properties:
    *                      body:
    *                        type: string
@@ -470,10 +726,49 @@ export const InitEmailCampaignRoute = (
    *                      reply_to:
    *                        type: string
    *                        nullable: true
+   *                      from:
+   *                        type: string
+   *                        example: 'Postman <donotreply@mail.postman.gov.sg>'
+   *                      themed_body:
+   *                        type: string
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/preview', emailMiddleware.previewFirstMessage)
 
@@ -485,16 +780,6 @@ export const InitEmailCampaignRoute = (
    *      tags:
    *        - Email
    *      summary: Start sending campaign
-   *      requestBody:
-   *        required: true
-   *        content:
-   *          application/json:
-   *            schema:
-   *              type: object
-   *              properties:
-   *                rate:
-   *                  type: integer
-   *                  minimum: 1
    *
    *      responses:
    *        200:
@@ -514,9 +799,41 @@ export const InitEmailCampaignRoute = (
    *        "401":
    *           description: Unauthorized
    *        "403":
-   *           description: Forbidden as there is a job in progress
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/send',
@@ -544,8 +861,42 @@ export const InitEmailCampaignRoute = (
    *                  type: integer
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post('/stop', JobMiddleware.stopCampaign)
 
@@ -571,8 +922,40 @@ export const InitEmailCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden as there is a job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/retry',
@@ -600,11 +983,52 @@ export const InitEmailCampaignRoute = (
    *          content:
    *            application/json:
    *              schema:
-   *                $ref: '#/components/schemas/CampaignStats'
+   *                allOf:
+   *                  - $ref: '#/components/schemas/CampaignStats'
+   *                  - type: object
+   *                    required:
+   *                      - unsubscribed
+   *                    properties:
+   *                      unsubscribed:
+   *                        type: number
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/stats', EmailStatsMiddleware.getStats)
 
@@ -628,11 +1052,52 @@ export const InitEmailCampaignRoute = (
    *          content:
    *            application/json:
    *              schema:
-   *                $ref: '#/components/schemas/CampaignStats'
+   *                allOf:
+   *                  - $ref: '#/components/schemas/CampaignStats'
+   *                  - type: object
+   *                    required:
+   *                      - unsubscribed
+   *                    properties:
+   *                      unsubscribed:
+   *                        type: number
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post('/refresh-stats', EmailStatsMiddleware.updateAndGetStats)
 
@@ -658,15 +1123,54 @@ export const InitEmailCampaignRoute = (
    *              schema:
    *                type: array
    *                items:
-   *                  $ref: '#/components/schemas/CampaignRecipient'
+   *                  allOf:
+   *                    - $ref: '#/components/schemas/CampaignRecipient'
+   *                    - type: object
+   *                      properties:
+   *                        'unsubscriber.recipient':
+   *                          type: string
+   *                        'unsubscriber.reason':
+   *                          type: string
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
    *        "410":
    *           description: Campaign has been redacted
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get(
     '/export',
@@ -719,8 +1223,42 @@ export const InitEmailCampaignRoute = (
    *           description: Invalid campaign type, not owned by user
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get(
     '/protect/upload/start',
@@ -777,8 +1315,42 @@ export const InitEmailCampaignRoute = (
    *           description: Bad Request
    *         "401":
    *           description: Unauthorized
+   *         "403":
+   *           description: Forbidden. Request violates firewall rules.
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.post(
     '/protect/upload/complete',
@@ -809,6 +1381,8 @@ export const InitEmailCampaignRoute = (
    *          application/json:
    *            schema:
    *              type: object
+   *              required:
+   *                - name
    *              properties:
    *                name:
    *                  type: string
@@ -816,12 +1390,48 @@ export const InitEmailCampaignRoute = (
    *      responses:
    *        "201":
    *           description: A duplicate of the campaign was created
+   *           content:
+   *            application/json:
+   *              schema:
+   *                $ref: '#/components/schemas/CampaignDuplicateMeta'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/duplicate',
@@ -856,12 +1466,46 @@ export const InitEmailCampaignRoute = (
    *      responses:
    *        "201":
    *           description: A duplicate of the campaign was created
+   *           schema:
+   *             $ref: '#/components/schemas/CampaignMeta'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/select-list',

--- a/backend/src/email/routes/email-settings.routes.ts
+++ b/backend/src/email/routes/email-settings.routes.ts
@@ -25,8 +25,6 @@ export const InitEmailSettingsRoute = (
    * paths:
    *  /settings/email/from/verify:
    *    post:
-   *      security:
-   *        - bearerAuth: []
    *      summary: Verifies a custom from email address
    *      description: >
    *        Verifies a custom from email address to see if it can be used to send out emails.

--- a/backend/src/email/routes/email-settings.routes.ts
+++ b/backend/src/email/routes/email-settings.routes.ts
@@ -22,7 +22,6 @@ export const InitEmailSettingsRoute = (
   }
 
   /**
-   * @swagger
    * paths:
    *  /settings/email/from/verify:
    *    post:
@@ -137,7 +136,6 @@ export const InitEmailSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/email/from:
    *    get:

--- a/backend/src/sms/routes/sms-callback.routes.ts
+++ b/backend/src/sms/routes/sms-callback.routes.ts
@@ -3,7 +3,6 @@ import { SmsCallbackMiddleware } from '@sms/middlewares'
 const router = Router()
 
 /**
- * @swagger
  * paths:
  *  /callback/sms/{campaignId}/{messageId}:
  *    post:

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -105,14 +105,51 @@ export const InitSmsCampaignRoute = (
    *          content:
    *            application/json:
    *              schema:
-   *                $ref: '#/components/schemas/SMSCampaign'
+   *                allOf:
+   *                - $ref: '#/components/schemas/SMSCampaign'
+   *                - type: object
+   *                  properties:
+   *                    cost_per_message:
+   *                      type: number
    *
    *        "401":
    *           description: Unauthorized
    *        "403" :
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/', smsMiddleware.getCampaignDetails)
 
@@ -179,8 +216,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.put(
     '/template',
@@ -231,8 +300,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.get(
     '/upload/start',
@@ -278,8 +379,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *         "403":
    *          description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.post(
     '/upload/complete',
@@ -322,8 +455,6 @@ export const InitSmsCampaignRoute = (
    *                   preview:
    *                     type: object
    *                     properties:
-   *                       subject:
-   *                         type: string
    *                       body:
    *                         type: string
    *         "400" :
@@ -358,8 +489,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden as there is a job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.delete(
     '/upload/status',
@@ -406,14 +569,52 @@ export const InitSmsCampaignRoute = (
    *            application/json:
    *              schema:
    *                type: object
+   *                required:
+   *                  - message
+   *                properties:
+   *                  message:
+   *                    type: string
+   *                    example: OK
    *        "400" :
    *           description: Bad Request
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/new-credentials',
@@ -460,14 +661,52 @@ export const InitSmsCampaignRoute = (
    *            application/json:
    *              schema:
    *                type: object
+   *                required:
+   *                  - message
+   *                properties:
+   *                  message:
+   *                    type: string
+   *                    example: OK
    *        "400" :
    *           description: Bad Request
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/credentials',
@@ -507,8 +746,42 @@ export const InitSmsCampaignRoute = (
    *                        type: string
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/preview', smsMiddleware.previewFirstMessage)
 
@@ -557,8 +830,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/send',
@@ -588,9 +893,41 @@ export const InitSmsCampaignRoute = (
    *        "401":
    *           description: Unauthorized
    *        "403":
-   *           description: Forbidden, campaign not owned by user
+   *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post('/stop', JobMiddleware.stopCampaign)
 
@@ -616,8 +953,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/retry',
@@ -650,8 +1019,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/stats', SmsStatsMiddleware.getStats)
 
@@ -680,8 +1081,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post('/refresh-stats', SmsStatsMiddleware.updateAndGetStats)
 
@@ -707,15 +1140,47 @@ export const InitSmsCampaignRoute = (
    *              schema:
    *                type: array
    *                items:
-   *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+   *                  $ref: '#/components/schemas/CampaignRecipient'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
    *        "410":
    *           description: Campaign has been redacted
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get(
     '/export',
@@ -743,18 +1208,56 @@ export const InitSmsCampaignRoute = (
    *          application/json:
    *            schema:
    *              type: object
+   *              required:
+   *                - name
    *              properties:
    *                name:
    *                  type: string
    *      responses:
    *        "201":
    *           description: A duplicate of the campaign was created
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/CampaignDuplicateMeta'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/duplicate',
@@ -793,8 +1296,40 @@ export const InitSmsCampaignRoute = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/select-list',

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -90,6 +90,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Get sms campaign details
@@ -158,6 +160,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/sms/template:
    *     put:
+   *       security:
+   *         - bearerAuth: []
    *       tags:
    *         - SMS
    *       summary: Stores body template for sms campaign
@@ -263,6 +267,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/sms/upload/start:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get a presigned URL for upload with Content-MD5 header"
    *       tags:
    *         - SMS
@@ -347,6 +353,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/sms/upload/complete:
    *     post:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Complete upload session with ETag verification"
    *       tags:
    *         - SMS
@@ -426,6 +434,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *   /campaign/{campaignId}/sms/upload/status:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get csv processing status"
    *       tags:
    *         - SMS
@@ -473,6 +483,8 @@ export const InitSmsCampaignRoute = (
    * post:
    *   /campaign/{campaignId}/sms/upload/status:
    *     delete:
+   *       security:
+   *         - bearerAuth: []
    *       description: "Deletes error status from previous failed upload"
    *       tags:
    *         - SMS
@@ -535,6 +547,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/new-credentials:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Validate twilio credentials and assign to campaign, if label is provided - store credentials for user
@@ -633,6 +647,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/credentials:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Validate stored credentials and assign to campaign
@@ -722,6 +738,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/preview:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Preview templated message
@@ -790,6 +808,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/send:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Start sending campaign
@@ -877,6 +897,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/stop:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Stop sending campaign
@@ -936,6 +958,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/retry:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Retry sending campaign
@@ -999,6 +1023,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/stats:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Get sms campaign stats
@@ -1061,6 +1087,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/refresh-stats:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Forcibly refresh sms campaign stats, then retrieves them
@@ -1123,6 +1151,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/export:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Get invalid recipients in campaign
@@ -1193,6 +1223,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/duplicate:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Duplicate the campaign and its template
@@ -1270,6 +1302,8 @@ export const InitSmsCampaignRoute = (
    * paths:
    *  /campaign/{campaignId}/sms/select-list:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - SMS
    *      summary: Select the list of recipients from an existing managed list

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -34,7 +34,6 @@ export const InitSmsSettingsRoute = (
   }
 
   /**
-   * @swagger
    * paths:
    *  /settings/sms/credentials:
    *    post:
@@ -77,7 +76,6 @@ export const InitSmsSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/sms/credentials/verify:
    *    post:

--- a/backend/src/telegram/routes/telegram-callback.routes.ts
+++ b/backend/src/telegram/routes/telegram-callback.routes.ts
@@ -3,7 +3,6 @@ import { TelegramCallbackMiddleware } from '@telegram/middlewares'
 const router = Router()
 
 /**
- * @swagger
  * paths:
  *  /callback/telegram/{botToken}:
  *    post:

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -110,8 +110,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403" :
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/', telegramMiddleware.getCampaignDetails)
 
@@ -178,8 +210,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.put(
     '/template',
@@ -230,8 +294,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.get(
     '/upload/start',
@@ -269,28 +365,48 @@ export const InitTelegramCampaignMiddleware = (
    *                 etag:
    *                   type: string
    *       responses:
-   *         200:
-   *           description: Success
-   *           content:
-   *             application/json:
-   *               schema:
-   *                 properties:
-   *                   num_recipients:
-   *                     type: number
-   *                   preview:
-   *                     type: object
-   *                     properties:
-   *                       body:
-   *                         type: string
-   *
+   *         "202" :
+   *           description: Accepted. The uploaded file is being processed.
    *         "400" :
    *           description: Bad Request
    *         "401":
    *           description: Unauthorized
    *         "403":
    *          description: Forbidden, campaign not owned by user or job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.post(
     '/upload/complete',
@@ -333,8 +449,6 @@ export const InitTelegramCampaignMiddleware = (
    *                   preview:
    *                     type: object
    *                     properties:
-   *                       subject:
-   *                         type: string
    *                       body:
    *                         type: string
    *         "400" :
@@ -343,8 +457,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden as there is a job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.get('/upload/status', TelegramTemplateMiddleware.pollCsvStatusHandler)
 
@@ -369,8 +515,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *         "403":
    *           description: Forbidden as there is a job in progress
+   *         "429":
+   *           description: Rate limit exceeded. Too many requests.
+   *           content:
+   *              application/json:
+   *                schema:
+   *                  $ref: '#/components/schemas/ErrorStatus'
+   *                example:
+   *                  {status: 429, message: Too many requests. Please try again later.}
    *         "500":
    *           description: Internal Server Error
+   *           content:
+   *              text/plain:
+   *                type: string
+   *                example: Internal Server Error
+   *         "502":
+   *           description: Bad Gateway
+   *         "504":
+   *           description: Gateway Timeout
+   *         "503":
+   *           description: Service Temporarily Unavailable
+   *         "520":
+   *           description: Web Server Returns An Unknown Error
+   *         "521":
+   *           description: Web Server Is Down
+   *         "522":
+   *           description: Connection Timed Out
+   *         "523":
+   *           description: Origin Is Unreachable
+   *         "524":
+   *           description: A Timeout occurred
+   *         "525":
+   *           description: SSL handshake failed
+   *         "526":
+   *           description: Invalid SSL certificate
    */
   router.delete(
     '/upload/status',
@@ -407,8 +585,42 @@ export const InitTelegramCampaignMiddleware = (
    *                        type: string
    *        "401":
    *           description: Unauthorized
+   *        "403":
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.get('/preview', telegramMiddleware.previewFirstMessage)
 
@@ -449,14 +661,52 @@ export const InitTelegramCampaignMiddleware = (
    *            application/json:
    *              schema:
    *                type: object
+   *                required:
+   *                  - message
+   *                properties:
+   *                  message:
+   *                    type: string
+   *                    example: OK
    *        "400" :
    *           description: Bad Request
    *        "401":
    *           description: Unauthorized
    *        "403":
-   *           description: Forbidden, campaign not owned by user or job in progress
+   *          description: Forbidden. Request violates firewall rules.
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/new-credentials',
@@ -500,14 +750,52 @@ export const InitTelegramCampaignMiddleware = (
    *            application/json:
    *              schema:
    *                type: object
+   *                required:
+   *                  - message
+   *                properties:
+   *                  message:
+   *                    type: string
+   *                    example: OK
    *        "400" :
    *           description: Bad Request
    *        "401":
    *           description: Unauthorized
    *        "403":
-   *           description: Forbidden, campaign not owned by user or job in progress
+   *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/credentials',
@@ -549,14 +837,52 @@ export const InitTelegramCampaignMiddleware = (
    *            application/json:
    *              schema:
    *                type: object
+   *                required:
+   *                  - message
+   *                properties:
+   *                  message:
+   *                    type: string
+   *                    example: OK
    *        "400" :
    *           description: Bad Request
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL certificate
    */
   router.post(
     '/credentials/verify',
@@ -612,8 +938,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.post(
     '/send',
@@ -644,8 +1002,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.post('/stop', JobMiddleware.stopCampaign)
 
@@ -671,8 +1061,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user or job in progress
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.post(
     '/retry',
@@ -705,8 +1127,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.get('/stats', TelegramStatsMiddleware.getStats)
 
@@ -735,8 +1189,40 @@ export const InitTelegramCampaignMiddleware = (
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.post('/refresh-stats', TelegramStatsMiddleware.updateAndGetStats)
 
@@ -762,15 +1248,47 @@ export const InitTelegramCampaignMiddleware = (
    *              schema:
    *                type: array
    *                items:
-   *                  $ref: '#/components/schemas/CampaignInvalidRecipient'
+   *                  $ref: '#/components/schemas/CampaignRecipient'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
    *        "410":
    *           description: Campaign has been redacted
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.get(
     '/export',
@@ -805,12 +1323,48 @@ export const InitTelegramCampaignMiddleware = (
    *      responses:
    *        "201":
    *           description: A duplicate of the campaign was created
+   *           content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/CampaignDuplicateMeta'
    *        "401":
    *           description: Unauthorized
    *        "403":
    *           description: Forbidden, campaign not owned by user
+   *        "429":
+   *          description: Rate limit exceeded. Too many requests.
+   *          content:
+   *             application/json:
+   *               schema:
+   *                 $ref: '#/components/schemas/ErrorStatus'
+   *               example:
+   *                 {status: 429, message: Too many requests. Please try again later.}
    *        "500":
-   *           description: Internal Server Error
+   *          description: Internal Server Error
+   *          content:
+   *             text/plain:
+   *               type: string
+   *               example: Internal Server Error
+   *        "502":
+   *          description: Bad Gateway
+   *        "504":
+   *          description: Gateway Timeout
+   *        "503":
+   *          description: Service Temporarily Unavailable
+   *        "520":
+   *          description: Web Server Returns An Unknown Error
+   *        "521":
+   *          description: Web Server Is Down
+   *        "522":
+   *          description: Connection Timed Out
+   *        "523":
+   *          description: Origin Is Unreachable
+   *        "524":
+   *          description: A Timeout occurred
+   *        "525":
+   *          description: SSL handshake failed
+   *        "526":
+   *          description: Invalid SSL c
    */
   router.post(
     '/duplicate',

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -85,6 +85,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Get telegram campaign details
@@ -152,6 +154,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *   /campaign/{campaignId}/telegram/template:
    *     put:
+   *       security:
+   *         - bearerAuth: []
    *       tags:
    *         - Telegram
    *       summary: Stores body template for telegram campaign
@@ -257,6 +261,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *   /campaign/{campaignId}/telegram/upload/start:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get a presigned URL for upload with Content-MD5 header"
    *       tags:
    *         - Telegram
@@ -341,6 +347,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *   /campaign/{campaignId}/telegram/upload/complete:
    *     post:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Complete upload session with ETag verification"
    *       tags:
    *         - Telegram
@@ -420,6 +428,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *   /campaign/{campaignId}/telegram/upload/status:
    *     get:
+   *       security:
+   *         - bearerAuth: []
    *       summary: "Get csv processing status"
    *       tags:
    *         - Telegram
@@ -499,6 +509,8 @@ export const InitTelegramCampaignMiddleware = (
    * post:
    *   /campaign/{campaignId}/telegram/upload/status:
    *     delete:
+   *       security:
+   *         - bearerAuth: []
    *       description: "Deletes error status from previous failed upload"
    *       tags:
    *         - Telegram
@@ -561,6 +573,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/preview:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Preview templated message
@@ -629,6 +643,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/new-credentials:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Validate Telegram bot token and assign to campaign, if label is provided store new telegram credentials for user
@@ -724,6 +740,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/credentials:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Validate stored credentials and assign to campaign
@@ -811,6 +829,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/credentials/verify:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Send a validation message using the campaign credentials.
@@ -897,6 +917,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/send:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Start sending campaign
@@ -985,6 +1007,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/stop:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Stop sending campaign
@@ -1044,6 +1068,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/retry:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Retry sending campaign
@@ -1107,6 +1133,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/stats:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Get telegram campaign stats
@@ -1169,6 +1197,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/update-stats:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Get telegram campaign stats
@@ -1231,6 +1261,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/export:
    *    get:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Get invalid recipients in campaign
@@ -1301,6 +1333,8 @@ export const InitTelegramCampaignMiddleware = (
    * paths:
    *  /campaign/{campaignId}/telegram/duplicate:
    *    post:
+   *      security:
+   *        - bearerAuth: []
    *      tags:
    *        - Telegram
    *      summary: Duplicate the campaign and its template

--- a/backend/src/telegram/routes/telegram-settings.routes.ts
+++ b/backend/src/telegram/routes/telegram-settings.routes.ts
@@ -33,7 +33,6 @@ export const InitTelegramSettingsRoute = (
   // Routes
 
   /**
-   * @swagger
    * paths:
    *  /settings/telegram/credentials:
    *    post:
@@ -73,7 +72,6 @@ export const InitTelegramSettingsRoute = (
   )
 
   /**
-   * @swagger
    * paths:
    *  /settings/telegram/credentials/verify:
    *    post:


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Revise-cookie-API-authentication-1fcff2fca43d425a9e735350f5734e0e)

## Solution

- Make auth middleware modular
- Restrict non-API-exposed endpoints to be cookie-only
- Remove non-API-exposed from our published swagger doc

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- N/A
