### PR TITLE
feat: bcc campaign messages to author

### DIFF
--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -134,7 +134,11 @@ const expressApp = ({ app }: { app: express.Application }): void => {
     ) => {
       logger.error({
         message: 'Unexpected error occured',
-        error: `${err.stack}`,
+        error: {
+          message: `${err.stack}`,
+          parent: (err as any).parent,
+          original: (err as any).original,
+        },
       })
       return res.sendStatus(500)
     }

--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -197,11 +197,12 @@ const updateCampaign = async (
 ): Promise<Response | void> => {
   try {
     const { campaignId } = req.params
-    const { name, should_save_list } = req.body
+    const { name, should_save_list, should_bcc_to_me } = req.body
     const [count, rows] = await CampaignService.updateCampaign({
       id: +campaignId,
       name,
       shouldSaveList: should_save_list,
+      shouldBccToMe: should_bcc_to_me,
     } as Campaign)
     if (count < 1) {
       logger.error({

--- a/backend/src/core/models/campaign.ts
+++ b/backend/src/core/models/campaign.ts
@@ -104,6 +104,12 @@ export class Campaign extends Model<Campaign> {
   })
   demoMessageLimit!: number
 
+  @Column({
+    type: DataType.BOOLEAN,
+    defaultValue: false,
+  })
+  shouldBccToMe!: boolean
+
   // Sets key in s3Object json
   static async updateS3ObjectKey(
     id: number,

--- a/backend/src/core/routes/campaign.routes.ts
+++ b/backend/src/core/routes/campaign.routes.ts
@@ -43,6 +43,8 @@ const updateCampaignValidator = {
   [Segments.BODY]: Joi.object({
     name: Joi.string().max(255).trim(),
     should_save_list: Joi.boolean().allow(null),
+    // only applicable to email campaigns
+    should_bcc_to_me: Joi.boolean().allow(null),
   }),
 }
 

--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -322,6 +322,7 @@ const getCampaignDetails = async (
       'protect',
       'demo_message_limit',
       'should_save_list',
+      'should_bcc_to_me',
       's3_object',
       [literal('cred_name IS NOT NULL'), 'has_credential'],
       [literal("s3_object -> 'filename'"), 'csv_filename'],

--- a/backend/src/database/migrations/20221208074426-add-should-campaign-should-bcc.js
+++ b/backend/src/database/migrations/20221208074426-add-should-campaign-should-bcc.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('campaigns', 'should_bcc_to_me', {
+      type: Sequelize.DataTypes.BOOLEAN,
+      defaultValue: false,
+      allowNull: false,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('campaigns', 'should_bcc_to_me')
+  },
+}

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -284,12 +284,18 @@ const uploadCompleteOnChunk = ({
   campaignId: number
 }): ((data: CSVParams[]) => Promise<void>) => {
   return async (data: CSVParams[]): Promise<void> => {
+    const { shouldBccToMe, user } = (await Campaign.findOne({
+      where: {
+        id: campaignId,
+      },
+      include: User,
+    })) as Campaign
     const records: Array<MessageBulkInsertInterface> = data.map((entry) => {
       const { recipient } = entry
       return {
         campaignId,
         recipient: recipient.trim().toLowerCase(),
-        params: entry,
+        params: shouldBccToMe ? { ...entry, bcc: user.email } : entry,
       }
     })
     // START populate template

--- a/frontend/src/classes/EmailCampaign.ts
+++ b/frontend/src/classes/EmailCampaign.ts
@@ -40,6 +40,7 @@ export class EmailCampaign extends Campaign {
   agencyLogoURI: string
   themedBody: string
   progress: EmailProgress = EmailProgress.CreateTemplate
+  shouldBccToMe: boolean
 
   constructor(input: any) {
     super(input)
@@ -56,6 +57,7 @@ export class EmailCampaign extends Campaign {
     this.agencyName = input['user']?.domain?.agency?.name
     this.agencyLogoURI = input['user']?.domain?.agency?.logo_uri
     this.setProgress()
+    this.shouldBccToMe = input.should_bcc_to_me || false
   }
 
   setProgress() {

--- a/frontend/src/components/dashboard/campaigns/Campaigns.tsx
+++ b/frontend/src/components/dashboard/campaigns/Campaigns.tsx
@@ -58,7 +58,7 @@ import { ModalContext } from 'contexts/modal.context'
 import {
   deleteCampaignById,
   getCampaigns,
-  renameCampaign,
+  updateCampaign,
 } from 'services/campaign.service'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 
@@ -195,7 +195,9 @@ const Campaigns = () => {
   )
 
   async function handleRename(): Promise<void> {
-    await renameCampaign(campaignIdWithRenameOpen as number, campaignNewName)
+    await updateCampaign(campaignIdWithRenameOpen as number, {
+      name: campaignNewName,
+    })
     setCampaignsDisplayed(
       campaignsDisplayed.map((c) => {
         if (c.id === campaignIdWithRenameOpen) {

--- a/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailRecipients.tsx
@@ -37,7 +37,7 @@ import {
 import { LINKS } from 'config'
 import { CampaignContext } from 'contexts/campaign.context'
 
-import { setCampaignToSaveList } from 'services/campaign.service'
+import { updateCampaign as apiUpdateCampaign } from 'services/campaign.service'
 import { sendTiming } from 'services/ga.service'
 import { selectList, getListsByChannel } from 'services/list.service'
 import {
@@ -175,7 +175,7 @@ const EmailRecipients = ({
 
   // If shouldSaveList is modified, send info to backend
   useEffect(() => {
-    void setCampaignToSaveList(campaignId as string, shouldSaveList)
+    void apiUpdateCampaign(campaignId as string, { shouldSaveList })
   }, [campaignId, shouldSaveList])
 
   // Handle file upload

--- a/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSRecipients.tsx
@@ -35,7 +35,7 @@ import {
 import { LINKS } from 'config'
 import { CampaignContext } from 'contexts/campaign.context'
 
-import { setCampaignToSaveList } from 'services/campaign.service'
+import { updateCampaign as apiUpdateCampaign } from 'services/campaign.service'
 import { sendTiming } from 'services/ga.service'
 import { selectList, getListsByChannel } from 'services/list.service'
 import {
@@ -166,7 +166,7 @@ const SMSRecipients = ({
 
   // If shouldSaveList is modified, send info to backend
   useEffect(() => {
-    void setCampaignToSaveList(campaignId as string, shouldSaveList)
+    void apiUpdateCampaign(campaignId as string, { shouldSaveList })
   }, [campaignId, shouldSaveList])
 
   // Handle file upload

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -224,3 +224,22 @@ export async function setCampaignToSaveList(
     should_save_list: shouldSaveList,
   })
 }
+
+export async function updateCampaign(
+  campaignId: string | number,
+  {
+    name,
+    shouldBccToMe,
+    shouldSaveList,
+  }: {
+    name?: string
+    shouldSaveList?: boolean
+    shouldBccToMe?: boolean
+  }
+): Promise<void> {
+  return axios.put(`/campaigns/${campaignId}`, {
+    name,
+    should_save_list: shouldSaveList,
+    should_bcc_to_me: shouldBccToMe,
+  })
+}

--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -83,6 +83,7 @@ export default class MailClient {
         html: input.body,
         headers,
         attachments: input.attachments,
+        bcc: input.bcc,
       }
 
       this.mailer.sendMail(options, (err, info) => {

--- a/shared/src/clients/mail-client.class/interfaces.ts
+++ b/shared/src/clients/mail-client.class/interfaces.ts
@@ -12,6 +12,7 @@ export interface MailToSend {
   from?: string
   unsubLink?: string
   attachments?: Array<MailAttachment>
+  bcc?: Array<string>
 }
 
 export interface MailCredentials {

--- a/worker/src/core/loaders/message-worker/email.class.ts
+++ b/worker/src/core/loaders/message-worker/email.class.ts
@@ -146,6 +146,7 @@ class Email {
         body: themedHTMLEmail,
         referenceId: String(id),
         unsubLink,
+        bcc: params.bcc ? params.bcc.split(',') : undefined,
         ...(replyTo ? { replyTo } : {}),
       })
 


### PR DESCRIPTION
## Problem


Closes [Ticket](https://www.notion.so/opengov/BCC-on-Postman-852b225df35a42b2bb034eaf38efd2c6)

## Solution

Implement it duh

**Some extra notes**: This PR was implemented with future "bcc to anyone" possibility in mind, hence going through the hoop of putting `bcc` inside the params. However, we haven't handled bounces and other notifications that are related to the bcc instead of the main email properly yet but for now since it's only `bcc`-ed to the main user email, we can perhaps live with this

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] Migrate DB