### PR TITLE
fix: attachment array bug

### DIFF
--- a/backend/src/core/middlewares/file-attachment.middleware.ts
+++ b/backend/src/core/middlewares/file-attachment.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import fileUpload from 'express-fileupload'
 import config from '@core/config'
+import { ensureAttachmentsFieldIsArray } from '@core/utils/attachment'
 
 const FILE_ATTACHMENT_MAX_NUM = config.get('file.maxAttachmentNum')
 const FILE_ATTACHMENT_MAX_SIZE = config.get('file.maxAttachmentSize')
@@ -33,12 +34,7 @@ function preprocessPotentialIncomingFile(
 ): void {
   if (req.files?.attachments) {
     const { attachments } = req.files
-
-    if (!Array.isArray(attachments)) {
-      req.body.attachments = [attachments]
-    } else {
-      req.body.attachments = attachments
-    }
+    req.body.attachments = ensureAttachmentsFieldIsArray(attachments)
     /**
      * Throw explicit error for exceeding num files.
      * express-fileupload does not throw error if num files

--- a/backend/src/core/utils/attachment.ts
+++ b/backend/src/core/utils/attachment.ts
@@ -1,0 +1,12 @@
+import { UploadedFile } from 'express-fileupload'
+
+const ensureAttachmentsFieldIsArray = (
+  attachments: UploadedFile | UploadedFile[]
+) => {
+  if (!Array.isArray(attachments)) {
+    return [attachments]
+  }
+  return attachments
+}
+
+export { ensureAttachmentsFieldIsArray }


### PR DESCRIPTION
## Problem

We previously modified the code to redact attachment data in the log to ensure our logs will be reasonably sized. However, the modification assumes that the `req.body.attachments` field will be an array, which is not the case.

## Solution

Have created an utility function `ensureAttachmentsFieldIsArray` to use in both part of the codebase that does what it says. 