### PR TITLE
feat: content-id image support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,4 @@ cypress/downloads/*.csv
 
 # IDE config files
 .idea
+.vscode

--- a/backend/src/core/services/file-attachment.service.ts
+++ b/backend/src/core/services/file-attachment.service.ts
@@ -30,7 +30,7 @@ const parseFiles = async (
   files: { data: Buffer; name: string }[]
 ): Promise<MailAttachment[]> => {
   return files.map(({ data, name }, index) => {
-    // TODO: refactor
+    // include cid field to support content-id images; see PR #1905
     return { filename: name, content: data, cid: index.toString() }
   })
 }

--- a/backend/src/core/services/file-attachment.service.ts
+++ b/backend/src/core/services/file-attachment.service.ts
@@ -29,10 +29,10 @@ const areFilesSafe = async (
 const parseFiles = async (
   files: { data: Buffer; name: string }[]
 ): Promise<MailAttachment[]> => {
-  const parsedFiles = files.map(({ data, name }) => {
-    return { filename: name, content: data }
+  return files.map(({ data, name }, index) => {
+    // TODO: refactor
+    return { filename: name, content: data, cid: index.toString() }
   })
-  return parsedFiles
 }
 
 export const UNSUPPORTED_FILE_TYPE_ERROR_CODE =

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -542,6 +542,26 @@ describe(`${emailTransactionalRoute}/send`, () => {
     expect(res.body).toBeDefined()
     expect(res.body.attachments_metadata).toBeDefined()
     expect(mockSendEmail).toBeCalledTimes(1)
+    expect(mockSendEmail).toBeCalledWith(
+      {
+        body: validApiCall.body,
+        from: validApiCall.from,
+        replyTo: validApiCall.reply_to,
+        subject: validApiCall.subject,
+        recipients: [validApiCall.recipient],
+        referenceId: expect.any(String),
+        attachments: [
+          {
+            cid: '0',
+            content: expect.any(Buffer),
+            filename: validAttachmentName,
+          },
+        ],
+      },
+      {
+        extraSmtpHeaders: { isTransactional: true },
+      }
+    )
     const transactionalEmail = await EmailMessageTransactional.findOne({
       where: { userId: user.id.toString() },
     })
@@ -615,6 +635,31 @@ describe(`${emailTransactionalRoute}/send`, () => {
 
     expect(res.status).toBe(201)
     expect(mockSendEmail).toBeCalledTimes(1)
+    expect(mockSendEmail).toBeCalledWith(
+      {
+        body: validApiCall.body,
+        from: validApiCall.from,
+        replyTo: validApiCall.reply_to,
+        subject: validApiCall.subject,
+        recipients: [validApiCall.recipient],
+        referenceId: expect.any(String),
+        attachments: [
+          {
+            cid: '0',
+            content: expect.any(Buffer),
+            filename: validAttachmentName,
+          },
+          {
+            cid: '1',
+            content: expect.any(Buffer),
+            filename: validAttachment2Name,
+          },
+        ],
+      },
+      {
+        extraSmtpHeaders: { isTransactional: true },
+      }
+    )
     const transactionalEmail = await EmailMessageTransactional.findOne({
       where: { userId: user.id.toString() },
     })

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -51,6 +51,10 @@ async function sendMessage({
   attachments?: { data: Buffer; name: string }[]
   emailMessageTransactionalId: number
 }): Promise<void> {
+  // TODO: flagging this coupling for future refactoring:
+  // currently, we are using EmailTemplateService to sanitize both tx emails and campaign emails
+  // while this works for now, in the future, we might want to have more liberal rules for tx emails
+  // to allow API users the freedom to customize the look and feel of their emails
   const sanitizedSubject =
     EmailTemplateService.client.replaceNewLinesAndSanitize(subject)
   const sanitizedBody = EmailTemplateService.client.filterXSS(body)

--- a/shared/src/clients/mail-client.class/interfaces.ts
+++ b/shared/src/clients/mail-client.class/interfaces.ts
@@ -1,6 +1,8 @@
 export interface MailAttachment {
   filename: string
   content: Buffer
+  // TODO: refactor into optional field?
+  cid: string // automatically generated for all attachments; for use as content-id images
 }
 
 export interface MailToSend {

--- a/shared/src/clients/mail-client.class/interfaces.ts
+++ b/shared/src/clients/mail-client.class/interfaces.ts
@@ -1,9 +1,6 @@
-export interface MailAttachment {
-  filename: string
-  content: Buffer
-  // TODO: refactor into optional field?
-  cid: string // automatically generated for all attachments; for use as content-id images
-}
+import { Attachment } from 'nodemailer/lib/mailer'
+
+export type MailAttachment = Pick<Attachment, 'filename' | 'content' | 'cid'>
 
 export interface MailToSend {
   recipients: Array<string>

--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -87,7 +87,7 @@ export const XSS_EMAIL_OPTION = {
     if (tag === 'img' && name === 'src' && value.match(KEYWORD_REGEX)) {
       return value
     }
-    // Do not sanitize keyword if eg: <img src="cid:attachment1">, to support content-id images
+    // Do not sanitize keyword if eg: <img src="cid:attachment">, to support content-id images
     if (tag === 'img' && name === 'src' && isCid(value)) {
       return value
     }

--- a/shared/src/templating/xss-options.ts
+++ b/shared/src/templating/xss-options.ts
@@ -14,7 +14,7 @@ const URL =
 const KEYWORD_REGEX = /^{{\s*?\w+\s*?}}$/
 
 /**
- * Helper method to determine if a string is a HTTP URL
+ * Helper method to determine if a string is an HTTP URL
  * @param urlStr
  */
 const isValidHttpUrl = (urlStr: string): boolean => {
@@ -24,6 +24,10 @@ const isValidHttpUrl = (urlStr: string): boolean => {
   } catch (_) {
     return false
   }
+}
+
+const isCid = (urlStr: string): boolean => {
+  return urlStr.startsWith('cid:')
 }
 
 const DEFAULT_EMAIL_ATTRS = ['style']
