### PR TITLE
feat: save transactional sms

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3255,11 +3255,14 @@ paths:
                   type: string
                 label:
                   type: string
-      # TODO feels like this is lacking a schema component?
       responses:
-        "202":
-          description: Accepted. The message is being sent.
-        "400":
+        '201':
+          description: Created. The message is being sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SmsMessageTransactional'
+        '400':
           description: Bad Request
         "401":
           description: Unauthorized
@@ -4826,6 +4829,30 @@ components:
               type: array
               items:
                 type: string
+    SmsMessageTransactional:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 42
+        credentials_label:
+          type: string
+          example: "ogp-twilio-creds"
+        recipient:
+          type: string
+          example: "98765432"
+        body:
+          type: string
+          example: "Hello world"
+        message_id:
+          type: string
+          example: "SM12345678901234567890123456789012"
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
     TelegramCampaign:
       type: object
       properties:

--- a/backend/src/core/models/initialize-models.ts
+++ b/backend/src/core/models/initialize-models.ts
@@ -24,7 +24,12 @@ import {
   EmailOp,
   EmailTemplate,
 } from '@email/models'
-import { SmsMessage, SmsTemplate, SmsOp } from '@sms/models'
+import {
+  SmsMessage,
+  SmsMessageTransactional,
+  SmsTemplate,
+  SmsOp,
+} from '@sms/models'
 import {
   BotSubscriber,
   TelegramMessage,
@@ -59,7 +64,7 @@ export const initializeModels = (sequelize: Sequelize): void => {
     EmailTemplate,
     ProtectedMessage,
   ]
-  const smsModels = [SmsMessage, SmsTemplate, SmsOp]
+  const smsModels = [SmsMessage, SmsMessageTransactional, SmsTemplate, SmsOp]
   const telegramModels = [
     BotSubscriber,
     TelegramOp,

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -33,7 +33,10 @@ export interface CredentialService {
     userId: number
   ): Promise<UserCredential>
   deleteUserCredential(userId: number, label: string): Promise<number>
-  getUserCredential(userId: number, label: string): Promise<UserCredential>
+  getUserCredential(
+    userId: number,
+    label: string
+  ): Promise<UserCredential | null>
   getSmsUserCredentialLabels(userId: number): Promise<string[]>
   getTelegramUserCredentialLabels(userId: number): Promise<string[]>
   getUserSettings(userId: number): Promise<UserSettings | null>
@@ -241,14 +244,14 @@ export const InitCredentialService = (redisService: RedisService) => {
   const getUserCredential = (
     userId: number,
     label: string
-  ): Promise<UserCredential> => {
+  ): Promise<UserCredential | null> => {
     return UserCredential.findOne({
       where: {
         userId,
         label,
       },
       attributes: ['credName'],
-    }) as Promise<UserCredential>
+    })
   }
 
   /**

--- a/backend/src/database/migrations/20221214101846-create-sms-message-transactional.js
+++ b/backend/src/database/migrations/20221214101846-create-sms-message-transactional.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
@@ -33,10 +33,18 @@ module.exports = {
         type: Sequelize.DataTypes.STRING(255),
         allowNull: true,
       },
+      created_at: {
+        allowNull: false,
+        type: Sequelize.DataTypes.DATE,
+      },
+      updated_at: {
+        allowNull: false,
+        type: Sequelize.DataTypes.DATE,
+      },
     })
   },
 
   down: async (queryInterface, _) => {
     await queryInterface.dropTable('sms_messages_transactional')
-  }
-};
+  },
+}

--- a/backend/src/database/migrations/20221214101846-create-sms-message-transactional.js
+++ b/backend/src/database/migrations/20221214101846-create-sms-message-transactional.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('sms_messages_transactional', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.BIGINT,
+      },
+      user_id: {
+        type: Sequelize.DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+      },
+      credentials_label: {
+        allowNull: false,
+        type: Sequelize.DataTypes.STRING(255),
+      },
+      recipient: {
+        allowNull: false,
+        type: Sequelize.DataTypes.STRING(255),
+      },
+      body: {
+        allowNull: false,
+        type: Sequelize.DataTypes.STRING(255),
+      },
+      message_id: {
+        type: Sequelize.DataTypes.STRING(255),
+        allowNull: true,
+      },
+    })
+  },
+
+  down: async (queryInterface, _) => {
+    await queryInterface.dropTable('sms_messages_transactional')
+  }
+};

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction, Handler } from 'express'
+import { Handler, NextFunction, Request, Response } from 'express'
 import { ChannelType, DefaultCredentialName } from '@core/constants'
 import { CredentialService } from '@core/services'
 import { SmsService } from '@sms/services'
@@ -8,7 +8,8 @@ import { formatDefaultCredentialName } from '@core/utils'
 
 export interface SmsMiddleware {
   getCredentialsFromBody: Handler
-  getCredentialsFromLabel: Handler
+  getCredentialsFromLabelCampaign: Handler
+  getCredentialsFromLabelTransactional: Handler
   isSmsCampaignOwnedByUser: Handler
   validateAndStoreCredentials: Handler
   setCampaignCredential: Handler
@@ -119,20 +120,11 @@ export const InitSmsMiddleware = (
     userId: number
   ): Promise<string> => {
     // Non-demo campaigns cannot use default credentials
-    if (label === DefaultCredentialName.SMS) {
-      throw new Error(
-        `Campaign cannot use demo credentials. ${label} is not allowed.`
-      )
-    } else {
-      // if label provided, fetch from aws secrets
-      const userCred = await credentialService.getUserCredential(userId, label)
-
-      if (!userCred) {
-        throw new Error('User credential cannot be found')
-      }
-
-      return userCred.credName
+    const userCred = await credentialService.getUserCredential(userId, label)
+    if (!userCred) {
+      throw new Error('User credential cannot be found')
     }
+    return userCred.credName
   }
 
   /**
@@ -142,7 +134,7 @@ export const InitSmsMiddleware = (
    * @param res
    * @param next
    */
-  const getCredentialsFromLabel = async (
+  const getCredentialsFromLabelCampaign = async (
     req: Request,
     res: Response,
     next: NextFunction
@@ -153,22 +145,58 @@ export const InitSmsMiddleware = (
     const logMeta = {
       campaignId,
       label,
-      action: 'getCredentialsFromLabel',
+      action: 'getCredentialsFromLabelCampaign',
     }
     try {
       /* Determine if credential name can be used */
       const campaign = campaignId
         ? await SmsService.findCampaign(+campaignId, userId)
         : null
-      const credentialName = campaign?.demoMessageLimit
+      const canUseDemoCredentials = !!campaign?.demoMessageLimit // false if (1) campaign is null or (2) demoMessageLimit is 0
+      if (!canUseDemoCredentials && label === DefaultCredentialName.SMS) {
+        throw new Error(
+          `Campaign cannot use demo credentials. ${label} is not allowed.`
+        )
+      }
+      const credentialName = canUseDemoCredentials
         ? getDemoCredentialName(label)
         : await getCredentialName(label, +userId)
 
       /* Get credential from the name */
-      const credentials = await credentialService.getTwilioCredentials(
+      res.locals.credentials = await credentialService.getTwilioCredentials(
         credentialName
       )
-      res.locals.credentials = credentials
+      res.locals.credentialName = credentialName
+      return next()
+    } catch (err) {
+      const errAsError = err as Error
+      logger.error({
+        ...logMeta,
+        message: `${errAsError.stack}`,
+      })
+      return res.status(400).json({ message: `${errAsError.message}` })
+    }
+  }
+
+  const getCredentialsFromLabelTransactional = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void | Response> => {
+    const { label } = req.body
+    const userId = req.session?.user?.id
+    const logMeta = {
+      label,
+      action: 'getCredentialsFromLabelTransactional',
+    }
+    try {
+      /* Determine if credential name can be used */
+      const credentialName = await getCredentialName(label, +userId)
+
+      /* Get credential from the name */
+      res.locals.credentials = await credentialService.getTwilioCredentials(
+        credentialName
+      )
       res.locals.credentialName = credentialName
       return next()
     } catch (err) {
@@ -187,6 +215,7 @@ export const InitSmsMiddleware = (
    * Set the credentialName and channelType in res.locals to be passed downstream
    * @param req
    * @param res
+   * @param next
    */
   const validateAndStoreCredentials = async (
     req: Request,
@@ -388,7 +417,8 @@ export const InitSmsMiddleware = (
 
   return {
     getCredentialsFromBody,
-    getCredentialsFromLabel,
+    getCredentialsFromLabelCampaign,
+    getCredentialsFromLabelTransactional,
     isSmsCampaignOwnedByUser,
     validateAndStoreCredentials,
     setCampaignCredential,

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -152,7 +152,8 @@ export const InitSmsMiddleware = (
       const campaign = campaignId
         ? await SmsService.findCampaign(+campaignId, userId)
         : null
-      const canUseDemoCredentials = !!campaign?.demoMessageLimit // false if (1) campaign is null or (2) demoMessageLimit is 0
+      const canUseDemoCredentials =
+        campaign?.demoMessageLimit && campaign?.demoMessageLimit > 0
       if (!canUseDemoCredentials && label === DefaultCredentialName.SMS) {
         throw new Error(
           `Campaign cannot use demo credentials. ${label} is not allowed.`

--- a/backend/src/sms/models/index.ts
+++ b/backend/src/sms/models/index.ts
@@ -1,3 +1,4 @@
 export * from './sms-message'
+export * from './sms-message-transactional'
 export * from './sms-template'
 export * from './sms-op'

--- a/backend/src/sms/models/sms-message-transactional.ts
+++ b/backend/src/sms/models/sms-message-transactional.ts
@@ -1,0 +1,41 @@
+import { UserCredential } from '@core/models'
+import { User } from '@core/models/user/user'
+import {
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  Table,
+} from 'sequelize-typescript'
+
+@Table({
+  tableName: 'sms_messages_transactional',
+  underscored: true,
+  timestamps: true,
+})
+export class SmsMessageTransactional extends Model<SmsMessageTransactional> {
+  @Column({
+    type: DataType.BIGINT,
+    autoIncrement: true,
+    primaryKey: true,
+    allowNull: false,
+  })
+  id: number
+
+  @ForeignKey(() => User)
+  @Column({ type: DataType.STRING, allowNull: false })
+  userId: string
+
+  @ForeignKey(() => UserCredential)
+  @Column({ type: DataType.STRING, allowNull: false })
+  credentialsLabel: string
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  recipient: string
+
+  @Column({ type: DataType.STRING, allowNull: false })
+  body: string
+
+  @Column({ type: DataType.STRING, allowNull: true })
+  messageId: string | null
+}

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -133,7 +133,7 @@ export const InitSmsCampaignRoute = (
     '/credentials',
     celebrate(useCredentialsValidator),
     CampaignMiddleware.canEditCampaign,
-    smsMiddleware.getCredentialsFromLabel,
+    smsMiddleware.getCredentialsFromLabelCampaign,
     smsMiddleware.validateAndStoreCredentials,
     smsMiddleware.setCampaignCredential
   )

--- a/backend/src/sms/routes/sms-settings.routes.ts
+++ b/backend/src/sms/routes/sms-settings.routes.ts
@@ -105,7 +105,7 @@ export const InitSmsSettingsRoute = (
     '/credentials/verify',
     celebrate(verifyCredentialValidator),
     smsMiddleware.canValidateCredentials,
-    smsMiddleware.getCredentialsFromLabel,
+    smsMiddleware.getCredentialsFromLabelCampaign,
     smsMiddleware.validateAndStoreCredentials,
     (_req: Request, res: Response) => res.sendStatus(200)
   )

--- a/backend/src/sms/routes/sms-transactional.routes.ts
+++ b/backend/src/sms/routes/sms-transactional.routes.ts
@@ -21,7 +21,8 @@ export const InitSmsTransactionalRoute = (
   router.post(
     '/send',
     celebrate(sendValidator),
-    smsMiddleware.getCredentialsFromLabel,
+    SmsTransactionalMiddleware.saveMessage,
+    smsMiddleware.getCredentialsFromLabelTransactional,
     SmsTransactionalMiddleware.sendMessage
   )
 

--- a/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
@@ -10,6 +10,7 @@ import { SmsService } from '@sms/services'
 import { mockSecretsManager } from '@mocks/aws-sdk'
 import initialiseServer from '@test-utils/server'
 import sequelizeLoader from '@test-utils/sequelize-loader'
+import { SmsMessageTransactional } from '@sms/models'
 
 const TEST_TWILIO_CREDENTIALS = {
   accountSid: '',
@@ -20,26 +21,24 @@ const TEST_TWILIO_CREDENTIALS = {
 
 let sequelize: Sequelize
 let user: User
-let userId = 1
 let apiKey: string
 let credential: Credential
-let userCredential: UserCredential
 
 const app = initialiseServer(false)
 
 beforeEach(async () => {
   user = await User.create({
-    id: userId,
-    email: `user_${userId}@agency.gov.sg`,
+    id: 1,
+    email: 'user_1@agency.gov.sg',
   } as User)
+  const userId = user.id
   apiKey = await user.regenerateAndSaveApiKey()
-  userCredential = await UserCredential.create({
+  await UserCredential.create({
     label: `twilio-${userId}`,
     type: ChannelType.SMS,
     credName: credential.name,
     userId,
   } as UserCredential)
-  userId += 1
 })
 
 beforeAll(async () => {
@@ -47,17 +46,25 @@ beforeAll(async () => {
   credential = await Credential.create({ name: 'twilio' } as Credential)
 })
 
-afterEach(() => jest.clearAllMocks())
+afterEach(async () => {
+  jest.clearAllMocks()
+  await SmsMessageTransactional.destroy({ where: {} })
+  await User.destroy({ where: {} })
+  await UserCredential.destroy({ where: {} })
+})
 
 afterAll(async () => {
-  await Credential.destroy({ where: {} })
-  await UserCredential.destroy({ where: {} })
-  await User.destroy({ where: {} })
   await sequelize.close()
   await (app as any).cleanup()
 })
 
 describe('POST /transactional/sms/send', () => {
+  const validApiCall = {
+    body: 'Hello world',
+    recipient: '98765432',
+    label: 'twilio-1',
+  }
+
   test('Should throw an error if API key is invalid', async () => {
     const res = await request(app)
       .post('/transactional/sms/send')
@@ -77,9 +84,10 @@ describe('POST /transactional/sms/send', () => {
   })
 
   test('Should send a message successfully', async () => {
+    const mockSendMessageResolvedValue = 'message_id'
     const mockSendMessage = jest
       .spyOn(SmsService, 'sendMessage')
-      .mockResolvedValue('message_id')
+      .mockResolvedValue(mockSendMessageResolvedValue)
     mockSecretsManager.getSecretValue().promise.mockResolvedValueOnce({
       SecretString: JSON.stringify(TEST_TWILIO_CREDENTIALS),
     })
@@ -87,14 +95,21 @@ describe('POST /transactional/sms/send', () => {
     const res = await request(app)
       .post('/transactional/sms/send')
       .set('Authorization', `Bearer ${apiKey}`)
-      .send({
-        recipient: '91234567',
-        body: 'body',
-        label: userCredential.label,
-      })
+      .send(validApiCall)
 
     expect(res.status).toBe(201)
     expect(mockSendMessage).toBeCalledTimes(1)
+    const transactionalSms = await SmsMessageTransactional.findOne({
+      where: { userId: user.id.toString() },
+    })
+    expect(transactionalSms).not.toBeNull()
+    expect(transactionalSms).toMatchObject({
+      recipient: validApiCall.recipient,
+      body: validApiCall.body,
+      userId: user.id.toString(),
+      credentialsLabel: validApiCall.label,
+      messageId: mockSendMessageResolvedValue,
+    })
     mockSendMessage.mockReset()
   })
 
@@ -109,11 +124,7 @@ describe('POST /transactional/sms/send', () => {
     const res = await request(app)
       .post('/transactional/sms/send')
       .set('Authorization', `Bearer ${apiKey}`)
-      .send({
-        recipient: '91234567',
-        body: 'body',
-        label: userCredential.label,
-      })
+      .send(validApiCall)
 
     expect(res.status).toBe(400)
     expect(mockSendMessage).toBeCalledTimes(1)
@@ -131,11 +142,7 @@ describe('POST /transactional/sms/send', () => {
     const res = await request(app)
       .post('/transactional/sms/send')
       .set('Authorization', `Bearer ${apiKey}`)
-      .send({
-        recipient: '91234567',
-        body: 'body',
-        label: userCredential.label,
-      })
+      .send(validApiCall)
 
     expect(res.status).toBe(400)
     expect(mockSendMessage).toBeCalledTimes(1)
@@ -153,11 +160,7 @@ describe('POST /transactional/sms/send', () => {
     const res = await request(app)
       .post('/transactional/sms/send')
       .set('Authorization', `Bearer ${apiKey}`)
-      .send({
-        recipient: '91234567',
-        body: 'body',
-        label: userCredential.label,
-      })
+      .send(validApiCall)
 
     expect(res.status).toBe(429)
     expect(mockSendMessage).toBeCalledTimes(1)

--- a/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
@@ -93,7 +93,7 @@ describe('POST /transactional/sms/send', () => {
         label: userCredential.label,
       })
 
-    expect(res.status).toBe(202)
+    expect(res.status).toBe(201)
     expect(mockSendMessage).toBeCalledTimes(1)
     mockSendMessage.mockReset()
   })

--- a/backend/src/sms/services/sms-transactional.service.ts
+++ b/backend/src/sms/services/sms-transactional.service.ts
@@ -18,7 +18,7 @@ async function sendMessage({
   credentials: TwilioCredentials
   body: string
   recipient: string
-}): Promise<void> {
+}): Promise<string | void> {
   const sanitizedBody =
     SmsTemplateService.client.replaceNewLinesAndSanitize(body)
   if (!sanitizedBody) {
@@ -28,10 +28,10 @@ async function sendMessage({
   }
 
   logger.info({
-    message: 'Sending transactional SMS',
+    message: 'Sending transactional SMS (service)',
     action: 'sendMessage',
   })
-  await SmsService.sendMessage(credentials, recipient, sanitizedBody)
+  return await SmsService.sendMessage(credentials, recipient, sanitizedBody)
 }
 
 export const SmsTransactionalService = {


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/fd466213f133486d85e4117f1ded521d?v=052d3609255c4dfcb2cf173aae7f7c5d&p=5114247758dd4f08997924f32e9f99c3&pm=s)

[RFC](https://www.notion.so/opengov/2022-12-13-RFC-for-Saving-SMSes-Sent-via-API-1eefc5346aae48d996786ae04ad57437)

Reviewers, please read the RFC + review the implementation.

Remaining tasks are:
- [x] Add tests
- [x] Update OpenAPI schema
- [x] Test on staging (works as intended!)

Deployment notes:
- [ ] Run database migration first (alr migrated on staging; to reverse if there are any changes to the migration history caa 16 Dec 2022)
- [ ] Need to do the following, need to grant permissions to `flamingo_iam` first (because new table is created). Specifically:
  - [ ] SSH to jumphost (`npm run connectjumphost:${staging|prod}`), connect to RDS via `psql -h <XXX>.rds.amazonaws.com -p 5432 -U <user_name><db_name> -W`
  - [ ] Run `GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO flamingo_iam;` (NB semi colon is important)
  - [ ] Run `GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO flamingo_iam;` (NB semi colon is important)