### PR TITLE
chore: log channel provider message id to aid debugging

### DIFF
--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -210,10 +210,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
    * @param email
    * @param ipAddress originating IP address that requests for OTP.
    */
-  const sendOtp = async (
-    email: string,
-    ipAddress: string
-  ): Promise<string | void> => {
+  const sendOtp = async (email: string, ipAddress: string): Promise<void> => {
     const otp = generateOtp()
     const hashValue = await bcrypt.hash(otp, SALT_ROUNDS)
     const hashedOtp: HashedOtp = {
@@ -224,7 +221,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     await saveHashedOtp(email, hashedOtp)
 
     const appName = config.get('APP_NAME')
-    return MailService.mailClient.sendMail({
+    await MailService.mailClient.sendMail({
       from: config.get('mailFrom'),
       recipients: [email],
       subject: `One-Time Password (OTP) for ${appName}`,

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -11,7 +11,7 @@ import { Transaction } from 'sequelize/types'
 
 export interface AuthService {
   canSendOtp(email: string): Promise<void>
-  sendOtp(email: string, ipAddress: string): Promise<boolean>
+  sendOtp(email: string, ipAddress: string): Promise<string | void>
   verifyOtp(input: VerifyOtpInput): Promise<boolean>
   findOrCreateUser(email: string): Promise<User>
   findUser(id: number): Promise<User>
@@ -213,7 +213,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
   const sendOtp = async (
     email: string,
     ipAddress: string
-  ): Promise<boolean> => {
+  ): Promise<string | void> => {
     const otp = generateOtp()
     const hashValue = await bcrypt.hash(otp, SALT_ROUNDS)
     const hashedOtp: HashedOtp = {

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -11,7 +11,7 @@ import { Transaction } from 'sequelize/types'
 
 export interface AuthService {
   canSendOtp(email: string): Promise<void>
-  sendOtp(email: string, ipAddress: string): Promise<string | void>
+  sendOtp(email: string, ipAddress: string): Promise<void>
   verifyOtp(input: VerifyOtpInput): Promise<boolean>
   findOrCreateUser(email: string): Promise<User>
   findUser(id: number): Promise<User>
@@ -221,7 +221,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     await saveHashedOtp(email, hashedOtp)
 
     const appName = config.get('APP_NAME')
-    await MailService.mailClient.sendMail({
+    void MailService.mailClient.sendMail({
       from: config.get('mailFrom'),
       recipients: [email],
       subject: `One-Time Password (OTP) for ${appName}`,

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -156,14 +156,14 @@ const sendEmail = async (
   opts?: SendEmailOpts
 ): Promise<boolean> => {
   try {
-    const channelProviderMessageId = await MailService.mailClient.sendMail(
+    const serviceProviderMessageId = await MailService.mailClient.sendMail(
       mail,
       opts
     )
     logger.info({
       message: 'Message sent to channel provider.',
       nativeMessageId: mail.messageId,
-      channelProviderMessageId: channelProviderMessageId,
+      serviceProviderMessageId: serviceProviderMessageId,
     })
   } catch (e) {
     logger.error({

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -163,7 +163,7 @@ const sendEmail = async (
     logger.info({
       message: 'Message sent to channel provider.',
       nativeMessageId: mail.messageId,
-      serviceProviderMessageId: serviceProviderMessageId,
+      serviceProviderMessageId,
     })
   } catch (e) {
     logger.error({

--- a/backend/src/email/services/email.service.ts
+++ b/backend/src/email/services/email.service.ts
@@ -156,7 +156,15 @@ const sendEmail = async (
   opts?: SendEmailOpts
 ): Promise<boolean> => {
   try {
-    await MailService.mailClient.sendMail(mail, opts)
+    const channelProviderMessageId = await MailService.mailClient.sendMail(
+      mail,
+      opts
+    )
+    logger.info({
+      message: 'Message sent to channel provider.',
+      nativeMessageId: mail.messageId,
+      channelProviderMessageId: channelProviderMessageId,
+    })
   } catch (e) {
     logger.error({
       message: 'Error while sending test email',

--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -38,8 +38,11 @@ export default class MailClient {
     this.configSet = configSet
   }
 
-  public sendMail(input: MailToSend, option?: SendEmailOpts): Promise<boolean> {
-    return new Promise<boolean>((resolve, reject) => {
+  public sendMail(
+    input: MailToSend,
+    option?: SendEmailOpts
+  ): Promise<string | void> {
+    return new Promise<string | void>((resolve, reject) => {
       const username = Math.random().toString(36).substring(2, 15) // random string
       const xSmtpHeader: { [key: string]: any } = {
         auth: {
@@ -83,11 +86,11 @@ export default class MailClient {
         bcc: input.bcc,
       }
 
-      this.mailer.sendMail(options, (err, _info) => {
+      this.mailer.sendMail(options, (err, info) => {
         if (err !== null) {
           reject(new Error(`${err}`))
         } else {
-          resolve(true)
+          resolve(info.messageId)
         }
       })
     })

--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -42,7 +42,7 @@ export default class MailClient {
     input: MailToSend,
     option?: SendEmailOpts
   ): Promise<string | void> {
-    return new Promise<string | void>((resolve, reject) => {
+    return new Promise<string>((resolve, reject) => {
       const username = Math.random().toString(36).substring(2, 15) // random string
       const xSmtpHeader: { [key: string]: any } = {
         auth: {


### PR DESCRIPTION
Task:
https://www.notion.so/opengov/Ensure-AWS-SES-message_id-are-logged-with-table-primary-key-ID-03254019c59f4a6d92af62a11043c6fc

## Solution
- Message AWS SES ID written to CloudWatch Logs alongside "native" message ID (i.e. DB table primary key value).
- Tested in staging (both campaign and tx).
- [Wrote guide on how to resolve AWS SES ID from native message ID.](https://www.notion.so/opengov/Resolving-AWS-SES-ID-from-Native-Message-ID-c6d47be3edcf433daf1bc8cd66b69c05)
- Confirmed both log groups have sufficient retention (currently infinite).
