### PR TITLE
fix: `log_job_email` fn

### DIFF
--- a/backend/src/database/migrations/20230301104113-recreate-log-job-email-fn.js
+++ b/backend/src/database/migrations/20230301104113-recreate-log-job-email-fn.js
@@ -32,8 +32,33 @@ module.exports = {
   },
 
   down: async (queryInterface, _) => {
-    await queryInterface.dropFunction('log_job_email', [
-      { type: 'integer', name: 'selected_campaign_id' },
-    ])
+    await queryInterface.createFunction(
+      'log_job_email',
+      [{ type: 'integer', name: 'selected_campaign_id' }],
+      'void',
+      'plpgsql',
+      `
+        UPDATE email_messages m
+          -- setting dequeued_at to null so it can be retried if needed
+        SET dequeued_at = NULL,
+          -- coalesced fields should prioritise message table over ops table
+          -- because callbacks might arrive before logging
+          error_code = COALESCE(m.error_code, p.error_code),
+            status = COALESCE(m.status, p.status),
+          message_id = p.message_id,
+          sent_at = p.sent_at,
+          delivered_at = p.delivered_at,
+          received_at = COALESCE(m.received_at, p.received_at),
+          updated_at = clock_timestamp()
+        FROM email_ops p WHERE
+        m.id = p.id;
+
+        DELETE FROM email_ops p WHERE  p.campaign_id = selected_campaign_id;
+
+        PERFORM update_stats_email(selected_campaign_id);
+      `,
+      [],
+      { force: true }
+    )
   },
 }

--- a/backend/src/database/migrations/20230301104113-recreate-log-job-email-fn.js
+++ b/backend/src/database/migrations/20230301104113-recreate-log-job-email-fn.js
@@ -1,0 +1,39 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, _) => {
+    await queryInterface.createFunction(
+      'log_job_email',
+      [{ type: 'integer', name: 'selected_campaign_id' }],
+      'void',
+      'plpgsql',
+      `
+        UPDATE email_messages m
+          -- setting dequeued_at to null so it can be retried if needed
+        SET dequeued_at = NULL,
+          -- coalesced fields should prioritise message table over ops table
+          -- because callbacks might arrive before logging
+          error_code = COALESCE(m.error_code, p.error_code),
+            status = COALESCE(m.status, p.status),
+          sent_at = p.sent_at,
+          delivered_at = p.delivered_at,
+          received_at = COALESCE(m.received_at, p.received_at),
+          updated_at = clock_timestamp()
+        FROM email_ops p WHERE
+        m.id = p.id;
+
+        DELETE FROM email_ops p WHERE  p.campaign_id = selected_campaign_id;
+
+        PERFORM update_stats_email(selected_campaign_id);
+      `,
+      [],
+      { force: true }
+    )
+  },
+
+  down: async (queryInterface, _) => {
+    await queryInterface.dropFunction('log_job_email', [
+      { type: 'integer', name: 'selected_campaign_id' },
+    ])
+  },
+}


### PR DESCRIPTION
Campaigns were stuck because the `log_job_email` function is looking for the `message_id` column, which was removed in an [earlier PR](https://github.com/opengovsg/postmangovsg/pull/1880). 

Fixed by creating a new `log_job_email` that does not look for the `message_id`. 

- [x] Run against staging
- [x] Run against prod