### PR TITLE
fix: use DataType.Text for sms transactional body

### DIFF
--- a/backend/src/database/migrations/20230125083046-convert-tx-sms-body-datatype.js
+++ b/backend/src/database/migrations/20230125083046-convert-tx-sms-body-datatype.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('sms_messages_transactional', 'body', {
+      type: Sequelize.DataTypes.TEXT,
+      allowNull: false,
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.changeColumn('sms_messages_transactional', 'body', {
+      type: Sequelize.DataTypes.STRING,
+      allowNull: false,
+    });
+  }
+};

--- a/backend/src/sms/models/sms-message-transactional.ts
+++ b/backend/src/sms/models/sms-message-transactional.ts
@@ -33,7 +33,7 @@ export class SmsMessageTransactional extends Model<SmsMessageTransactional> {
   @Column({ type: DataType.STRING, allowNull: false })
   recipient: string
 
-  @Column({ type: DataType.STRING, allowNull: false })
+  @Column({ type: DataType.TEXT, allowNull: false })
   body: string
 
   @Column({ type: DataType.STRING, allowNull: true })


### PR DESCRIPTION
## Problem

Previously, `DataType.String` defaults to 255 chars, which may be too short.

Related:
- https://stackoverflow.com/questions/4848964/difference-between-text-and-varchar-character-varying
- https://dba.stackexchange.com/questions/189876/size-limit-of-character-varying-postgresql

## Solution

Use `DataType.Text` instead

## Deployment Checklist
- [x] Test on staging
- [x] Order of running migration vs merging in PR doesn't matter

Backend code unchanged