### PR TITLE
feat(backend): minor validation to pass scheduledTiming field

### DIFF
--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -65,6 +65,7 @@ export const InitSmsCampaignRoute = (
   const sendCampaignValidator = {
     [Segments.BODY]: Joi.object({
       rate: Joi.number().integer().positive().default(10),
+      scheduledTiming: Joi.string().optional(),
     }),
   }
 

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -66,6 +66,7 @@ export const InitTelegramCampaignMiddleware = (
   const sendCampaignValidator = {
     [Segments.BODY]: Joi.object({
       rate: Joi.number().integer().positive().max(30).default(30),
+      scheduledTiming: Joi.string().optional(),
     }),
   }
 


### PR DESCRIPTION
## Problem

Slight problem with Joi validator that caused Scheduled Sending to fail on SMS and Telegram Campaigns
## Solution

Allow scheduledTiming as an optional field 