### PR TITLE
feat: user-specific rate limit for tx email API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -200,7 +200,7 @@
         "filename": "backend/src/core/middlewares/auth.middleware.ts",
         "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 18
       }
     ],
     "backend/src/email/services/tests/email-template.service.test.ts": [

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -85,8 +85,6 @@ interface ConfigSchema {
   mailVia: string
   mailDefaultRate: number
   transactionalEmail: {
-    rate: number
-    window: number
     bodySizeLimit: number
   }
   defaultCountry: string
@@ -451,18 +449,6 @@ const config: Config<ConfigSchema> = convict({
     format: 'int',
   },
   transactionalEmail: {
-    rate: {
-      doc: 'The max number of transactional emails that can be requested per window per user',
-      default: 10,
-      env: 'TRANSACTIONAL_EMAIL_RATE',
-      format: 'int',
-    },
-    window: {
-      doc: 'The duration of each window for transactional emails in seconds.',
-      default: 1,
-      env: 'TRANSACTIONAL_EMAIL_WINDOW',
-      format: 'int',
-    },
     bodySizeLimit: {
       doc: 'The maximum size of the body of a transactional email in bytes',
       default: 1048576, // 1 mebibyte; 2^20 bytes

--- a/backend/src/core/models/user/user.ts
+++ b/backend/src/core/models/user/user.ts
@@ -23,6 +23,8 @@ import { loggerWithLabel } from '@core/logger'
 
 const logger = loggerWithLabel(module)
 
+export const DEFAULT_TX_EMAIL_RATE_LIMIT = 10
+
 @Table({ tableName: 'users', underscored: true, timestamps: true })
 export class User extends Model<User> {
   @Column({
@@ -38,6 +40,13 @@ export class User extends Model<User> {
 
   @Column({ type: DataType.STRING, allowNull: true })
   apiKeyHash: string | null
+
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: DEFAULT_TX_EMAIL_RATE_LIMIT,
+  })
+  rateLimit: number
 
   @HasMany(() => UserCredential)
   creds: UserCredential[]

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -181,7 +181,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
       const hash = await ApiKeyService.getApiKeyHash(apiKey)
       return await User.findOne({
         where: { apiKeyHash: hash },
-        attributes: ['id', 'email'],
+        attributes: ['id', 'email', ['rate_limit', 'rateLimit']],
       })
     }
     return null

--- a/backend/src/database/migrations/20230215073856-create-rate-limit-column-in-users-table.js
+++ b/backend/src/database/migrations/20230215073856-create-rate-limit-column-in-users-table.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('users', 'rate_limit', {
+      type: Sequelize.DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 10, // 10 requests per second
+    })
+  },
+
+  down: async (queryInterface, _) => {
+    await queryInterface.removeColumn('users', 'rate_limit')
+  },
+}

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -3,7 +3,6 @@ import expressRateLimit from 'express-rate-limit'
 import RedisStore from 'rate-limit-redis'
 import { RedisService } from '@core/services'
 import { EmailTransactionalService } from '@email/services'
-import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { AuthService } from '@core/services/auth.service'
 import {
@@ -33,6 +32,8 @@ export interface EmailTransactionalMiddleware {
 
 export const RATE_LIMIT_ERROR_MESSAGE =
   'Error 429: Too many requests, rate limit reached'
+
+export const TRANSACTIONAL_EMAIL_WINDOW = 1 // in seconds
 
 const getAttachmentHash = (content: Buffer): string => {
   const hash = crypto.createHash('md5')
@@ -230,11 +231,11 @@ export const InitEmailTransactionalMiddleware = (
     store: new RedisStore({
       prefix: 'transactionalEmail:',
       client: redisService.rateLimitClient,
-      expiry: config.get('transactionalEmail.window'),
+      expiry: TRANSACTIONAL_EMAIL_WINDOW,
     }),
     keyGenerator: (req: Request) => req?.session?.user.id,
-    windowMs: config.get('transactionalEmail.window') * 1000,
-    max: config.get('transactionalEmail.rate'),
+    windowMs: TRANSACTIONAL_EMAIL_WINDOW * 1000,
+    max: (req: Request) => req.session?.rateLimit,
     draft_polli_ratelimit_headers: true,
     message: {
       status: 429,

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -6,7 +6,10 @@ import {
   FileExtensionService,
   UNSUPPORTED_FILE_TYPE_ERROR_CODE,
 } from '@core/services'
-import { RATE_LIMIT_ERROR_MESSAGE } from '@email/middlewares'
+import {
+  RATE_LIMIT_ERROR_MESSAGE,
+  TRANSACTIONAL_EMAIL_WINDOW,
+} from '@email/middlewares'
 import {
   EmailFromAddress,
   EmailMessageTransactional,
@@ -38,6 +41,7 @@ beforeEach(async () => {
   user = await User.create({
     id: 1,
     email: userEmail,
+    rateLimit: 1, // for ease of testing, so second API call within a second would fail
   } as User)
   apiKey = await user.regenerateAndSaveApiKey()
 })
@@ -859,7 +863,9 @@ describe(`${emailTransactionalRoute}/send`, () => {
     })
 
     // Third request passes after 1s
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await new Promise((resolve) =>
+      setTimeout(resolve, TRANSACTIONAL_EMAIL_WINDOW * 1000)
+    )
     res = await send()
     expect(res.status).toBe(201)
     expect(mockSendEmail).toBeCalledTimes(1)


### PR DESCRIPTION
See [ticket](https://www.notion.so/opengov/Rate-limit-for-tx-email-API-b6f4eb2a755d45e3a91fa557d6ac87c9?pvs=4) 

Todos:
- [x] Test on staging, both default rate limit and custom rate limit are working

## Deployment Checklist

- [x] Run database migration first
- [ ] Deploy new backend
- [ ] Remove unnecessary env vars from Secrets Manager
