### PR TITLE
fix: remove cypress test temporarily

### DIFF
--- a/.github/workflows/non-serverless-deploy.yml
+++ b/.github/workflows/non-serverless-deploy.yml
@@ -94,10 +94,43 @@ jobs:
     uses: ./.github/workflows/deploy-frontend.yml
     secrets: inherit
 
+  # e2e-test:
+  #   needs:
+  #     - deploy-backend
+  #     - deploy-frontend
+  #     - deploy-worker
+  #   name: Cypress Test
+  #   uses: ./.github/workflows/cypress.yml
+  #   secrets: inherit
+
+  # revert-on-e2e-failure:
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - deploy-backend
+  #     - deploy-frontend
+  #     - deploy-worker
+  #     # - e2e-test
+  #   if: always()
+  #   steps:
+  #     - name: Configure AWS credentials
+  #       uses: aws-actions/configure-aws-credentials@v1
+  #       with:
+  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: ap-southeast-1
+  #     - run: |
+  #         if [ "${{ needs.e2e-test.outputs.cypress_result }}" = "failure" ];then
+  #           ${{ needs.deploy-worker.outputs.sending_revert_command }}
+  #           ${{ needs.deploy-worker.outputs.logging_revert_command }}
+  #           ${{ needs.deploy-frontend.outputs.revert_command }}
+  #           ${{ needs.deploy-backend.outputs.revert_command_backend }}
+  #           ${{ needs.deploy-backend.outputs.revert_command_callback }}
+  #         fi
   slack-success:
     needs:
       - slack-prepare
       - slack-started
+      # - e2e-test
     if: success()
     name: Send Slack message about successful build
     runs-on: ubuntu-latest
@@ -150,6 +183,7 @@ jobs:
       - deploy-backend
       - deploy-frontend
       - deploy-worker
+      # - e2e-test
     if: failure()
     name: Send Slack message about failed build and tag engineers if it's prod
     runs-on: ubuntu-latest

--- a/.github/workflows/non-serverless-deploy.yml
+++ b/.github/workflows/non-serverless-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           message=${{ toJSON(github.event.head_commit.message) }}
           # taking only the first line and removing double quotes from string value
-          message="$(echo $message | sed -z 's/\\n.*//g; s/"//g')" 
+          message="$(echo $message | sed -z 's/\\n.*//g; s/"//g')"
           echo "commit_message=$message" >> $GITHUB_OUTPUT
 
   slack-started:
@@ -94,43 +94,10 @@ jobs:
     uses: ./.github/workflows/deploy-frontend.yml
     secrets: inherit
 
-  e2e-test:
-    needs:
-      - deploy-backend
-      - deploy-frontend
-      - deploy-worker
-    name: Cypress Test
-    uses: ./.github/workflows/cypress.yml
-    secrets: inherit
-
-  revert-on-e2e-failure:
-    runs-on: ubuntu-latest
-    needs:
-      - deploy-backend
-      - deploy-frontend
-      - deploy-worker
-      - e2e-test
-    if: always()
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-southeast-1
-      - run: |
-          if [ "${{ needs.e2e-test.outputs.cypress_result }}" = "failure" ];then
-            ${{ needs.deploy-worker.outputs.sending_revert_command }}
-            ${{ needs.deploy-worker.outputs.logging_revert_command }}
-            ${{ needs.deploy-frontend.outputs.revert_command }}
-            ${{ needs.deploy-backend.outputs.revert_command_backend }}
-            ${{ needs.deploy-backend.outputs.revert_command_callback }}
-          fi
   slack-success:
     needs:
       - slack-prepare
       - slack-started
-      - e2e-test
     if: success()
     name: Send Slack message about successful build
     runs-on: ubuntu-latest
@@ -183,7 +150,6 @@ jobs:
       - deploy-backend
       - deploy-frontend
       - deploy-worker
-      - e2e-test
     if: failure()
     name: Send Slack message about failed build and tag engineers if it's prod
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

- Currently, Cypress test is flaky and, combined with the reversion after failure, is causing dev issues
- We also discovered the Cypress test coverage is less than we expected (something to fix soon)

## Solution

- We will be temporarily disabling the Cypress test until we fix the flakiness. We should have a subsequent PR to fix the coverage issue too.