### PR TITLE
docs(api): removed .doc, .ppt, .xls from attachment file types supported

### DIFF
--- a/backend/src/core/services/file-extensions.service.ts
+++ b/backend/src/core/services/file-extensions.service.ts
@@ -6,7 +6,6 @@ const DEFAULT_ALLOWED_EXTENSIONS = [
   'bmp',
   'csv',
   'dgn',
-  'doc',
   'docx',
   'dwf',
   'dwg',
@@ -24,7 +23,6 @@ const DEFAULT_ALLOWED_EXTENSIONS = [
   'ods',
   'pdf',
   'png',
-  'ppt',
   'pptx',
   'rtf',
   'sxc',
@@ -35,7 +33,6 @@ const DEFAULT_ALLOWED_EXTENSIONS = [
   'tiff',
   'txt',
   'wmv',
-  'xls',
   'xlsx',
 ]
 

--- a/docs/supported-file-types.md
+++ b/docs/supported-file-types.md
@@ -5,7 +5,6 @@
 - bmp
 - csv
 - dgn
-- doc
 - docx
 - dwf
 - dwg
@@ -23,7 +22,6 @@
 - ods
 - pdf
 - png
-- ppt
 - pptx
 - rtf
 - sxc
@@ -34,5 +32,4 @@
 - tiff
 - txt
 - wmv
-- xls
 - xlsx


### PR DESCRIPTION
the library file-type we use currently does not accept cfb file types because these file types are old formats of Microsoft (.doc, .xls, .ppt) can be weaponized and exploited for malicious usecases. more on this [here](https://www.decalage.info/en/book/export/html/55).

the team decided to disallow cfb file types for 2 reasons:

keeping our system more secure by avoiding highly exploitable file types
aligning our practices with go.gov.sg which we intend to transit over our attachments in the longer run
list of cfb file types that we will not support:

.doc - Microsoft Word 97-2003 Document
.xls - Microsoft Excel 97-2003 Document
.ppt - Microsoft PowerPoint97-2003 Document