### PR TITLE
feat: rate limited emails should not be saved to db

### DIFF
--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -246,14 +246,6 @@ export const InitEmailTransactionalMiddleware = (
         message: 'Rate limited request to send transactional email',
         userId: req?.session?.user.id,
       })
-      void EmailMessageTransactional.update(
-        {
-          errorCode: RATE_LIMIT_ERROR_MESSAGE,
-        },
-        {
-          where: { id: req.body.emailMessageTransactionalId },
-        }
-      )
       res
         .status(429)
         .json({ message: 'Too many requests. Please try again later.' })

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -80,6 +80,7 @@ export const InitEmailTransactionalRoute = (
 
   router.post(
     '/send',
+    emailTransactionalMiddleware.rateLimit,
     FileAttachmentMiddleware.fileUploadHandler,
     FileAttachmentMiddleware.preprocessPotentialIncomingFile,
     celebrate(sendValidator),
@@ -87,7 +88,6 @@ export const InitEmailTransactionalRoute = (
     emailTransactionalMiddleware.saveMessage,
     emailMiddleware.isFromAddressAccepted,
     emailMiddleware.existsFromAddress, // future todo: put a cache to reduce db hits
-    emailTransactionalMiddleware.rateLimit,
     emailTransactionalMiddleware.sendMessage
   )
 

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -6,10 +6,7 @@ import {
   FileExtensionService,
   UNSUPPORTED_FILE_TYPE_ERROR_CODE,
 } from '@core/services'
-import {
-  RATE_LIMIT_ERROR_MESSAGE,
-  TRANSACTIONAL_EMAIL_WINDOW,
-} from '@email/middlewares'
+import { TRANSACTIONAL_EMAIL_WINDOW } from '@email/middlewares'
 import {
   EmailFromAddress,
   EmailMessageTransactional,
@@ -788,24 +785,6 @@ describe(`${emailTransactionalRoute}/send`, () => {
     expect(res.status).toBe(429)
     expect(mockSendEmail).not.toBeCalled()
     mockSendEmail.mockClear()
-    // second email is saved in db but has error code 429
-    const secondEmail = await EmailMessageTransactional.findOne({
-      where: { userId: user.id.toString() },
-      order: [['createdAt', 'DESC']],
-    })
-    expect(secondEmail).not.toBeNull()
-    expect(secondEmail).toMatchObject({
-      recipient: validApiCall.recipient,
-      from: validApiCall.from,
-      status: TransactionalEmailMessageStatus.Unsent,
-      errorCode: RATE_LIMIT_ERROR_MESSAGE,
-    })
-    expect(secondEmail?.params).toMatchObject({
-      subject: validApiCall.subject,
-      body: validApiCall.body,
-      from: validApiCall.from,
-      reply_to: validApiCall.reply_to,
-    })
   })
 
   test('Requests should not be rate limited after window elasped and metadata is saved correctly in db', async () => {
@@ -844,24 +823,6 @@ describe(`${emailTransactionalRoute}/send`, () => {
     expect(res.status).toBe(429)
     expect(mockSendEmail).not.toBeCalled()
     mockSendEmail.mockClear()
-    const secondEmail = await EmailMessageTransactional.findOne({
-      where: { userId: user.id.toString() },
-      order: [['createdAt', 'DESC']],
-    })
-    expect(secondEmail).not.toBeNull()
-    expect(secondEmail).toMatchObject({
-      recipient: validApiCall.recipient,
-      from: validApiCall.from,
-      status: TransactionalEmailMessageStatus.Unsent,
-      errorCode: RATE_LIMIT_ERROR_MESSAGE,
-    })
-    expect(secondEmail?.params).toMatchObject({
-      subject: validApiCall.subject,
-      body: validApiCall.body,
-      from: validApiCall.from,
-      reply_to: validApiCall.reply_to,
-    })
-
     // Third request passes after 1s
     await new Promise((resolve) =>
       setTimeout(resolve, TRANSACTIONAL_EMAIL_WINDOW * 1000)


### PR DESCRIPTION
## Problem

- Previously, rate-limited emails are sent to database. This is a problem as we scale up as it means even rate-limited emails are causing db writes. This issue is thankfully flagged by @stanleynguyen prior to our upcoming big deployment.

## Solution

- Move rate-limit up, so that it precedes writing to database
- Remove tests that checks that rate-limited emails have been written to db

## Deployment Checklist

N/A just deploy only
