### PR TITLE
build(actions): revert application version upon e2e failure

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,6 +6,10 @@ name: Cypress Test
 on:
   workflow_dispatch:
   workflow_call:
+    outputs:
+      cypress_result:
+        description: "Outcome of the cypress suite, enum<success, failure, skipped, cancelled>"
+        value: ${{ jobs.cypress-run.outputs.outcome }}
 
 jobs:
   set_environment:
@@ -17,15 +21,17 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "::set-output name=current_env::production"
+            echo "current_env=production" >> $GITHUB_OUTPUT
           else
-             echo "::set-output name=current_env::staging"
+             echo "current_env=staging" >> $GITHUB_OUTPUT
           fi
   cypress-run:
     runs-on: ubuntu-latest
     needs: [set_environment]
     environment:
       name: ${{ needs.set_environment.outputs.current_env }}
+    outputs:
+      outcome: ${{ steps.cypress.outcome }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,6 +45,7 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npx cypress install
       - name: Cypress.io
+        id: cypress
         env:
           CYPRESS_BASE_URL: ${{ github.ref == 'refs/heads/master' && 'https://postman.gov.sg/' || 'https://staging.postman.gov.sg/' }}
           CYPRESS_API_BASE_URL: ${{ github.ref == 'refs/heads/master' && 'https://api.postman.gov.sg/' || 'https://api-staging.postman.gov.sg/' }}
@@ -47,7 +54,7 @@ jobs:
           CYPRESS_EMAIL: "internal-testing@open.gov.sg"
           CYPRESS_SMS_NUMBER: "+6582410222"
           CYPRESS_API_KEY: ${{ secrets.CYPRESS_API_KEY }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           config-file: cypress.config.js
           install: false

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -1,5 +1,13 @@
 name: Deploy backend to AWS Elastic Beanstalk
-on: workflow_call
+on:
+  workflow_call:
+    outputs:
+      revert_command_backend:
+        description: "Command to revert backend deployment"
+        value: ${{ jobs.deploy_backend.outputs.revert_cmd }}
+      revert_command_callback:
+        description: "Command to revert callback server deployment"
+        value: ${{ jobs.deploy_callback.outputs.revert_cmd }}
 env:
   # Update this common config
   DIRECTORY: backend
@@ -14,9 +22,9 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "::set-output name=current_env::production"
+            echo "current_env=production" >> $GITHUB_OUTPUT
           else
-             echo "::set-output name=current_env::staging"
+             echo "current_env=staging" >> $GITHUB_OUTPUT
           fi
 
   lint-test:
@@ -51,7 +59,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
-          cd shared 
+          cd shared
           npm ci
           cd ..
           cd $DIRECTORY
@@ -66,7 +74,7 @@ jobs:
       name: ${{ needs.set_environment.outputs.current_env }}
     env:
       IMAGE_TAG: "github-actions-backend-${{ github.sha }}-${{ github.run_id }}-${{github.run_attempt}}"
-      BRANCH: ${{ needs.set_environment.outputs.current_env }}
+      CURRENT_ENV: ${{ needs.set_environment.outputs.current_env }}
     runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.set-image-tag.outputs.image_tag }}
@@ -90,7 +98,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ap-southeast-1
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -98,27 +106,27 @@ jobs:
 
       - name: Build, tag, and push image to Amazon ECR
         env:
-          ECR_REPOSITORY: ${{ secrets.REPO }}
+          ECR_REPOSITORY: 454894717801.dkr.ecr.ap-southeast-1.amazonaws.com/postmangovsg
         run: |
           cd $DIRECTORY
           sed -i -e "s|@TAG|$IMAGE_TAG|g" Dockerrun.aws.json
           sed -i -e "s|@REPO|$ECR_REPOSITORY|g" Dockerrun.aws.json 
           docker build -f Dockerfile -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$CURRENT_ENV
           docker push -a $ECR_REPOSITORY
           zip -r "$IMAGE_TAG.zip" .ebextensions .platform Dockerrun.aws.json
 
       - name: Copy to S3
         env:
