### PR TITLE
feat: better error message for unverified custom from address

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1825,7 +1825,8 @@ paths:
                       "from" must be a valid email
                     validation: { source: body, keys: [from] }
                 FromError:
-                  value: { message: Invalid 'from' email address. }
+                  # align with message in backend/src/email/middlewares/email.middleware.ts
+                  value: { message: Invalid 'from' email address, which must be either the default donotreply@mail.postman.gov.sg or the user's email (which requires setup with Postman team). Contact us to learn more. }
 
         "401":
           description: Unauthorized.

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -26,6 +26,9 @@ export interface EmailMiddleware {
 export const INVALID_FROM_ADDRESS_ERROR_MESSAGE =
   "Invalid 'from' email address, which must be either the default donotreply@mail.postman.gov.sg or the user's email (which requires setup with Postman team). Contact us to learn more."
 
+export const UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE =
+  'From Address has not been verified.'
+
 export const InitEmailMiddleware = (
   authService: AuthService
 ): EmailMiddleware => {
@@ -265,7 +268,7 @@ export const InitEmailMiddleware = (
       // therefore, can simply check whether own email is in the list of verified emails
       // this is not great as the function is impure and relies on the order of middleware...
       const exists = await CustomDomainService.existsFromAddress(fromAddress)
-      if (!exists) throw new Error('From Address has not been verified.')
+      if (!exists) throw new Error(UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE)
     } catch (err) {
       logger.error({
         message: "Invalid 'from' email address",

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -199,6 +199,8 @@ export const InitEmailMiddleware = (
     // Since from addresses with display name are accepted, we need to extract just the email address
     const { from } = req.body
     const { fromName, fromAddress } = parseFromAddress(from)
+    const errorMessage =
+      "Invalid 'from' email address, which must be either the default donotreply@mail.postman.gov.sg or the user's email (which requires setup with Postman team). Contact us to learn more."
 
     // Retrieve logged in user's email
     const userEmail =
@@ -211,7 +213,7 @@ export const InitEmailMiddleware = (
 
     if (fromAddress !== userEmail && fromAddress !== defaultFromAddress) {
       logger.error({
-        message: "Invalid 'from' email address",
+        message: errorMessage,
         from,
         userEmail,
         defaultFromName,
@@ -230,7 +232,7 @@ export const InitEmailMiddleware = (
           }
         )
       }
-      return res.status(400).json({ message: "Invalid 'from' email address." })
+      return res.status(400).json({ message: errorMessage })
     }
 
     res.locals.fromName = fromName

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -287,6 +287,8 @@ export const InitEmailMiddleware = (
 
   /**
    * Verifies the user's email address to see if it can be used as custom 'from' address
+   * - if it is the default donotreply@mail.postman.gov.sg, return immediately
+   * - else, make network calls to AWS SES and the user's domain to verify DNS settings are set up properly.
    */
   const verifyFromAddress = async (
     req: Request,

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -252,7 +252,8 @@ export const InitEmailMiddleware = (
   }
 
   /**
-   * Verifies that the 'from' address provided is valid
+   * Verifies that the 'from' address exists in the EmailFromAddress table
+   * NOTE: Must be called AFTER isFromAddressAccepted, which sets the required res.locals.fromName and res.locals.fromAddress
    */
   const existsFromAddress = async (
     req: Request,

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -85,7 +85,7 @@ export const InitEmailTransactionalRoute = (
     celebrate(sendValidator),
     emailTransactionalMiddleware.saveMessage,
     emailMiddleware.isFromAddressAccepted,
-    emailMiddleware.existsFromAddress,
+    emailMiddleware.existsFromAddress, // future todo: put a cache to reduce db hits
     emailTransactionalMiddleware.rateLimit,
     emailTransactionalMiddleware.sendMessage
   )

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -85,6 +85,7 @@ export const InitEmailTransactionalRoute = (
     celebrate(sendValidator),
     emailTransactionalMiddleware.saveMessage,
     emailMiddleware.isFromAddressAccepted,
+    emailMiddleware.existsFromAddress,
     emailTransactionalMiddleware.rateLimit,
     emailTransactionalMiddleware.sendMessage
   )

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -8,7 +8,10 @@ import { UploadService } from '@core/services'
 import { EmailFromAddress, EmailMessage } from '@email/models'
 import { CustomDomainService } from '@email/services'
 import { ChannelType } from '@core/constants'
-import { INVALID_FROM_ADDRESS_ERROR_MESSAGE } from '@email/middlewares'
+import {
+  INVALID_FROM_ADDRESS_ERROR_MESSAGE,
+  UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE,
+} from '@email/middlewares'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
@@ -148,7 +151,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         reply_to: 'user@agency.gov.sg',
       })
     expect(res.status).toBe(400)
-    expect(res.body).toEqual({ message: 'From Address has not been verified.' })
+    expect(res.body).toEqual({ message: UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE })
   })
 
   test("Verified user's email as from address is accepted", async () => {
@@ -246,7 +249,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
       })
 
     expect(res.status).toBe(400)
-    expect(res.body).toEqual({ message: 'From Address has not been verified.' })
+    expect(res.body).toEqual({ message: UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE })
   })
 
   test('Mail via should only be appended once', async () => {

--- a/backend/src/email/routes/tests/email-campaign.routes.test.ts
+++ b/backend/src/email/routes/tests/email-campaign.routes.test.ts
@@ -8,6 +8,7 @@ import { UploadService } from '@core/services'
 import { EmailFromAddress, EmailMessage } from '@email/models'
 import { CustomDomainService } from '@email/services'
 import { ChannelType } from '@core/constants'
+import { INVALID_FROM_ADDRESS_ERROR_MESSAGE } from '@email/middlewares'
 
 const app = initialiseServer(true)
 let sequelize: Sequelize
@@ -59,7 +60,7 @@ describe('PUT /campaign/{campaignId}/email/template', () => {
         reply_to: 'user@agency.gov.sg',
       })
     expect(res.status).toBe(400)
-    expect(res.body).toEqual({ message: "Invalid 'from' email address." })
+    expect(res.body).toEqual({ message: INVALID_FROM_ADDRESS_ERROR_MESSAGE })
   })
 
   test('Invalid values for email is not accepted', async () => {


### PR DESCRIPTION
## Problem

We are getting a lot of potential users on our transactional email API who are (understandably) filling up the `from` field wrongly. (See latest on #postman-alerts channel)

Closes https://github.com/opengovsg/postmangovsg/issues/1837 too

## Solution

- Give them a more informative error message. 
- Check against `email-from-address` table first before allowing sending

### For Future Optimisation

This PR introduces one more database call in the code path of our transactional email API. Actually, the set of users in the `email-from-address` table is quite small and we can put a cache in front of it if we want to optimise in the future.

## Deployment Notes

- [x] Make sure list of users with custom domain in SES properly matches those in `email_from_address` table
- [x] Make sure current users of transactional email API with custom domain have their email addresses added in `email_from_address` table