### PR TITLE
fix(backend): exclude not-spam complainer from blacklist

### DIFF
--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -122,10 +122,13 @@ const shouldBlacklist = ({
   bounceType?: string
   complaintType?: string
 }): boolean => {
-  return (
-    (notificationType === 'Bounce' && bounceType === 'Permanent') ||
-    (notificationType === 'Complaint' && !!complaintType)
-  )
+  const isHardBounced =
+    notificationType === 'Bounce' && bounceType === 'Permanent'
+  const isNegativelyCompplained =
+    notificationType === 'Complaint' &&
+    !!complaintType &&
+    complaintType !== 'not-spam'
+  return isHardBounced || isNegativelyCompplained
 }
 
 const parseNotificationAndEvent = async (

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -124,11 +124,11 @@ const shouldBlacklist = ({
 }): boolean => {
   const isHardBounced =
     notificationType === 'Bounce' && bounceType === 'Permanent'
-  const isNegativelyCompplained =
+  const isNegativelyComplained =
     notificationType === 'Complaint' &&
     !!complaintType &&
     complaintType !== 'not-spam'
-  return isHardBounced || isNegativelyCompplained
+  return isHardBounced || isNegativelyComplained
 }
 
 const parseNotificationAndEvent = async (


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Discuss-account-suppression-list-and-blacklist-cd1e0863ceda46c288a1dcd4df4bd708)

## Solution

Exclude `not-spam` complaints from blacklist

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- N/A