@@ -81,6 +85,10 @@ export const XSS_EMAIL_OPTION = {
 
     // Do not sanitize keyword when it's a img src, eg: <img src="{{protectedImg}}">
     if (tag === 'img' && name === 'src' && value.match(KEYWORD_REGEX)) {
+      return value
+    }
+    // Do not sanitize keyword if eg: <img src="cid:attachment1">, to support content-id images
+    if (tag === 'img' && name === 'src' && isCid(value)) {
       return value
     }
     // The default safeAttrValue does guard against some edge cases


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/Content-ID-images-3624a41d30224e569db710c71b2b0c2e)

Support [CID images](https://sendgrid.com/blog/embedding-images-emails-facts/)

## Remaining To-Dos

- [x] Discuss how we want to design the API interface for this feature
  - [x] Implement design
  - [x] Write tests

- Figure out + document :
  - [x] Format types that can be supported by content-id images
  - [x] Support for CID images in different clients (Web Outlook, Web Yahoo, Gmail, GSIB Outlook etc.)

## Solution

### Current Implementation

- Relax xss filtering rules are to allow CID img tags to be passed through
- Include a `cid` field for **all** attachments uploaded based on its index (0, 1, 2, 3...) and passing it to [Nodemailer](https://nodemailer.com/message/attachments/). 

^In theory, this causes a change to the email's content-disposition, per [Nodemailer's API documentation](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ba7447ad38c4f69cf4f8d23fc4660fb2e3303700/types/nodemailer/lib/mailer/index.d.ts#L40-L58):
> using `cid` sets the default `contentDisposition` to 'inline' and moves the attachment into a multipart/related mime node, so use it only if you actually want to use this attachment as an embedded image 

However, based on our tests, all major email clients are able to handle this change gracefully. 

### CID Image Rendering on web clients

Behavior of our content-id image email:
- [x] Gmail web client
  - CID image show-up in-line, does not present as a separate attachment
  - Remaining attachments: show up as regular attachment (identical to prior to this PR)
- [x] Outlook web client
  - CID image show-up in-line AND presents as a separate attachment
  - Remaining attachments: show up as regular attachment (identical to prior to this PR)
- [x] Yahoo Mail web client
  - CID image show-up in-line, does not present as a separate attachment
  - Remaining attachments: show up as regular attachment (identical to prior to this PR)
- [x] Outlook desktop client (GSIB): 
  - CID image show-up in-line, does not present as a separate attachment
  - Remaining attachments: show up as regular attachment (identical to prior to this PR)
- [x] Apple Mail desktop client
  - CID image show-up in-line, does not present as a separate attachment
  - Remaining attachments: show up as regular attachment (identical to prior to this PR)

Current behavior of ICA's content-id image email:
- Gmail web client: CID image shows up in-line + present as a separate attachment at the end with no extension
- Outlook web client: CID image shows up in-line + present as a separate attachment at the end with no extension
- Yahoo Mail web client: CID image shows up in-line + present as a separate attachment at the end with no extension
- Outlook desktop client (GSIB): CID image show-up in-line, does not present as a separate attachment
- Apple Mail desktop client: CID image does not show up, presents as an in-line attachment

### Tested file types on Gmail
- Supported: `bmp`, `gif`, `jpeg`, `jpg`, `tif`, `tiff`, `png`
- Not supported: `jp2`

### How API call looks like

```
Hello there.
<br>
<img src="cid:0">
<br>
<img src="cid:1">
```

First image is indexed as 0, second image indexed as 1. 

### Alternatives Considered

- We considered validating CID image files are actually images, but we conclude there is little benefit to this and the onus should be on the API user to do this
- We considered alternatives to setting the `cid` based on the file's position in the `attachments` array, such as the file name. However, the file's position in the `attachments` array is guaranteed to be unique and is something the API user can directly control. 

## Misc

### Code coupling

Currently, we're using `EmailTemplateService` to sanitize both tx emails and campaign emails. While this works for now, in the future, we might want to have more liberal rules for tx emailsto allow API users the freedom to customize the look and feel of their emails.

As such, this coupling should be refactored away in the future.

### Weird commit issue

Getting this weird message when I commit (doesn't stop the commit from going through)
```
✔ Preparing lint-staged...
✔ Running tasks for staged files...
✖ The following paths are ignored by one of your .gitignore files:
  shared/src/clients/mail-client.class
  hint: Use -f if you really want to add them.
  hint: Turn this message off by running
  hint: "git config advice.addIgnoredFile false"
✔ Cleaning up temporary files...
```

don't think I saw any paths in `.gitignore` that coves this though