-          BUCKET_NAME: ${{ secrets.EB_BUCKET_NAME }}
+          BUCKET_NAME: postmangovsg-elasticbeanstalk-appversion
         run: |
           cd backend
           aws s3 cp $IMAGE_TAG.zip s3://$BUCKET_NAME/$IMAGE_TAG.zip
 
       - name: Create application version
         env:
-          BUCKET_NAME: ${{ secrets.EB_BUCKET_NAME }}
-          APP_NAME: ${{ secrets.EB_APP_NAME }}
+          BUCKET_NAME: postmangovsg-elasticbeanstalk-appversion
+          APP_NAME: postmangovsg
         run: |
           cd backend
           TRUNCATED_DESC=$(echo "${{github.event.head_commit.message}}" | head -n 1 | cut -b1-180)
@@ -129,38 +137,86 @@ jobs:
 
       - name: Set image tag
         id: set-image-tag
-        run: echo "::set-output name=image_tag::$IMAGE_TAG"
+        run: echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_backend:
     needs: [set_environment, lint-test, build_application]
     environment:
       name: ${{ needs.set_environment.outputs.current_env }}
+    outputs:
+      revert_cmd: ${{ steps.generate-revert-command.outputs.revert_cmd }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        run: |
+          if [$CURRENT_ENV == 'production']
+          then
+            echo "EB_ENV_NAME=postmangovsg-production-amz2" >> $GITHUB_ENV
+          else
+            echo "EB_ENV_NAME=postmangovsg-staging-amz2" >> $GITHUB_ENV
+          fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - name: Generate revert commands
+        id: generate-revert-command
+        env:
+          APP_NAME: postmangovsg
+          EB_ENV_NAME: ${{ env.EB_ENV_NAME }}
+        run: |
+          CURRENT_VERSION_LABEL=$(aws elasticbeanstalk describe-environments --application-name $APP_NAME --environment-names $EB_ENV_NAME --max-items 1 | jq .Environments[0].VersionLabel)
+          echo "revert_cmd=aws elasticbeanstalk update-environment --application-name $APP_NAME --environment-name $EB_ENV_NAME --version-label $CURRENT_VERSION_LABEL" >> $GITHUB_OUTPUT
       - name: Deploy to EB
         uses: einaregilsson/beanstalk-deploy@v20
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          application_name: ${{ secrets.EB_APP_NAME }}
-          environment_name: ${{ secrets.EB_ENV_NAME }}
+          application_name: postmangovsg
+          environment_name: ${{ env.EB_ENV_NAME }}
           version_label: ${{ needs.build_application.outputs.image_tag }}
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ap-southeast-1
           wait_for_environment_recovery: 300 # 5 minutes
 
   deploy_callback:
     needs: [set_environment, lint-test, build_application]
     environment:
       name: ${{ needs.set_environment.outputs.current_env }}
+    outputs:
+      revert_cmd: ${{ steps.generate-revert-command.outputs.revert_cmd }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        run: |
+          if [$CURRENT_ENV == 'production']
+          then
+            echo "EB_ENV_NAME=postmangovsg-production-amz2-callback" >> $GITHUB_ENV
+          else
+            echo "EB_ENV_NAME=postmangovsg-staging-amz2-callback" >> $GITHUB_ENV
+          fi
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - name: Generate revert commands
+        id: generate-revert-command
+        env:
+          APP_NAME: postmangovsg
+          EB_ENV_NAME: ${{ env.EB_ENV_NAME }}
+        run: |
+          CURRENT_VERSION_LABEL=$(aws elasticbeanstalk describe-environments --application-name $APP_NAME --environment-names $EB_ENV_NAME --max-items 1 | jq .Environments[0].VersionLabel)
+          echo "revert_cmd=aws elasticbeanstalk update-environment --application-name $APP_NAME --environment-name $EB_ENV_NAME --version-label $CURRENT_VERSION_LABEL" >> $GITHUB_OUTPUT
       - name: Deploy to EB
         uses: einaregilsson/beanstalk-deploy@v20
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          application_name: ${{ secrets.EB_APP_NAME }}
-          environment_name: ${{ secrets.EB_ENV_NAME_2 }}
+          application_name: postmangovsg
+          environment_name: ${{ env.EB_ENV_NAME }}
           version_label: ${{ needs.build_application.outputs.image_tag }}
-          region: ${{ secrets.AWS_DEFAULT_REGION }}
+          region: ap-southeast-1
           wait_for_environment_recovery: 300 # 5 minutes

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,8 +1,17 @@
 name: Deploy frontend to AWS Amplify
-on: workflow_call
+on:
+  workflow_call:
+    outputs:
+      revert_command:
+        description: "Command to revert frontend deployment"
+        value: ${{ jobs.deploy-frontend.outputs.revert_cmd }}
+env:
+  APP_ID: d3k3b7zs07zjio
 jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
+    outputs:
+      revert_cmd: ${{ steps.generate-revert-command.outputs.revert_cmd }}
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
@@ -16,14 +25,21 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "##[set-output name=branch;]master"
+            echo "branch=master" >> $GITHUB_OUTPUT
           else
-            echo "##[set-output name=branch;]staging"
+            echo "branch=staging" >> $GITHUB_OUTPUT
           fi
         id: extract_branch
+      - name: Generate revert command
+        id: generate-revert-command
+        env:
+          BRANCH: ${{ steps.extract_branch.outputs.branch }}
+        run: |
+          aws amplify list-jobs --app-id $APP_ID --branch-name $BRANCH --max-items 1 | jq '.jobSummaries[0]' | echo
+          JOB_ID=$(aws amplify list-jobs --app-id $APP_ID --branch-name $BRANCH --max-items 1 | jq '.jobSummaries[0].jobId')
+          echo "revert_cmd=aws amplify start-job --app-id $APP_ID --branch-name $BRANCH --job-id $JOB_ID --job-type RETRY" >> $GITHUB_OUTPUT
       - name: Deploy
         shell: bash
         env:
           BRANCH: ${{ steps.extract_branch.outputs.branch }}
-          APP_ID: d3k3b7zs07zjio
         run: ./scripts/amplify-deploy.sh $APP_ID $BRANCH

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,5 +1,13 @@
 name: Deploy worker to AWS Elastic Container Service
-on: workflow_call
+on:
+  workflow_call:
+    outputs:
+      sending_revert_command:
+        description: "Command to revert sending worker"
+        value: ${{ jobs.deploy_sending.outputs.revert_cmd }}
+      logging_revert_command:
+        description: "Command to revert logging worker"
+        value: ${{ jobs.deploy_logging.outputs.revert_cmd }}
 env:
   # Update this common config
   DIRECTORY: worker
@@ -14,9 +22,9 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "::set-output name=current_env::production"
+            echo "current_env=production" >> $GITHUB_OUTPUT
           else
-             echo "::set-output name=current_env::staging"
+            echo "current_env=staging" >> $GITHUB_OUTPUT
           fi
 
   lint:
@@ -44,11 +52,19 @@ jobs:
       name: ${{ needs.set_environment.outputs.current_env }}
     env:
       IMAGE_TAG: "github-actions-worker-${{ github.sha }}-${{ github.run_id }}-${{github.run_attempt}}"
-      BRANCH: ${{ needs.set_environment.outputs.current_env }}
+      CURRENT_ENV: ${{ needs.set_environment.outputs.current_env }}
     outputs:
       image: ${{ steps.build-image.outputs.image }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        run: |
+          if [$CURRENT_ENV == 'production']
+          then
+            echo "SECRET_ID=env/eb/postmangovsg-production-amz2" >> $GITHUB_ENV
+          else
+            echo "SECRET_ID=env/eb/postmangovsg-staging-amz2" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
@@ -60,7 +76,7 @@ jobs:
       - name: Replace id of secret to be used for retrieving env vars from secrets manager
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
-          SECRET_ID: ${{ secrets.SECRET_ID }}
+          SECRET_ID: ${{ env.SECRET_ID }}
         run: |
           cd $DIRECTORY
           cp -R ../shared ./
@@ -70,7 +86,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ap-southeast-1
 
       - name: Login to Amazon ECR
         id: login-ecr
@@ -79,86 +95,123 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
-          ECR_REPOSITORY: ${{ secrets.REPO }}
+          ECR_REPOSITORY: 454894717801.dkr.ecr.ap-southeast-1.amazonaws.com/postmangovsg
         run: |
           cd $DIRECTORY
           docker build -f Dockerfile -t $ECR_REPOSITORY:$IMAGE_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$BRANCH
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REPOSITORY:$CURRENT_ENV
           docker push -a $ECR_REPOSITORY
-          echo "::set-output name=image::$IMAGE_TAG"
+          echo "image=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deploy_sending:
     needs: [set_environment, build_application]
     environment:
       name: ${{ needs.set_environment.outputs.current_env }}
+    outputs:
+      revert_cmd: ${{ steps.get-task-definition-sending.outputs.revert_cmd }}
+      test_value: ${{ steps.get-task-definition-sending.outputs.test_value }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        run: |
+          if [$CURRENT_ENV == 'production']
+          then
+            echo "WORKER_TASK_DEFINITION_SENDING=postmangovsg-production-sending-06f404f5" >> $GITHUB_ENV
+            echo "WORKER_SERVICE_SENDING=prod-sending" >> $GITHUB_ENV
+          else
+            echo "WORKER_TASK_DEFINITION_SENDING=postmangovsg-staging-sending-39eb9204" >> $GITHUB_ENV
+            echo "WORKER_SERVICE_SENDING=staging-sending" >> $GITHUB_ENV
+          fi
+          echo "WORKER_CLUSTER=postmangovsg-workers" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ap-southeast-1
 
       - name: (Sending) Download task definition
         id: get-task-definition-sending
         env:
-          TASK_DEFINITION: ${{ secrets.WORKER_TASK_DEFINITION_SENDING }}
+          TASK_DEFINITION: ${{ env.WORKER_TASK_DEFINITION_SENDING }}
           OUT: task-definition-sending.json
+          SERVICE: ${{ env.WORKER_SERVICE_SENDING }}
+          CLUSTER: ${{ env.WORKER_CLUSTER }}
         run: |
           aws ecs describe-task-definition --task-definition $TASK_DEFINITION --query taskDefinition > $OUT
-          echo "::set-output name=task-definition::$OUT"
+          echo "task-definition=$OUT" >> $GITHUB_OUTPUT
+          CMD="aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition $TASK_DEFINITION:$(jq .revision $OUT)"
+          echo "revert_cmd=$CMD" >> $GITHUB_OUTPUT
 
       - name: (Sending) Fill in the new image ID in the Amazon ECS task definition
         id: task-def-sending
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: ${{ steps.get-task-definition-sending.outputs.task-definition }}
-          image: "${{ secrets.REPO }}:${{ needs.build_application.outputs.image }}"
+          image: "454894717801.dkr.ecr.ap-southeast-1.amazonaws.com/postmangovsg:${{ needs.build_application.outputs.image }}"
           container-name: sending
 
       - name: (Sending) Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def-sending.outputs.task-definition }}
-          service: ${{ secrets.WORKER_SERVICE_SENDING }}
-          cluster: ${{ secrets.WORKER_CLUSTER }}
+          service: ${{ env.WORKER_SERVICE_SENDING }}
+          cluster: ${{ env.WORKER_CLUSTER }}
           wait-for-service-stability: true
 
   deploy_logging:
     needs: [set_environment, build_application]
     environment:
       name: ${{ needs.set_environment.outputs.current_env }}
+    outputs:
+      revert_cmd: ${{ steps.get-task-definition-logging.outputs.revert_cmd }}
     runs-on: ubuntu-latest
     steps:
+      - name: Set environment variables
+        run: |
+          if [$CURRENT_ENV == 'production']
+          then
+            echo "WORKER_TASK_DEFINITION_LOGGING=postmangovsg-production-logging-06f404f5" >> $GITHUB_ENV
+            echo "WORKER_SERVICE_LOGGING=prod-logging" >> $GITHUB_ENV
+          else
+            echo "WORKER_TASK_DEFINITION_LOGGING=postmangovsg-staging-logging-39eb9204" >> $GITHUB_ENV
+            echo "WORKER_SERVICE_LOGGING=staging-logging" >> $GITHUB_ENV
+          fi
+          echo "WORKER_CLUSTER=postmangovsg-workers" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ap-southeast-1
 
       - name: (Logging) Download task definition
         id: get-task-definition-logging
         env:
-          TASK_DEFINITION: ${{ secrets.WORKER_TASK_DEFINITION_LOGGING }}
+          TASK_DEFINITION: ${{ env.WORKER_TASK_DEFINITION_LOGGING }}
           OUT: task-definition-logging.json
+          SERVICE: ${{ env.WORKER_SERVICE_LOGGING }}
+          CLUSTER: ${{ env.WORKER_CLUSTER }}
         run: |
           aws ecs describe-task-definition --task-definition $TASK_DEFINITION --query taskDefinition > $OUT
-          echo "::set-output name=task-definition::$OUT"
+          echo "task-definition=$OUT" >> $GITHUB_OUTPUT
+          CMD="aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition $TASK_DEFINITION:$(jq .revision $OUT)"
+          echo "revert_cmd=$CMD" >> $GITHUB_OUTPUT
 
       - name: (Logging) Fill in the new image ID in the Amazon ECS task definition
         id: task-def-logging
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: ${{ steps.get-task-definition-logging.outputs.task-definition }}
-          image: "${{ secrets.REPO }}:${{ needs.build_application.outputs.image }}"
+          image: "454894717801.dkr.ecr.ap-southeast-1.amazonaws.com/postmangovsg:${{ needs.build_application.outputs.image }}"
           container-name: logging
 
       - name: (Logging) Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def-logging.outputs.task-definition }}
