### PR TITLE
feat(openapi): expose spec at `/v1/swagger.json`

### DIFF
--- a/backend/src/core/loaders/swagger.loader.ts
+++ b/backend/src/core/loaders/swagger.loader.ts
@@ -10,6 +10,7 @@ const logger = loggerWithLabel(module)
 const swaggerUiOptions = {
   explorer: false,
   customCss: '.swagger-ui .topbar { display: none; }',
+  url: '/v1/swagger.json',
 }
 
 const removeCspHeader = (
@@ -26,6 +27,7 @@ const swaggerDocument = YAML.load(
 )
 
 const swaggerLoader = ({ app }: { app: Application }): void => {
+  app.get('/v1/swagger.json', (_req, res) => res.json(swaggerDocument))
   app.use(
     '/docs',
     removeCspHeader,


### PR DESCRIPTION
## Problem

The OpenAPI spec is not readily served by api.postman.gov.sg. Consumers may retrieve it via GitHub, but this results in generated code with GitHub and not Postman as base URL. In some cases, this is hard-coded and cannot be easily changed.

## Solution

Serve the spec as a JSON at `/v1/swagger.json`, to allow consumption by code generators and similar utilities
