### PR TITLE
fix(openapi): correct validation errors

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -880,6 +880,12 @@ paths:
       tags:
         - Email
       summary: Sends a test message and defaults to Postman's credentials for the campaign
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       requestBody:
         content:
           application/json:
@@ -1027,7 +1033,12 @@ paths:
       tags:
         - Email
       summary: Start sending campaign
-
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -1091,7 +1102,12 @@ paths:
       tags:
         - Email
       summary: Stop sending campaign
-
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -1149,7 +1165,12 @@ paths:
       tags:
         - Email
       summary: Retry sending campaign
-
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -2804,6 +2825,12 @@ paths:
       tags:
         - SMS
       summary: Stop sending campaign
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -2861,6 +2888,12 @@ paths:
       tags:
         - SMS
       summary: Retry sending campaign
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Success
@@ -4120,7 +4153,12 @@ paths:
       tags:
         - Telegram
       summary: Stop sending campaign
-
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: OK
@@ -4179,7 +4217,12 @@ paths:
       tags:
         - Telegram
       summary: Retry sending campaign
-
+      parameters:
+        - name: campaignId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: OK
@@ -4819,7 +4862,7 @@ components:
         job_queue:
           type: array
           items:
-          $ref: "#/components/schemas/JobQueue"
+            $ref: "#/components/schemas/JobQueue"
         sms_templates:
           type: object
           properties:


### PR DESCRIPTION
## Problem
The OpenAPI spec yaml for Postman fails validation by openapi-generator:
```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 9, Warning count: 0
Errors: 
	-attribute components.schemas.SMSCampaign.items is not of type `object`
	-paths.'/campaign/{campaignId}/email/retry'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/telegram/retry'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/telegram/stop'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/email/send'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/sms/retry'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/email/stop'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/email/credentials'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
	-paths.'/campaign/{campaignId}/sms/stop'. Declared path parameter campaignId needs to be defined as a path parameter in path or operation level
```

## Solution

- add missing parameter spec for `campaignId`
- indent `SMSCampaign.items.$ref`