-          service: ${{ secrets.WORKER_SERVICE_LOGGING }}
-          cluster: ${{ secrets.WORKER_CLUSTER }}
+          service: ${{ env.WORKER_SERVICE_LOGGING }}
+          cluster: ${{ env.WORKER_CLUSTER }}
           wait-for-service-stability: true

--- a/.github/workflows/non-serverless-deploy.yml
+++ b/.github/workflows/non-serverless-deploy.yml
@@ -26,6 +26,7 @@ jobs:
     name: Deploy frontend to AWS Amplify
     uses: ./.github/workflows/deploy-frontend.yml
     secrets: inherit
+
   e2e-test:
     needs:
       - deploy-backend
@@ -34,3 +35,27 @@ jobs:
     name: Cypress Test
     uses: ./.github/workflows/cypress.yml
     secrets: inherit
+
+  revert-on-e2e-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - deploy-backend
+      - deploy-frontend
+      - deploy-worker
+      - e2e-test
+    if: always()
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-southeast-1
+      - run: |
+          if [ "${{ needs.e2e-test.outputs.cypress_result }}" = "failure" ];then
+            ${{ needs.deploy-worker.outputs.sending_revert_command }}
+            ${{ needs.deploy-worker.outputs.logging_revert_command }}
+            ${{ needs.deploy-frontend.outputs.revert_command }}
+            ${{ needs.deploy-backend.outputs.revert_command_backend }}
+            ${{ needs.deploy-backend.outputs.revert_command_callback }}
+          fi

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -131,7 +131,65 @@
         "filename": ".github/workflows/deploy-eb.yml",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 37
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-eb.yml",
+        "hashed_secret": "80fd3bbdc5ed1d95a332d24bd91d6f1b9a0b8c46",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-eb.yml",
+        "hashed_secret": "e5256d1117a5e036bd450906433fd9faddc5ac27",
+        "is_verified": false,
+        "line_number": 192
+      }
+    ],
+    ".github/workflows/deploy-worker.yml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "6cfcb7ab8d7fb73d78e6d6fd2337c808d6b3c505",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "4083553ccb49a6967a7052331885915e7507c9bb",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "6db60f045cf60db2ad37bfbf0fb719ff402ae1da",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "be9aa7f7565b7af0a56bcfa2e92c9a23b6b1dc65",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "34ad521605635a65d92e6312862d42a599ef54d2",
+        "is_verified": false,
+        "line_number": 172
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/deploy-worker.yml",
+        "hashed_secret": "60e93d2cd9c963eb9416bde9d6f77ff214397a86",
+        "is_verified": false,
+        "line_number": 172
       }
     ],
     ".github/workflows/non-serverless-deploy.yml": [


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Postman-CI-CD-E2E-Rolling-Back-Was-Canary-RFC-ee42f3356a264cdf8832649bb988b569)

## Solution

As stated in the ticket's comment.
To be followed up with another PR for notifying on Slack on build successes & failures

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A
