### PR TITLE
feat: use api key table api records instead

### DIFF
--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -11,17 +11,11 @@ import { Transaction } from 'sequelize/types'
 
 export interface AuthService {
   canSendOtp(email: string): Promise<void>
-
   sendOtp(email: string, ipAddress: string): Promise<boolean>
-
   verifyOtp(input: VerifyOtpInput): Promise<boolean>
-
   findOrCreateUser(email: string): Promise<User>
-
   findUser(id: number): Promise<User>
-
   checkCookie(req: Request): boolean
-
   getUserForApiKey(req: Request): Promise<User | null>
 }
 


### PR DESCRIPTION
resolves [ticket](https://www.notion.so/opengov/Update-API-authentication-middleware-to-use-api_keys-table-874cbd2343c34aad85fe20883e205eef?pvs=4)

included
- rewrote logic flow to move all sad path above
- find the key from api key table, then find in user that has that api key