### PR TITLE
announcement: schedule send (draft)

### DIFF
--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -111,11 +111,11 @@ msgstr "null"
 
 #: config.ts:105
 msgid "announcement.subtext"
-msgstr "Say goodbye to sending your campaigns after work hours! You can now prepare your campaign in advance, schedule and sit back while we send your campaign at a later time."
+msgstr "Say goodbye to sending your campaigns after work hours! \n You can now prepare your campaign in advance, schedule and sit back while we send your campaign at a later time."
 
 #: config.ts:104
 msgid "announcement.title"
-msgstr "Scheduled campaigns is here!"
+msgstr "Scheduled campaign is here!"
 
 #: components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
 #: config.ts:88

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -91,15 +91,15 @@ msgstr "file.go.gov.sg;file.for.sg;file.for.edu.sg"
 
 #: config.ts:106
 msgid "announcement.mediaUrl"
-msgstr "https://file.go.gov.sg/dz52q4.png"
+msgstr "https://file.go.gov.sg/scheduled-send-modal.png"
 
 #: config.ts:108
 msgid "announcement.primaryButtonText"
-msgstr "Read our guide here"
+msgstr "Find out how"
 
 #: config.ts:107
 msgid "announcement.primaryButtonUrl"
-msgstr "https://guide.postman.gov.sg/release-notes"
+msgstr "https://go.gov.sg/postman-scheduled-send"
 
 #: config.ts:110
 msgid "announcement.secondaryButtonText"
@@ -111,11 +111,11 @@ msgstr "null"
 
 #: config.ts:105
 msgid "announcement.subtext"
-msgstr "You can now prepare your campaign in advance and schedule it to be sent at a later time."
+msgstr "Say goodbye to sending your campaigns after work hours! You can now prepare your campaign in advance, schedule and sit back while we send your campaign at a later time."
 
 #: config.ts:104
 msgid "announcement.title"
-msgstr "Scheduled sending is here!"
+msgstr "Scheduled campaigns is here!"
 
 #: components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
 #: config.ts:88

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -95,7 +95,7 @@ msgstr "https://file.go.gov.sg/dz52q4.png"
 
 #: config.ts:108
 msgid "announcement.primaryButtonText"
-msgstr "Read guide"
+msgstr "Read our guide here"
 
 #: config.ts:107
 msgid "announcement.primaryButtonUrl"
@@ -111,11 +111,11 @@ msgstr "null"
 
 #: config.ts:105
 msgid "announcement.subtext"
-msgstr "Thanks for using Postman and joining us every step of the way while we mature as a product. We'll be releasing exciting new features this year. For instance, this is an announcement modal that will keep you up-to-date about our new features! Watch this space for things that are brewing. Learn more about Postman's releases by reading our guide."
+msgstr "You can now prepare your campaign in advance and schedule it to be sent at a later time."
 
 #: config.ts:104
 msgid "announcement.title"
-msgstr "Happy New Year! Congrats on making it through 2020."
+msgstr "Scheduled sending is here!"
 
 #: components/dashboard/settings/custom-from-address/CustomFromAddress.tsx:74
 #: config.ts:88


### PR DESCRIPTION
We are releasing Schedule Send on 27 Dec 2022 and this will be communicated to our users via our announcement modal on postman.gov.sg

pending items
- [ ] image @khaleedah 
- [ ] link to guide @kendra-wong 
- [ ] final copy including the 2 above @lisatjide 
