### PR TITLE
build(deps): upgrade snyk security vuln

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.145.0",
-        "@aws-sdk/client-sns": "3.112.0",
+        "@aws-sdk/client-sns": "3.287.0",
         "@sentry/node": "5.30.0",
         "async-retry": "1.3.3",
         "aws-sdk": "2.1158.0",
@@ -42,7 +42,7 @@
         "rate-limit-redis": "2.1.0",
         "redis": "3.1.2",
         "reflect-metadata": "0.1.13",
-        "sequelize": "6.21.2",
+        "sequelize": "6.29.1",
         "sequelize-typescript": "2.1.3",
         "source-map-support": "0.5.19",
         "starkbank-ecdsa": "1.1.4",
@@ -198,15 +198,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.110.0.tgz",
-      "integrity": "sha512-zok/WEVuK7Jh6V9YeA56pNZtxUASon9LTkS7vE65A4UFmNkPGNBCNgoiBcbhWfxwrZ8wtXcQk6rtUut39831mA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
@@ -868,292 +868,782 @@
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.112.0.tgz",
-      "integrity": "sha512-4PzIhfXJvIL9RzD+xKO82Sd7SS2ds0avcM1h99kE/TtVvi1LIzhnRBgAk9C9gAJ1RH3drNvWBPmdjqO+O45JdA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.287.0.tgz",
+      "integrity": "sha512-oEd5b+Uo4P6bbXRPiN8G/m24RS9XMpOXziyGPj3nAhj3jhhC2q0Ygfeaw5D4KoHL46O8HzWpGC6uTvKR2HDYgg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.112.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-node": "3.112.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.287.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns/node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.112.0.tgz",
-      "integrity": "sha512-FwFmiapxuVQiyMdDaBvCpajnJkVWEUHBdO+7rIpzgKHkODEPou5/AwboaGRPEFYULOyYeI0HiDFzpK0G6de+7Q==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.287.0.tgz",
+      "integrity": "sha512-YXD/oP38tsgKYTnft17O6OLTBBdal7CZsRhCJUHUSg3xAV9AiLloMwGrSxcZh4qMhx5bcn9XaVxu8dApsXnJXw==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.287.0.tgz",
+      "integrity": "sha512-zrUy5jpu32sjmOcSlr8IVNTT/Pfa8ZPj6v0P/sNN3PWIv9fbep/0MJyIwbWJLCfQVLZqRvlMovFzVlnWixjraw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.112.0.tgz",
-      "integrity": "sha512-hSApRO2wg3jk9VRGM6SCZO3aFP7DKVSUqs6FrvlXlj+JU88ZKObjrGE61cCzXoD89Dh+b9t8A2T6W51Nzriaxw==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.287.0.tgz",
+      "integrity": "sha512-s6ST78bxSH+nFAFcvSU7bhNAGz/e9Q/77+0Y0JPl/Q2ZWKMfO9AWs/uAieATMBhVuG/8ok4WKrR9YCbMr/ai8A==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-node": "3.112.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-sdk-sts": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-sdk-sts": "3.282.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.110.0.tgz",
-      "integrity": "sha512-7VvtKy4CL63BAktQ2vgsjhWDSXpkXO5YdiI56LQnHztrvSuJBBaxJ7R1p/k0b2tEUhYKUziAIW8EKE/7EGPR4g==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.287.0.tgz",
+      "integrity": "sha512-YLJ9+ufcrj73DBmqgG50WMAVNHb8PdWL7hkp3gs00VOsXeEMGdQK92fVlx8Him8yPDikvLS2orrEVRcYxj5Uag==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-config-provider": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.110.0.tgz",
-      "integrity": "sha512-oFU3IYk/Bl5tdsz1qigtm3I25a9cvXPqlE8VjYjxVDdLujF5zd/4HLbhP4GQWhpEwZmM1ijcSNfLcyywVevTZg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.110.0.tgz",
-      "integrity": "sha512-atl+7/dAB+8fG9XI2fYyCgXKYDbOzot65VAwis+14bOEUCVp7PCJifBEZ/L8GEq564p+Fa2p1IpV0wuQXxqFUQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.287.0.tgz",
+      "integrity": "sha512-awvsREwUgb9V5pbrP9DyNGh5iXBE8Pbb5EeMw8zJsX+cYuD95N0YncrU/7MAf0+ro851gBqjC3Dty8ujrAhkSg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.112.0.tgz",
-      "integrity": "sha512-ebgZ6/jZdTGHQ3zfq/ccmS+7YmLk6yUWHDmh69VK+B1Dd+S1jFwbD9EQ+pYWCp/gEl9F620NSwb6KghRylPWEQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.287.0.tgz",
+      "integrity": "sha512-mDl/twCpXvWUb4A+L3z+v0N4oRF9cnOrkdhW9yP3hBT84RJqCIFHtk966rFiZod8MbhE2LluODtzXVJEIHpmpg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/credential-provider-sso": "3.112.0",
-        "@aws-sdk/credential-provider-web-identity": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.112.0.tgz",
-      "integrity": "sha512-7txS7P3BAaU4cksFw/PnoVskVvO8h/TPvOl/BxFtCiUdwA6FRltLvBeMlN08fwUoqgM6z06q8areBdeDqCHOSw==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.287.0.tgz",
+      "integrity": "sha512-7f41hmgwMpMOFgDmpR76xEAXDlG4OHkS1pJU5bt9P4UL2EJWuxvJkdbvI4g9th+lT4cbzWXGFwK+oZ7xBKsVKw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/credential-provider-ini": "3.112.0",
-        "@aws-sdk/credential-provider-process": "3.110.0",
-        "@aws-sdk/credential-provider-sso": "3.112.0",
-        "@aws-sdk/credential-provider-web-identity": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-ini": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.110.0.tgz",
-      "integrity": "sha512-JJcZePvRTfQHYj/+EEY13yItnZH/e8exlARFUjN0L13UrgHpOJtDQBa+YBHXo6MbTFQh+re25z2kzc+zOYSMNQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.287.0.tgz",
+      "integrity": "sha512-3iWtit/4Iyv/JjL2L0cO7v94NvsISTH/ak0CXqAgb2LdCOz0JN3txgg+ciZzdVLUP8M7x/bm4HjMcUVaxS0HZw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.112.0.tgz",
-      "integrity": "sha512-b6rOrSXbNK3fGyPvNpyF5zdktmAoNOqHCTmFSUcxRxOipyRGb5JACsbjWthIQkpWkpNCT8GFNLEg9spXPFIdLA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.287.0.tgz",
+      "integrity": "sha512-aJGV4zIFOPWn6PQRjduI3jX+cPCtDtqTNefmsdpw+BIdWFwFINDwoCKfkodnkzxGrB0n35wkGEiddJlwlMwROA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.112.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/client-sso": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/token-providers": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.110.0.tgz",
-      "integrity": "sha512-e4e5u7v3fsUFZsMcFMhMy1NdJBQpunYcLwpYlszm3OEICwTTekQ+hVvnVRd134doHvzepE4yp9sAop0Cj+IRVQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.110.0.tgz",
-      "integrity": "sha512-vk+K4GeCZL2J2rtvKO+T0Q7i3MDpEGZBMg5K2tj9sMcEQwty0BF0aFnP7Eu2l4/Zif2z1mWuUFM2WcZI6DVnbw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
+      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/querystring-builder": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.110.0.tgz",
-      "integrity": "sha512-wakl+kP2O8wTGYiQ3InZy+CVfGrIpFfq9fo4zif9PZac0BbUbguUU1dkY34uZiaf+4o2/9MoDYrHU2HYeXKxWw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.110.0.tgz",
-      "integrity": "sha512-O8J1InmtJkoiUMbQDtxBfOzgigBp9iSVsNXQrhs2qHh3826cJOfE7NGT3u+NMw73Pk5j2cfmOh1+7k/76IqxOg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
@@ -1169,70 +1659,100 @@
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.110.0.tgz",
-      "integrity": "sha512-hKU+zdqfAJQg22LXMVu/z35nNIHrVAKpVKPe9+WYVdL/Z7JKUPK7QymqKGOyDuDbzW6OxyulC1zKGEX12zGmdA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
+      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
+      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.110.0.tgz",
-      "integrity": "sha512-/Cknn1vL2LTlclI0MX2RzmtdPlCJ5palCRXxm/mod1oHwg4oNTKRlUX3LUD+L8g7JuJ4h053Ch9KS/A0vanE5Q==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
+      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.110.0.tgz",
-      "integrity": "sha512-+pz+a+8dfTnzLj79nHrv3aONMp/N36/erMd+7JXeR84QEosVLrFBUwKA8x5x6O3s1iBbQzRKMYEIuja9xn1BPA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.287.0.tgz",
+      "integrity": "sha512-YZe/3Qs3IelJGK/mUYrCAzTIP1iu6uN4NZCofRP113UXrbipSF+wG2rZWPYyJ/cfAXL1kG4SWtdcKvLiwVEn0g==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.110.0.tgz",
-      "integrity": "sha512-Wav782zd7bcd1e6txRob76CDOdVOaUQ8HXoywiIm/uFrEEUZvhs2mgnXjVUVCMBUehdNgnL99z420aS13JeL/Q==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
+      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.110.0.tgz",
-      "integrity": "sha512-lwLAQQveCiUqymQvVYjCee6QOXw3Zqbc9yq+pxYdXbs1Cv1XMA6PeJeUU5r5KEVuSceBLyyrnl6E0R1l1om1MQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.287.0.tgz",
+      "integrity": "sha512-pXIAWuwGpWRWjIIJwbkNQGbhOGoOYVaO5WZZ+65PgKkOVDLeCYU0O26PD5cHw2ksUye8dKGfIXHTbe4CmxDveA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/service-error-classification": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-middleware": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
@@ -1244,214 +1764,291 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.110.0.tgz",
-      "integrity": "sha512-EjY/YFdlr5jECde6qIrTIyGBbn/34CKcQGKvmvRd31+3qaClIJLAwNuHfcVzWvCUGbAslsfvdbOpLju33pSQRA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
+      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.110.0.tgz",
-      "integrity": "sha512-brVupxgEAmcZ9cZvdHEH8zncjvGKIiud8pOe4fiimp5NpHmjBLew4jUbnOKNZNAjaidcKUtz//cxtutD6yXEww==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.110.0.tgz",
-      "integrity": "sha512-y6ZKrGYfgDlFMzWhZmoq5J1UctBgZOUvMmnU9sSeZ020IlEPiOxFMvR0Zu6TcYThp8uy3P0wyjQtGYeTl9Z/kA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
+      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.110.0.tgz",
-      "integrity": "sha512-iaLHw6ctOuGa9UxNueU01Xes+15dR+mqioRpUOUZ9Zx+vhXVpD7C8lnNqhRnYeFXs10/rNIzASgsIrAHTlnlIQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.110.0.tgz",
-      "integrity": "sha512-Y6FgiZr99DilYq6AjeaaWcNwVlSQpNGKrILzvV4Tmz03OaBIspe4KL+8EZ2YA/sAu5Lpw80vItdezqDOwGAlnQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
+      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.110.0.tgz",
-      "integrity": "sha512-46p4dCPGYctuybTQTwLpjenA1QFHeyJw/OyggGbtUJUy+833+ldnAwcPVML2aXJKUKv3APGI8vq1kaloyNku3Q==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.287.0.tgz",
+      "integrity": "sha512-+AO5dy6JEDvgtH9fcuCNnAQd6ilZjww8d/HNTCb5xOhiW1/pKSNMRhouGfn47uxq61WwDN/qUnv2nlVN83RB6w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.110.0.tgz",
-      "integrity": "sha512-/rP+hY516DpP8fZhwFW5xM/ElH0w6lxw/15VvZCoY5EnOLAF5XIsJdzscWPSEW2FHCylBM4SNrKhGar14BDXhA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
+      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/querystring-builder": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.110.0.tgz",
-      "integrity": "sha512-7NkpmYeOkK3mhWBNU+/zSDqwzeaSPH1qrq4L//WV7WS/weYyE/jusQeZoOxVsuZQnQEXHt5O2hKVeUwShl12xA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.110.0.tgz",
-      "integrity": "sha512-qdi2gCbJiyPyLn+afebPNp/5nVCRh1X7t7IRIFl3FHVEC+o54u/ojay/MLZ4M/+X9Fa4Zxsb0Wpp3T0xAHVDBg==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
+      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.110.0.tgz",
-      "integrity": "sha512-7V3CDXj519izmbBn9ZE68ymASwGriA+Aq+cb/yHSVtffnvXjPtvONNw7G/5iVblisGLSCUe2hSvpYtcaXozbHw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.110.0.tgz",
-      "integrity": "sha512-//pJHH7hrhdDMZGBPKXKymmC/tJM7gFT0w/qbu/yd3Wm4W2fMB+8gkmj6EZctx7jrsWlfRQuvFejKqEfapur/g==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
-      "integrity": "sha512-ccgCE0pU/4RmXR6CP3fLAdhPAve7bK/yXBbGzpSHGAQOXqNxYzOsAvQ30Jg6X+qjLHsI/HR2pLIE65z4k6tynw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.110.0.tgz",
-      "integrity": "sha512-E1ERoqEoG206XNBYWCKLgHkzCbTxdpDEGbsLET2DnvjFsT0s9p2dPvVux3bYl7JVAhyGduE+qcqWk7MzhFCBNQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.287.0.tgz",
+      "integrity": "sha512-CxZp6R11uC12lNg+vKXc8bU7mqIrM43ZY2BbLRZ4tBlc7RLQpcJyccpEwEQAmJq0PA+rDUNod0gYnrM5DOUCLg==",
       "dependencies": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.110.0.tgz",
-      "integrity": "sha512-utxxdllOnmQDhbpipnFAbuQ4c2pwefZ+2hi48jKvQRULQ2PO4nxLmdZm6B0FXaTijbKsyO7GrMik+EZ6mi3ARQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
+      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.110.0.tgz",
-      "integrity": "sha512-gNLYrmdAe/1hVF2Nv2LF4OkL1A0a1o708pEMZHzql9xP164omRDaLrGDhz9tH7tsJEgLz+Bf4E8nTuISeDwvGg==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
+      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.287.0.tgz",
+      "integrity": "sha512-RuqgncuQpLD5+W84RbTj/pgJmrjxSPJG0GBAtnISXrc39mGoc0ArOzQUTKIs+cLqDY+WS1/pqXlnQmKvmw3TQw==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
-      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/url-parser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.110.0.tgz",
-      "integrity": "sha512-tILFB8/Q73yzgO0dErJNnELmmBszd0E6FucwAnG3hfDefjqCBe09Q/1yhu2aARXyRmZa4AKp0sWcdwIWHc8dnA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/querystring-parser": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
@@ -1472,6 +2069,29 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
@@ -1517,12 +2137,12 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.110.0.tgz",
-      "integrity": "sha512-Y2dcOOD20S3bv/IjUqpdKIiDt6995SXNG5Pu/LeSdXNyLCOIm9rX4gHTxl9fC1KK5M/gR9fGJ362f67WwqEEqw==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
+      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -1531,19 +2151,31 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.110.0.tgz",
-      "integrity": "sha512-Cr3Z5nyrw1KowjbW76xp8hkT/zJtYjAVZ9PS4l84KxIicbVvDOBpxG3yNddkuQcavmlH6G4wH9uM5DcnpKDncg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.287.0.tgz",
+      "integrity": "sha512-ZGpbPvUA+m+Lf01eTDHkXmulEPT4LphffEt6M9cHPMhwEZfzxhXLyNXyGRunraoBBzB62hKBbFM2atsoHpuIZA==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-hex-encoding": {
@@ -1569,14 +2201,26 @@
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.110.0.tgz",
-      "integrity": "sha512-PTVWrI5fA9d5hHJs6RzX2dIS2jRQ3uW073Fm0BePpQeDdZrEk+S5KNwRhUtpN6sdSV45vm6S9rrjZUG51qwGmA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
@@ -1591,26 +2235,46 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.110.0.tgz",
-      "integrity": "sha512-rNdhmHDMV5dNJctqlBWimkZLJRB+x03DB+61pm+SKSFk6gPIVIvc1WNXqDFphkiswT4vA13ZUkGHzt+N4+noQQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
+      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
       "dependencies": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.110.0.tgz",
-      "integrity": "sha512-OQ915TPCCBwZWz5Np8zkNWn7U6KvrTZfFoCOy/VIemK3dUqmnBZ7HqGpuZx8SwJ2R9JE1x+j0niYSJ5fWJZZKA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.287.0.tgz",
+      "integrity": "sha512-yXg0C3WyxyRkQstR4VCTgnEPQd/ViRz+9rEPkYNIWXPvp1l8hPygk5q9tmSD09Lg8wzm6jR6V0MSyJnbwdzq+g==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
@@ -1631,6 +2295,29 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8/node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -10451,9 +11138,9 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -10657,9 +11344,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -10674,9 +11361,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -10695,6 +11382,9 @@
           "optional": true
         },
         "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
           "optional": true
         },
         "pg": {
@@ -11179,6 +11869,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/strtok3": {
       "version": "6.3.0",
@@ -12649,11 +13344,11 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.110.0.tgz",
-      "integrity": "sha512-zok/WEVuK7Jh6V9YeA56pNZtxUASon9LTkS7vE65A4UFmNkPGNBCNgoiBcbhWfxwrZ8wtXcQk6rtUut39831mA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
@@ -13193,256 +13888,760 @@
       }
     },
     "@aws-sdk/client-sns": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.112.0.tgz",
-      "integrity": "sha512-4PzIhfXJvIL9RzD+xKO82Sd7SS2ds0avcM1h99kE/TtVvi1LIzhnRBgAk9C9gAJ1RH3drNvWBPmdjqO+O45JdA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.287.0.tgz",
+      "integrity": "sha512-oEd5b+Uo4P6bbXRPiN8G/m24RS9XMpOXziyGPj3nAhj3jhhC2q0Ygfeaw5D4KoHL46O8HzWpGC6uTvKR2HDYgg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.112.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-node": "3.112.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.287.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.112.0.tgz",
-      "integrity": "sha512-FwFmiapxuVQiyMdDaBvCpajnJkVWEUHBdO+7rIpzgKHkODEPou5/AwboaGRPEFYULOyYeI0HiDFzpK0G6de+7Q==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.287.0.tgz",
+      "integrity": "sha512-YXD/oP38tsgKYTnft17O6OLTBBdal7CZsRhCJUHUSg3xAV9AiLloMwGrSxcZh4qMhx5bcn9XaVxu8dApsXnJXw==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.287.0.tgz",
+      "integrity": "sha512-zrUy5jpu32sjmOcSlr8IVNTT/Pfa8ZPj6v0P/sNN3PWIv9fbep/0MJyIwbWJLCfQVLZqRvlMovFzVlnWixjraw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.112.0.tgz",
-      "integrity": "sha512-hSApRO2wg3jk9VRGM6SCZO3aFP7DKVSUqs6FrvlXlj+JU88ZKObjrGE61cCzXoD89Dh+b9t8A2T6W51Nzriaxw==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.287.0.tgz",
+      "integrity": "sha512-s6ST78bxSH+nFAFcvSU7bhNAGz/e9Q/77+0Y0JPl/Q2ZWKMfO9AWs/uAieATMBhVuG/8ok4WKrR9YCbMr/ai8A==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-node": "3.112.0",
-        "@aws-sdk/fetch-http-handler": "3.110.0",
-        "@aws-sdk/hash-node": "3.110.0",
-        "@aws-sdk/invalid-dependency": "3.110.0",
-        "@aws-sdk/middleware-content-length": "3.110.0",
-        "@aws-sdk/middleware-host-header": "3.110.0",
-        "@aws-sdk/middleware-logger": "3.110.0",
-        "@aws-sdk/middleware-recursion-detection": "3.110.0",
-        "@aws-sdk/middleware-retry": "3.110.0",
-        "@aws-sdk/middleware-sdk-sts": "3.110.0",
-        "@aws-sdk/middleware-serde": "3.110.0",
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/middleware-user-agent": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/node-http-handler": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/smithy-client": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.110.0",
-        "@aws-sdk/util-defaults-mode-node": "3.110.0",
-        "@aws-sdk/util-user-agent-browser": "3.110.0",
-        "@aws-sdk/util-user-agent-node": "3.110.0",
-        "@aws-sdk/util-utf8-browser": "3.109.0",
-        "@aws-sdk/util-utf8-node": "3.109.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-sdk-sts": "3.282.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-crypto/ie11-detection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+          "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-browser": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+          "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+          "requires": {
+            "@aws-crypto/ie11-detection": "^3.0.0",
+            "@aws-crypto/sha256-js": "^3.0.0",
+            "@aws-crypto/supports-web-crypto": "^3.0.0",
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-locate-window": "^3.0.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/sha256-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+          "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+          "requires": {
+            "@aws-crypto/util": "^3.0.0",
+            "@aws-sdk/types": "^3.222.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/supports-web-crypto": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+          "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+          "requires": {
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-crypto/util": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+          "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+          "requires": {
+            "@aws-sdk/types": "^3.222.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
+            "tslib": "^1.11.1"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@aws-sdk/util-body-length-browser": {
+          "version": "3.188.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+          "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-body-length-node": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+          "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "fast-xml-parser": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+          "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        }
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.110.0.tgz",
-      "integrity": "sha512-7VvtKy4CL63BAktQ2vgsjhWDSXpkXO5YdiI56LQnHztrvSuJBBaxJ7R1p/k0b2tEUhYKUziAIW8EKE/7EGPR4g==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.287.0.tgz",
+      "integrity": "sha512-YLJ9+ufcrj73DBmqgG50WMAVNHb8PdWL7hkp3gs00VOsXeEMGdQK92fVlx8Him8yPDikvLS2orrEVRcYxj5Uag==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-config-provider": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.110.0.tgz",
-      "integrity": "sha512-oFU3IYk/Bl5tdsz1qigtm3I25a9cvXPqlE8VjYjxVDdLujF5zd/4HLbhP4GQWhpEwZmM1ijcSNfLcyywVevTZg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.110.0.tgz",
-      "integrity": "sha512-atl+7/dAB+8fG9XI2fYyCgXKYDbOzot65VAwis+14bOEUCVp7PCJifBEZ/L8GEq564p+Fa2p1IpV0wuQXxqFUQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.287.0.tgz",
+      "integrity": "sha512-awvsREwUgb9V5pbrP9DyNGh5iXBE8Pbb5EeMw8zJsX+cYuD95N0YncrU/7MAf0+ro851gBqjC3Dty8ujrAhkSg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/url-parser": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.112.0.tgz",
-      "integrity": "sha512-ebgZ6/jZdTGHQ3zfq/ccmS+7YmLk6yUWHDmh69VK+B1Dd+S1jFwbD9EQ+pYWCp/gEl9F620NSwb6KghRylPWEQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.287.0.tgz",
+      "integrity": "sha512-mDl/twCpXvWUb4A+L3z+v0N4oRF9cnOrkdhW9yP3hBT84RJqCIFHtk966rFiZod8MbhE2LluODtzXVJEIHpmpg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/credential-provider-sso": "3.112.0",
-        "@aws-sdk/credential-provider-web-identity": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.112.0.tgz",
-      "integrity": "sha512-7txS7P3BAaU4cksFw/PnoVskVvO8h/TPvOl/BxFtCiUdwA6FRltLvBeMlN08fwUoqgM6z06q8areBdeDqCHOSw==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.287.0.tgz",
+      "integrity": "sha512-7f41hmgwMpMOFgDmpR76xEAXDlG4OHkS1pJU5bt9P4UL2EJWuxvJkdbvI4g9th+lT4cbzWXGFwK+oZ7xBKsVKw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/credential-provider-ini": "3.112.0",
-        "@aws-sdk/credential-provider-process": "3.110.0",
-        "@aws-sdk/credential-provider-sso": "3.112.0",
-        "@aws-sdk/credential-provider-web-identity": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-ini": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.110.0.tgz",
-      "integrity": "sha512-JJcZePvRTfQHYj/+EEY13yItnZH/e8exlARFUjN0L13UrgHpOJtDQBa+YBHXo6MbTFQh+re25z2kzc+zOYSMNQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.287.0.tgz",
+      "integrity": "sha512-3iWtit/4Iyv/JjL2L0cO7v94NvsISTH/ak0CXqAgb2LdCOz0JN3txgg+ciZzdVLUP8M7x/bm4HjMcUVaxS0HZw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.112.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.112.0.tgz",
-      "integrity": "sha512-b6rOrSXbNK3fGyPvNpyF5zdktmAoNOqHCTmFSUcxRxOipyRGb5JACsbjWthIQkpWkpNCT8GFNLEg9spXPFIdLA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.287.0.tgz",
+      "integrity": "sha512-aJGV4zIFOPWn6PQRjduI3jX+cPCtDtqTNefmsdpw+BIdWFwFINDwoCKfkodnkzxGrB0n35wkGEiddJlwlMwROA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.112.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/client-sso": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/token-providers": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.110.0.tgz",
-      "integrity": "sha512-e4e5u7v3fsUFZsMcFMhMy1NdJBQpunYcLwpYlszm3OEICwTTekQ+hVvnVRd134doHvzepE4yp9sAop0Cj+IRVQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.110.0.tgz",
-      "integrity": "sha512-vk+K4GeCZL2J2rtvKO+T0Q7i3MDpEGZBMg5K2tj9sMcEQwty0BF0aFnP7Eu2l4/Zif2z1mWuUFM2WcZI6DVnbw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
+      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/querystring-builder": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.110.0.tgz",
-      "integrity": "sha512-wakl+kP2O8wTGYiQ3InZy+CVfGrIpFfq9fo4zif9PZac0BbUbguUU1dkY34uZiaf+4o2/9MoDYrHU2HYeXKxWw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.110.0.tgz",
-      "integrity": "sha512-O8J1InmtJkoiUMbQDtxBfOzgigBp9iSVsNXQrhs2qHh3826cJOfE7NGT3u+NMw73Pk5j2cfmOh1+7k/76IqxOg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
@@ -13455,53 +14654,79 @@
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.110.0.tgz",
-      "integrity": "sha512-hKU+zdqfAJQg22LXMVu/z35nNIHrVAKpVKPe9+WYVdL/Z7JKUPK7QymqKGOyDuDbzW6OxyulC1zKGEX12zGmdA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
+      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.110.0.tgz",
-      "integrity": "sha512-/Cknn1vL2LTlclI0MX2RzmtdPlCJ5palCRXxm/mod1oHwg4oNTKRlUX3LUD+L8g7JuJ4h053Ch9KS/A0vanE5Q==",
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
+      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/util-config-provider": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+          "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
+      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.110.0.tgz",
-      "integrity": "sha512-+pz+a+8dfTnzLj79nHrv3aONMp/N36/erMd+7JXeR84QEosVLrFBUwKA8x5x6O3s1iBbQzRKMYEIuja9xn1BPA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.287.0.tgz",
+      "integrity": "sha512-YZe/3Qs3IelJGK/mUYrCAzTIP1iu6uN4NZCofRP113UXrbipSF+wG2rZWPYyJ/cfAXL1kG4SWtdcKvLiwVEn0g==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.110.0.tgz",
-      "integrity": "sha512-Wav782zd7bcd1e6txRob76CDOdVOaUQ8HXoywiIm/uFrEEUZvhs2mgnXjVUVCMBUehdNgnL99z420aS13JeL/Q==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
+      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.110.0.tgz",
-      "integrity": "sha512-lwLAQQveCiUqymQvVYjCee6QOXw3Zqbc9yq+pxYdXbs1Cv1XMA6PeJeUU5r5KEVuSceBLyyrnl6E0R1l1om1MQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.287.0.tgz",
+      "integrity": "sha512-pXIAWuwGpWRWjIIJwbkNQGbhOGoOYVaO5WZZ+65PgKkOVDLeCYU0O26PD5cHw2ksUye8dKGfIXHTbe4CmxDveA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/service-error-classification": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-middleware": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
@@ -13514,166 +14739,248 @@
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.110.0.tgz",
-      "integrity": "sha512-EjY/YFdlr5jECde6qIrTIyGBbn/34CKcQGKvmvRd31+3qaClIJLAwNuHfcVzWvCUGbAslsfvdbOpLju33pSQRA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
+      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.110.0.tgz",
-      "integrity": "sha512-brVupxgEAmcZ9cZvdHEH8zncjvGKIiud8pOe4fiimp5NpHmjBLew4jUbnOKNZNAjaidcKUtz//cxtutD6yXEww==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.110.0.tgz",
-      "integrity": "sha512-y6ZKrGYfgDlFMzWhZmoq5J1UctBgZOUvMmnU9sSeZ020IlEPiOxFMvR0Zu6TcYThp8uy3P0wyjQtGYeTl9Z/kA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
+      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/signature-v4": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.110.0.tgz",
-      "integrity": "sha512-iaLHw6ctOuGa9UxNueU01Xes+15dR+mqioRpUOUZ9Zx+vhXVpD7C8lnNqhRnYeFXs10/rNIzASgsIrAHTlnlIQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.110.0.tgz",
-      "integrity": "sha512-Y6FgiZr99DilYq6AjeaaWcNwVlSQpNGKrILzvV4Tmz03OaBIspe4KL+8EZ2YA/sAu5Lpw80vItdezqDOwGAlnQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
+      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.110.0.tgz",
-      "integrity": "sha512-46p4dCPGYctuybTQTwLpjenA1QFHeyJw/OyggGbtUJUy+833+ldnAwcPVML2aXJKUKv3APGI8vq1kaloyNku3Q==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.287.0.tgz",
+      "integrity": "sha512-+AO5dy6JEDvgtH9fcuCNnAQd6ilZjww8d/HNTCb5xOhiW1/pKSNMRhouGfn47uxq61WwDN/qUnv2nlVN83RB6w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/shared-ini-file-loader": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.110.0.tgz",
-      "integrity": "sha512-/rP+hY516DpP8fZhwFW5xM/ElH0w6lxw/15VvZCoY5EnOLAF5XIsJdzscWPSEW2FHCylBM4SNrKhGar14BDXhA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
+      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.110.0",
-        "@aws-sdk/protocol-http": "3.110.0",
-        "@aws-sdk/querystring-builder": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.110.0.tgz",
-      "integrity": "sha512-7NkpmYeOkK3mhWBNU+/zSDqwzeaSPH1qrq4L//WV7WS/weYyE/jusQeZoOxVsuZQnQEXHt5O2hKVeUwShl12xA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.110.0.tgz",
-      "integrity": "sha512-qdi2gCbJiyPyLn+afebPNp/5nVCRh1X7t7IRIFl3FHVEC+o54u/ojay/MLZ4M/+X9Fa4Zxsb0Wpp3T0xAHVDBg==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
+      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.110.0.tgz",
-      "integrity": "sha512-7V3CDXj519izmbBn9ZE68ymASwGriA+Aq+cb/yHSVtffnvXjPtvONNw7G/5iVblisGLSCUe2hSvpYtcaXozbHw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.110.0.tgz",
-      "integrity": "sha512-//pJHH7hrhdDMZGBPKXKymmC/tJM7gFT0w/qbu/yd3Wm4W2fMB+8gkmj6EZctx7jrsWlfRQuvFejKqEfapur/g==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.110.0.tgz",
-      "integrity": "sha512-ccgCE0pU/4RmXR6CP3fLAdhPAve7bK/yXBbGzpSHGAQOXqNxYzOsAvQ30Jg6X+qjLHsI/HR2pLIE65z4k6tynw=="
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.110.0.tgz",
-      "integrity": "sha512-E1ERoqEoG206XNBYWCKLgHkzCbTxdpDEGbsLET2DnvjFsT0s9p2dPvVux3bYl7JVAhyGduE+qcqWk7MzhFCBNQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.287.0.tgz",
+      "integrity": "sha512-CxZp6R11uC12lNg+vKXc8bU7mqIrM43ZY2BbLRZ4tBlc7RLQpcJyccpEwEQAmJq0PA+rDUNod0gYnrM5DOUCLg==",
       "requires": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.110.0.tgz",
-      "integrity": "sha512-utxxdllOnmQDhbpipnFAbuQ4c2pwefZ+2hi48jKvQRULQ2PO4nxLmdZm6B0FXaTijbKsyO7GrMik+EZ6mi3ARQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
+      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.110.0",
-        "@aws-sdk/util-hex-encoding": "3.109.0",
-        "@aws-sdk/util-middleware": "3.110.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+          "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-uri-escape": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+          "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.110.0.tgz",
-      "integrity": "sha512-gNLYrmdAe/1hVF2Nv2LF4OkL1A0a1o708pEMZHzql9xP164omRDaLrGDhz9tH7tsJEgLz+Bf4E8nTuISeDwvGg==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
+      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.287.0.tgz",
+      "integrity": "sha512-RuqgncuQpLD5+W84RbTj/pgJmrjxSPJG0GBAtnISXrc39mGoc0ArOzQUTKIs+cLqDY+WS1/pqXlnQmKvmw3TQw==",
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.110.0.tgz",
-      "integrity": "sha512-dLVoqODU3laaqNFPyN1QLtlQnwX4gNPMXptEBIt/iJpuZf66IYJe6WCzVZGt4Zfa1CnUmrlA428AzdcA/KCr2A=="
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.110.0.tgz",
-      "integrity": "sha512-tILFB8/Q73yzgO0dErJNnELmmBszd0E6FucwAnG3hfDefjqCBe09Q/1yhu2aARXyRmZa4AKp0sWcdwIWHc8dnA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/querystring-parser": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/util-base64-browser": {
@@ -13727,26 +15034,35 @@
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.110.0.tgz",
-      "integrity": "sha512-Y2dcOOD20S3bv/IjUqpdKIiDt6995SXNG5Pu/LeSdXNyLCOIm9rX4gHTxl9fC1KK5M/gR9fGJ362f67WwqEEqw==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
+      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.110.0.tgz",
-      "integrity": "sha512-Cr3Z5nyrw1KowjbW76xp8hkT/zJtYjAVZ9PS4l84KxIicbVvDOBpxG3yNddkuQcavmlH6G4wH9uM5DcnpKDncg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.287.0.tgz",
+      "integrity": "sha512-ZGpbPvUA+m+Lf01eTDHkXmulEPT4LphffEt6M9cHPMhwEZfzxhXLyNXyGRunraoBBzB62hKBbFM2atsoHpuIZA==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.110.0",
-        "@aws-sdk/credential-provider-imds": "3.110.0",
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/property-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "requires": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
@@ -13767,10 +15083,19 @@
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.110.0.tgz",
-      "integrity": "sha512-PTVWrI5fA9d5hHJs6RzX2dIS2jRQ3uW073Fm0BePpQeDdZrEk+S5KNwRhUtpN6sdSV45vm6S9rrjZUG51qwGmA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
       "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
@@ -13783,23 +15108,51 @@
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.110.0.tgz",
-      "integrity": "sha512-rNdhmHDMV5dNJctqlBWimkZLJRB+x03DB+61pm+SKSFk6gPIVIvc1WNXqDFphkiswT4vA13ZUkGHzt+N4+noQQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
+      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
       "requires": {
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.110.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.110.0.tgz",
-      "integrity": "sha512-OQ915TPCCBwZWz5Np8zkNWn7U6KvrTZfFoCOy/VIemK3dUqmnBZ7HqGpuZx8SwJ2R9JE1x+j0niYSJ5fWJZZKA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.287.0.tgz",
+      "integrity": "sha512-yXg0C3WyxyRkQstR4VCTgnEPQd/ViRz+9rEPkYNIWXPvp1l8hPygk5q9tmSD09Lg8wzm6jR6V0MSyJnbwdzq+g==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.110.0",
-        "@aws-sdk/types": "3.110.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": {
+          "version": "3.201.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+          "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-buffer-from": {
+          "version": "3.208.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+          "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.201.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/util-utf8-browser": {
@@ -20719,9 +22072,9 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -20869,9 +22222,9 @@
       }
     },
     "sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",
@@ -20880,9 +22233,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -21250,6 +22603,11 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "strtok3": {
       "version": "6.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.145.0",
-    "@aws-sdk/client-sns": "3.112.0",
+    "@aws-sdk/client-sns": "3.287.0",
     "@sentry/node": "5.30.0",
     "async-retry": "1.3.3",
     "aws-sdk": "2.1158.0",
@@ -62,7 +62,7 @@
     "rate-limit-redis": "2.1.0",
     "redis": "3.1.2",
     "reflect-metadata": "0.1.13",
-    "sequelize": "6.21.2",
+    "sequelize": "6.29.1",
     "sequelize-typescript": "2.1.3",
     "source-map-support": "0.5.19",
     "starkbank-ecdsa": "1.1.4",

--- a/serverless/redaction-digest/package-lock.json
+++ b/serverless/redaction-digest/package-lock.json
@@ -22,7 +22,7 @@
         "pg-connection-string": "2.4.0",
         "reflect-metadata": "0.1.13",
         "sequelize": "6.29.1",
-        "sequelize-typescript": "1.1.0",
+        "sequelize-typescript": "2.1.3",
         "source-map-support": "0.5.19"
       },
       "devDependencies": {
@@ -147,7 +147,8 @@
     "node_modules/@types/bluebird": {
       "version": "3.5.33",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
+      "dev": true
     },
     "node_modules/@types/convict": {
       "version": "5.2.2",
@@ -266,9 +267,9 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -398,7 +399,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/convict": {
       "version": "6.2.4",
@@ -571,7 +572,26 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -601,7 +621,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -791,7 +811,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
       }
@@ -813,7 +833,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1106,37 +1126,20 @@
       }
     },
     "node_modules/sequelize-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.1.0.tgz",
-      "integrity": "sha512-FAPEQPeAhIaFQNLAcf9Q2IWcqWhNcvn5OZZ7BzGB0CJMtImIsGg4E/EAb7huMmPaPwDArxJUWGqk1KurphTNRA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.3.tgz",
+      "integrity": "sha512-0mejGAaLywuCoOOLSXCQs2sMBNudU/QtWZkGY5VT2dfTHToXZi5bOxCa3/CukNNk7wJwXnLuIdeHdlqjvVoj1g==",
       "dependencies": {
-        "glob": "7.1.2"
+        "glob": "7.2.0"
       },
       "engines": {
-        "node": ">=0.8.15"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "@types/bluebird": "*",
         "@types/node": "*",
         "@types/validator": "*",
         "reflect-metadata": "*",
-        "sequelize": "^5.1.0"
-      }
-    },
-    "node_modules/sequelize-typescript/node_modules/glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "sequelize": ">=6.8.0"
       }
     },
     "node_modules/sequelize/node_modules/@types/validator": {
@@ -1459,7 +1462,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xml2js": {
       "version": "0.4.19",
@@ -1589,7 +1592,8 @@
     "@types/bluebird": {
       "version": "3.5.33",
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ=="
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
+      "dev": true
     },
     "@types/convict": {
       "version": "5.2.2",
@@ -1698,9 +1702,9 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base64-js": {
       "version": "1.5.1",
@@ -1804,7 +1808,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "convict": {
       "version": "6.2.4",
@@ -1934,7 +1938,20 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "https-proxy-agent": {
       "version": "5.0.0",
@@ -1958,7 +1975,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2115,7 +2132,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -2137,7 +2154,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-key": {
       "version": "3.1.1",
@@ -2336,26 +2353,11 @@
       "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg=="
     },
     "sequelize-typescript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-1.1.0.tgz",
-      "integrity": "sha512-FAPEQPeAhIaFQNLAcf9Q2IWcqWhNcvn5OZZ7BzGB0CJMtImIsGg4E/EAb7huMmPaPwDArxJUWGqk1KurphTNRA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/sequelize-typescript/-/sequelize-typescript-2.1.3.tgz",
+      "integrity": "sha512-0mejGAaLywuCoOOLSXCQs2sMBNudU/QtWZkGY5VT2dfTHToXZi5bOxCa3/CukNNk7wJwXnLuIdeHdlqjvVoj1g==",
       "requires": {
-        "glob": "7.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "glob": "7.2.0"
       }
     },
     "shebang-command": {
@@ -2608,7 +2610,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/serverless/redaction-digest/package-lock.json
+++ b/serverless/redaction-digest/package-lock.json
@@ -21,7 +21,7 @@
         "pg": "8.5.1",
         "pg-connection-string": "2.4.0",
         "reflect-metadata": "0.1.13",
-        "sequelize": "5.22.5",
+        "sequelize": "6.29.1",
         "sequelize-typescript": "1.1.0",
         "source-map-support": "0.5.19"
       },
@@ -158,11 +158,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.165",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
       "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
       "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "14.14.7",
@@ -212,11 +225,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "node_modules/async": {
       "version": "3.2.4",
@@ -281,11 +289,6 @@
         }
       ]
     },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -316,15 +319,6 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "dependencies": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
       }
     },
     "node_modules/color": {
@@ -447,10 +441,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -598,9 +591,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==",
       "engines": [
         "node >= 0.4.0"
       ]
@@ -624,14 +617,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
-    },
-    "node_modules/is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/is-stream": {
       "version": "2.0.0",
@@ -712,6 +697,17 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/map-stream": {
       "version": "0.1.0",
@@ -998,12 +994,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/retry-as-promised": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
-      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
-      "dependencies": {
-        "any-promise": "^1.3.0"
-      }
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1029,38 +1022,87 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
-    "node_modules/sequelize": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.5.tgz",
-      "integrity": "sha512-ySIHof18sJbeVG4zjEvsDL490cd9S14/IhkCrZR/g0C/FPlZq1AzEJVeSAo++9/sgJH2eERltAIGqYQNgVqX/A==",
-      "deprecated": "Please update to v6 or higher! A migration guide can be found here: https://sequelize.org/v6/manual/upgrade-to-v6.html",
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
-        "debug": "^4.1.1",
-        "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
-        "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sequelize": {
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "@types/validator": "^13.7.1",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.2",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.35",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^7.0.3",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
       }
     },
     "node_modules/sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/sequelize-typescript": {
@@ -1097,13 +1139,15 @@
         "node": "*"
       }
     },
-    "node_modules/sequelize/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
+    "node_modules/sequelize/node_modules/@types/validator": {
+      "version": "13.7.13",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.13.tgz",
+      "integrity": "sha512-EMfHccxNKXaSxTK6DN0En9WsXa7uR4w3LQtx31f6Z2JjG5hJQeVX5zUYMZoatjZgnoQmRcT94WnNWwi0BzQW6Q=="
+    },
+    "node_modules/sequelize/node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "node_modules/sequelize/node_modules/uuid": {
       "version": "8.3.2",
@@ -1133,11 +1177,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -1410,9 +1449,9 @@
       }
     },
     "node_modules/wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1446,6 +1485,11 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs-parser": {
       "version": "20.2.9",
@@ -1556,11 +1600,24 @@
         "@types/node": "*"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.165",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
       "integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
       "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
       "version": "14.14.7",
@@ -1603,11 +1660,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "async": {
       "version": "3.2.4",
@@ -1655,11 +1707,6 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1688,15 +1735,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
-    },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
-      }
     },
     "color": {
       "version": "3.0.0",
@@ -1800,9 +1838,9 @@
       }
     },
     "debug": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-      "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -1913,9 +1951,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "inflection": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
-      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.13.4.tgz",
+      "integrity": "sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1936,11 +1974,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
-    },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
     },
     "is-stream": {
       "version": "2.0.0",
@@ -2009,6 +2042,14 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "map-stream": {
       "version": "0.1.0",
@@ -2227,12 +2268,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "retry-as-promised": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
-      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
-      "requires": {
-        "any-promise": "^1.3.0"
-      }
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -2244,32 +2282,46 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
-    "sequelize": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.22.5.tgz",
-      "integrity": "sha512-ySIHof18sJbeVG4zjEvsDL490cd9S14/IhkCrZR/g0C/FPlZq1AzEJVeSAo++9/sgJH2eERltAIGqYQNgVqX/A==",
+    "semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
-        "debug": "^4.1.1",
-        "dottie": "^2.0.0",
-        "inflection": "1.12.0",
-        "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
-        "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "sequelize": {
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
+      "requires": {
+        "@types/debug": "^4.1.7",
+        "@types/validator": "^13.7.1",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.2",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.35",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^7.0.3",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        "@types/validator": {
+          "version": "13.7.13",
+          "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.13.tgz",
+          "integrity": "sha512-EMfHccxNKXaSxTK6DN0En9WsXa7uR4w3LQtx31f6Z2JjG5hJQeVX5zUYMZoatjZgnoQmRcT94WnNWwi0BzQW6Q=="
+        },
+        "pg-connection-string": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+          "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
         },
         "uuid": {
           "version": "8.3.2",
@@ -2279,9 +2331,9 @@
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg=="
     },
     "sequelize-typescript": {
       "version": "1.1.0",
@@ -2320,11 +2372,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -2551,9 +2598,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }
@@ -2581,6 +2628,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs-parser": {
       "version": "20.2.9",

--- a/serverless/redaction-digest/package.json
+++ b/serverless/redaction-digest/package.json
@@ -36,7 +36,7 @@
     "pg-connection-string": "2.4.0",
     "reflect-metadata": "0.1.13",
     "sequelize": "6.29.1",
-    "sequelize-typescript": "1.1.0",
+    "sequelize-typescript": "2.1.3",
     "source-map-support": "0.5.19"
   },
   "_moduleAliases": {

--- a/serverless/redaction-digest/package.json
+++ b/serverless/redaction-digest/package.json
@@ -35,7 +35,7 @@
     "pg": "8.5.1",
     "pg-connection-string": "2.4.0",
     "reflect-metadata": "0.1.13",
-    "sequelize": "5.22.5",
+    "sequelize": "6.29.1",
     "sequelize-typescript": "1.1.0",
     "source-map-support": "0.5.19"
   },

--- a/serverless/redaction-digest/src/index.ts
+++ b/serverless/redaction-digest/src/index.ts
@@ -53,7 +53,9 @@ const handler = async (event: any): Promise<{ statusCode: number }> => {
         logger.log(`Redaction reminder sent to ${email}`)
       } catch (err) {
         logger.log(
-          `Failed to send redaction reminder to ${email}. Error: ${(err as Error).message}`
+          `Failed to send redaction reminder to ${email}. Error: ${
+            (err as Error).message
+          }`
         )
 
         failedRecipients.push(email)

--- a/serverless/redaction-digest/src/redaction.ts
+++ b/serverless/redaction-digest/src/redaction.ts
@@ -31,13 +31,12 @@ export const getUserRedactedCampaigns = async (
   const options = {
     useMaster: false,
     replacements: {
-      start: NOTICE_PERIOD,
-      end: NOTICE_PERIOD * 2,
-      retentionPeriod: RETENTION_PERIOD,
+      start: `${NOTICE_PERIOD} days`,
+      end: `${NOTICE_PERIOD * 2} days`,
+      retentionPeriod: `${RETENTION_PERIOD} days`,
       ...(selectedRecipients ? { selectedRecipients } : {}),
     },
   }
-
   const redactedCampaigns = (
     await sequelize?.query(
       `WITH redacted_campaigns AS (
@@ -46,7 +45,7 @@ export const getUserRedactedCampaigns = async (
         json_build_object(
           'id', campaigns.id,
           'name', campaigns.name,
-          'expiry_date', max(job_queue.updated_at) + interval ':retentionPeriod days'
+          'expiry_date', max(job_queue.updated_at) + interval :retentionPeriod
         ) AS campaign_json
       FROM
         campaigns
@@ -59,8 +58,8 @@ export const getUserRedactedCampaigns = async (
       HAVING
         sum(unsent) = 0
         AND every(job_queue.status = 'LOGGED')
-        AND (max(job_queue.updated_at) + interval ':retentionPeriod days') BETWEEN
-            (cast(current_timestamp as date) + interval ':start days') AND (cast(current_timestamp as date) + interval ':end days')
+        AND (max(job_queue.updated_at) + interval :retentionPeriod) BETWEEN
+            (cast(current_timestamp as date) + interval :start) AND (cast(current_timestamp as date) + interval :end)
       ORDER BY
         max(job_queue.updated_at)
     )
@@ -75,6 +74,5 @@ export const getUserRedactedCampaigns = async (
       options
     )
   )?.[0] as Array<UserRedactedCampaigns>
-
   return redactedCampaigns
 }

--- a/serverless/unsubscribe-digest/package-lock.json
+++ b/serverless/unsubscribe-digest/package-lock.json
@@ -20,7 +20,7 @@
         "pg": "8.5.1",
         "pg-connection-string": "2.4.0",
         "reflect-metadata": "0.1.13",
-        "sequelize": "6.21.2",
+        "sequelize": "6.29.1",
         "sequelize-typescript": "2.1.3",
         "source-map-support": "0.5.19"
       },
@@ -850,9 +850,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -910,9 +910,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -931,6 +931,9 @@
           "optional": true
         },
         "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
           "optional": true
         },
         "pg": {
@@ -1858,9 +1861,9 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -1881,9 +1884,9 @@
       }
     },
     "sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",
@@ -1892,9 +1895,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",

--- a/serverless/unsubscribe-digest/package.json
+++ b/serverless/unsubscribe-digest/package.json
@@ -26,7 +26,7 @@
     "pg": "8.5.1",
     "pg-connection-string": "2.4.0",
     "reflect-metadata": "0.1.13",
-    "sequelize": "6.21.2",
+    "sequelize": "6.29.1",
     "sequelize-typescript": "2.1.3",
     "source-map-support": "0.5.19"
   },

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -7,7 +7,7 @@
       "name": "worker",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-sns": "3.95.0",
+        "@aws-sdk/client-sns": "3.287.0",
         "@types/bcrypt": "3.0.0",
         "@types/cheerio": "^0.22.31",
         "@types/validator": "13.1.3",
@@ -25,7 +25,7 @@
         "nodemailer": "6.6.2",
         "pg": "8.5.1",
         "reflect-metadata": "0.1.13",
-        "sequelize": "6.21.2",
+        "sequelize": "6.29.1",
         "sequelize-typescript": "2.1.3",
         "source-map-support": "0.5.19",
         "telegraf": "3.38.0",
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -82,15 +82,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -102,12 +102,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       }
     },
@@ -117,9 +117,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dependencies": {
         "tslib": "^1.11.1"
       }
@@ -130,11 +130,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dependencies": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       }
@@ -145,649 +145,743 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
-      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sns": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.95.0.tgz",
-      "integrity": "sha512-BMxrRH0/4NS+Tpk6tjPnllLHuOLClW7RuN5pQ5hW520GD6w26jkB7nRkLRpqp7azIalZUlRphG+tNZBigMbzgA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.287.0.tgz",
+      "integrity": "sha512-oEd5b+Uo4P6bbXRPiN8G/m24RS9XMpOXziyGPj3nAhj3jhhC2q0Ygfeaw5D4KoHL46O8HzWpGC6uTvKR2HDYgg==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.95.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.287.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.95.0.tgz",
-      "integrity": "sha512-yxiVyRG5ULTVzOTmlrsy1krjpBQo20+ZfQ9p++A7cA8dIsytzjlPLvtY+Pzz0pTa3h2B6tlVBmumgEQzh5Y8Ug==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.287.0.tgz",
+      "integrity": "sha512-YXD/oP38tsgKYTnft17O6OLTBBdal7CZsRhCJUHUSg3xAV9AiLloMwGrSxcZh4qMhx5bcn9XaVxu8dApsXnJXw==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.287.0.tgz",
+      "integrity": "sha512-zrUy5jpu32sjmOcSlr8IVNTT/Pfa8ZPj6v0P/sNN3PWIv9fbep/0MJyIwbWJLCfQVLZqRvlMovFzVlnWixjraw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.95.0.tgz",
-      "integrity": "sha512-qeoiEyBB5IQyjgjkCCBiQnISar7OJgjuTf2alM6ehjq8H4/T5VeMCeohEs5FR0/O60sJn40ZpL3YY/OmMh55UA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.287.0.tgz",
+      "integrity": "sha512-s6ST78bxSH+nFAFcvSU7bhNAGz/e9Q/77+0Y0JPl/Q2ZWKMfO9AWs/uAieATMBhVuG/8ok4WKrR9YCbMr/ai8A==",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-sdk-sts": "3.78.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-sdk-sts": "3.282.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
-      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.287.0.tgz",
+      "integrity": "sha512-YLJ9+ufcrj73DBmqgG50WMAVNHb8PdWL7hkp3gs00VOsXeEMGdQK92fVlx8Him8yPDikvLS2orrEVRcYxj5Uag==",
       "dependencies": {
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
-      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.81.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
-      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.287.0.tgz",
+      "integrity": "sha512-awvsREwUgb9V5pbrP9DyNGh5iXBE8Pbb5EeMw8zJsX+cYuD95N0YncrU/7MAf0+ro851gBqjC3Dty8ujrAhkSg==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.95.0.tgz",
-      "integrity": "sha512-Ditfnmo8/F79Zj8HmaRZZTDsthhvKcdgGFus+pF3kxZxyR3YU/k7/eGUISZeCQhA0/9nwxXMFDUmAIsa0AMfyg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.287.0.tgz",
+      "integrity": "sha512-mDl/twCpXvWUb4A+L3z+v0N4oRF9cnOrkdhW9yP3hBT84RJqCIFHtk966rFiZod8MbhE2LluODtzXVJEIHpmpg==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.78.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
-        "@aws-sdk/credential-provider-web-identity": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.95.0.tgz",
-      "integrity": "sha512-NCXejOQg5p+oJPaUPa+jIrU7pStm8zZtOn6lXVnubZrQClv2+ZQrgxVt6otN464SWqMQbmLFYNyYf4bsLJaEhA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.287.0.tgz",
+      "integrity": "sha512-7f41hmgwMpMOFgDmpR76xEAXDlG4OHkS1pJU5bt9P4UL2EJWuxvJkdbvI4g9th+lT4cbzWXGFwK+oZ7xBKsVKw==",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.78.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-ini": "3.95.0",
-        "@aws-sdk/credential-provider-process": "3.80.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
-        "@aws-sdk/credential-provider-web-identity": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-ini": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
-      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.287.0.tgz",
+      "integrity": "sha512-3iWtit/4Iyv/JjL2L0cO7v94NvsISTH/ak0CXqAgb2LdCOz0JN3txgg+ciZzdVLUP8M7x/bm4HjMcUVaxS0HZw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.95.0.tgz",
-      "integrity": "sha512-YIzBBWUKkazvoM8CsCbf4YIs5ENtOr5KXUd6e993c3oRMNsUykOtf/AUBN6G3HItuyxoA8vW/8M6tKX44cRCAg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.287.0.tgz",
+      "integrity": "sha512-aJGV4zIFOPWn6PQRjduI3jX+cPCtDtqTNefmsdpw+BIdWFwFINDwoCKfkodnkzxGrB0n35wkGEiddJlwlMwROA==",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.95.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/client-sso": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/token-providers": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
-      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
-      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
+      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/querystring-builder": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/hash-node": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
-      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
-      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
-      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
+      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
+      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
-      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
+      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
-      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.287.0.tgz",
+      "integrity": "sha512-YZe/3Qs3IelJGK/mUYrCAzTIP1iu6uN4NZCofRP113UXrbipSF+wG2rZWPYyJ/cfAXL1kG4SWtdcKvLiwVEn0g==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
+      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
-      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.287.0.tgz",
+      "integrity": "sha512-pXIAWuwGpWRWjIIJwbkNQGbhOGoOYVaO5WZZ+65PgKkOVDLeCYU0O26PD5cHw2ksUye8dKGfIXHTbe4CmxDveA==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/service-error-classification": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
-      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
+      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
       "dependencies": {
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
-      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
-      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
+      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
-      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
-      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
+      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
       "dependencies": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
-      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.287.0.tgz",
+      "integrity": "sha512-+AO5dy6JEDvgtH9fcuCNnAQd6ilZjww8d/HNTCb5xOhiW1/pKSNMRhouGfn47uxq61WwDN/qUnv2nlVN83RB6w==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.94.0.tgz",
-      "integrity": "sha512-g9q6k+PS+BrtOzt8jrBWr9D543uB3ZoYZ2JCriwuCwnP4uIHlMf9wAOGcOgqgykfUAPBOLvz2rTwVs3Xl8GUmQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
+      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
       "dependencies": {
-        "@aws-sdk/abort-controller": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/querystring-builder": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/property-provider": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
-      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
-      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
+      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
-      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
-      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
-      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w==",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
-      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.287.0.tgz",
+      "integrity": "sha512-CxZp6R11uC12lNg+vKXc8bU7mqIrM43ZY2BbLRZ4tBlc7RLQpcJyccpEwEQAmJq0PA+rDUNod0gYnrM5DOUCLg==",
       "dependencies": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
-      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
+      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.78.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.85.0.tgz",
-      "integrity": "sha512-Ox/yQEAnANzhpJMyrpuxWtF/i3EviavENczT7fo4uwSyZTz/sfSBQNjs/YAG1UeA6uOI3pBP5EaFERV5hr2fRA==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
+      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
       "dependencies": {
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.287.0.tgz",
+      "integrity": "sha512-RuqgncuQpLD5+W84RbTj/pgJmrjxSPJG0GBAtnISXrc39mGoc0ArOzQUTKIs+cLqDY+WS1/pqXlnQmKvmw3TQw==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
-      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ==",
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
-      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
       "dependencies": {
-        "@aws-sdk/querystring-parser": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "dependencies": {
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.85.0.tgz",
-      "integrity": "sha512-oqK/e2pHuMWrvTJWtDBzylbj232ezlTay5dCq4RQlyi3LPPVBQ08haYD1Mk2ikQ/qa0XvbSD6YVhjpTlvwRNjw==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
+      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
       "dependencies": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       },
@@ -796,106 +890,138 @@
       }
     },
     "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.85.0.tgz",
-      "integrity": "sha512-KDNl4H8jJJLh6y7I3MSwRKe4plKbFKK8MVkS0+Fce/GJh4EnqxF0HzMMaSeNUcPvO2wHRq2a60+XW+0d7eWo1A==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.287.0.tgz",
+      "integrity": "sha512-ZGpbPvUA+m+Lf01eTDHkXmulEPT4LphffEt6M9cHPMhwEZfzxhXLyNXyGRunraoBBzB62hKBbFM2atsoHpuIZA==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
-      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
-      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "dependencies": {
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
-      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
+      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
       "dependencies": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
-      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.287.0.tgz",
+      "integrity": "sha512-yXg0C3WyxyRkQstR4VCTgnEPQd/ViRz+9rEPkYNIWXPvp1l8hPygk5q9tmSD09Lg8wzm6jR6V0MSyJnbwdzq+g==",
       "dependencies": {
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dependencies": {
         "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4403,11 +4529,14 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
       "bin": {
-        "xml2js": "cli.js"
+        "fxparser": "src/cli/cli.js"
       },
       "funding": {
         "type": "paypal",
@@ -7316,9 +7445,9 @@
       }
     },
     "node_modules/retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "node_modules/reusify": {
       "version": "1.0.4",
@@ -7453,9 +7582,9 @@
       "dev": true
     },
     "node_modules/sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7470,9 +7599,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -7491,6 +7620,9 @@
           "optional": true
         },
         "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
           "optional": true
         },
         "pg": {
@@ -7818,6 +7950,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8797,9 +8934,9 @@
       }
     },
     "@aws-crypto/ie11-detection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-      "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -8812,15 +8949,15 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
@@ -8834,12 +8971,12 @@
       }
     },
     "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -8851,9 +8988,9 @@
       }
     },
     "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-      "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "requires": {
         "tslib": "^1.11.1"
       },
@@ -8866,11 +9003,11 @@
       }
     },
     "@aws-crypto/util": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
-      "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "requires": {
-        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
@@ -8883,618 +9020,718 @@
       }
     },
     "@aws-sdk/abort-controller": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.78.0.tgz",
-      "integrity": "sha512-iz1YLwM2feJUj/y97yO4XmDeTxs+yZ1XJwQgoawKuc8IDBKUutnJNCHL5jL04WUKU7Nrlq+Hr2fCTScFh2z9zg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.272.0.tgz",
+      "integrity": "sha512-s2TV3phapcTwZNr4qLxbfuQuE9ZMP4RoJdkvRRCkKdm6jslsWLJf2Zlcxti/23hOlINUMYv2iXE2pftIgWGdpg==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sns": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.95.0.tgz",
-      "integrity": "sha512-BMxrRH0/4NS+Tpk6tjPnllLHuOLClW7RuN5pQ5hW520GD6w26jkB7nRkLRpqp7azIalZUlRphG+tNZBigMbzgA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.287.0.tgz",
+      "integrity": "sha512-oEd5b+Uo4P6bbXRPiN8G/m24RS9XMpOXziyGPj3nAhj3jhhC2q0Ygfeaw5D4KoHL46O8HzWpGC6uTvKR2HDYgg==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.95.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.287.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.95.0.tgz",
-      "integrity": "sha512-yxiVyRG5ULTVzOTmlrsy1krjpBQo20+ZfQ9p++A7cA8dIsytzjlPLvtY+Pzz0pTa3h2B6tlVBmumgEQzh5Y8Ug==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.287.0.tgz",
+      "integrity": "sha512-YXD/oP38tsgKYTnft17O6OLTBBdal7CZsRhCJUHUSg3xAV9AiLloMwGrSxcZh4qMhx5bcn9XaVxu8dApsXnJXw==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.287.0.tgz",
+      "integrity": "sha512-zrUy5jpu32sjmOcSlr8IVNTT/Pfa8ZPj6v0P/sNN3PWIv9fbep/0MJyIwbWJLCfQVLZqRvlMovFzVlnWixjraw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/client-sts": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.95.0.tgz",
-      "integrity": "sha512-qeoiEyBB5IQyjgjkCCBiQnISar7OJgjuTf2alM6ehjq8H4/T5VeMCeohEs5FR0/O60sJn40ZpL3YY/OmMh55UA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.287.0.tgz",
+      "integrity": "sha512-s6ST78bxSH+nFAFcvSU7bhNAGz/e9Q/77+0Y0JPl/Q2ZWKMfO9AWs/uAieATMBhVuG/8ok4WKrR9YCbMr/ai8A==",
       "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-node": "3.95.0",
-        "@aws-sdk/fetch-http-handler": "3.78.0",
-        "@aws-sdk/hash-node": "3.78.0",
-        "@aws-sdk/invalid-dependency": "3.78.0",
-        "@aws-sdk/middleware-content-length": "3.78.0",
-        "@aws-sdk/middleware-host-header": "3.78.0",
-        "@aws-sdk/middleware-logger": "3.78.0",
-        "@aws-sdk/middleware-retry": "3.80.0",
-        "@aws-sdk/middleware-sdk-sts": "3.78.0",
-        "@aws-sdk/middleware-serde": "3.78.0",
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/middleware-user-agent": "3.78.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/node-http-handler": "3.94.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/smithy-client": "3.85.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
-        "@aws-sdk/util-base64-node": "3.55.0",
-        "@aws-sdk/util-body-length-browser": "3.55.0",
-        "@aws-sdk/util-body-length-node": "3.55.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.85.0",
-        "@aws-sdk/util-defaults-mode-node": "3.85.0",
-        "@aws-sdk/util-user-agent-browser": "3.78.0",
-        "@aws-sdk/util-user-agent-node": "3.80.0",
-        "@aws-sdk/util-utf8-browser": "3.55.0",
-        "@aws-sdk/util-utf8-node": "3.55.0",
-        "entities": "2.2.0",
-        "fast-xml-parser": "3.19.0",
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-node": "3.287.0",
+        "@aws-sdk/fetch-http-handler": "3.282.0",
+        "@aws-sdk/hash-node": "3.272.0",
+        "@aws-sdk/invalid-dependency": "3.272.0",
+        "@aws-sdk/middleware-content-length": "3.282.0",
+        "@aws-sdk/middleware-endpoint": "3.282.0",
+        "@aws-sdk/middleware-host-header": "3.282.0",
+        "@aws-sdk/middleware-logger": "3.287.0",
+        "@aws-sdk/middleware-recursion-detection": "3.282.0",
+        "@aws-sdk/middleware-retry": "3.287.0",
+        "@aws-sdk/middleware-sdk-sts": "3.282.0",
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/middleware-user-agent": "3.282.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/node-http-handler": "3.282.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/smithy-client": "3.279.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.279.0",
+        "@aws-sdk/util-defaults-mode-node": "3.287.0",
+        "@aws-sdk/util-endpoints": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
+        "@aws-sdk/util-user-agent-browser": "3.282.0",
+        "@aws-sdk/util-user-agent-node": "3.287.0",
+        "@aws-sdk/util-utf8": "3.254.0",
+        "fast-xml-parser": "4.1.2",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/config-resolver": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.80.0.tgz",
-      "integrity": "sha512-vFruNKlmhsaC8yjnHmasi1WW/7EELlEuFTj4mqcqNqR4dfraf0maVvpqF1VSR8EstpFMsGYI5dmoWAnnG4PcLQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.287.0.tgz",
+      "integrity": "sha512-YLJ9+ufcrj73DBmqgG50WMAVNHb8PdWL7hkp3gs00VOsXeEMGdQK92fVlx8Him8yPDikvLS2orrEVRcYxj5Uag==",
       "requires": {
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-config-provider": "3.55.0",
-        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-env": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.78.0.tgz",
-      "integrity": "sha512-K41VTIzVHm2RyIwtBER8Hte3huUBXdV1WKO+i7olYVgLFmaqcZUNrlyoGDRqZcQ/u4AbxTzBU9jeMIbIfzMOWg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.272.0.tgz",
+      "integrity": "sha512-QI65NbLnKLYHyTYhXaaUrq6eVsCCrMUb05WDA7+TJkWkjXesovpjc8vUKgFiLSxmgKmb2uOhHNcDyObKMrYQFw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-imds": {
-      "version": "3.81.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.81.0.tgz",
-      "integrity": "sha512-BHopP+gaovTYj+4tSrwCk8NNCR48gE9CWmpIOLkP9ell0gOL81Qh7aCEiIK0BZBZkccv1s16cYq1MSZZGS7PEQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.287.0.tgz",
+      "integrity": "sha512-awvsREwUgb9V5pbrP9DyNGh5iXBE8Pbb5EeMw8zJsX+cYuD95N0YncrU/7MAf0+ro851gBqjC3Dty8ujrAhkSg==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/url-parser": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-ini": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.95.0.tgz",
-      "integrity": "sha512-Ditfnmo8/F79Zj8HmaRZZTDsthhvKcdgGFus+pF3kxZxyR3YU/k7/eGUISZeCQhA0/9nwxXMFDUmAIsa0AMfyg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.287.0.tgz",
+      "integrity": "sha512-mDl/twCpXvWUb4A+L3z+v0N4oRF9cnOrkdhW9yP3hBT84RJqCIFHtk966rFiZod8MbhE2LluODtzXVJEIHpmpg==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.78.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
-        "@aws-sdk/credential-provider-web-identity": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-node": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.95.0.tgz",
-      "integrity": "sha512-NCXejOQg5p+oJPaUPa+jIrU7pStm8zZtOn6lXVnubZrQClv2+ZQrgxVt6otN464SWqMQbmLFYNyYf4bsLJaEhA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.287.0.tgz",
+      "integrity": "sha512-7f41hmgwMpMOFgDmpR76xEAXDlG4OHkS1pJU5bt9P4UL2EJWuxvJkdbvI4g9th+lT4cbzWXGFwK+oZ7xBKsVKw==",
       "requires": {
-        "@aws-sdk/credential-provider-env": "3.78.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/credential-provider-ini": "3.95.0",
-        "@aws-sdk/credential-provider-process": "3.80.0",
-        "@aws-sdk/credential-provider-sso": "3.95.0",
-        "@aws-sdk/credential-provider-web-identity": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/credential-provider-env": "3.272.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/credential-provider-ini": "3.287.0",
+        "@aws-sdk/credential-provider-process": "3.287.0",
+        "@aws-sdk/credential-provider-sso": "3.287.0",
+        "@aws-sdk/credential-provider-web-identity": "3.272.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-process": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.80.0.tgz",
-      "integrity": "sha512-3Ro+kMMyLUJHefOhGc5pOO/ibGcJi8bkj0z/Jtqd5I2Sm1qi7avoztST67/k48KMW1OqPnD/FUqxz5T8B2d+FQ==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.287.0.tgz",
+      "integrity": "sha512-3iWtit/4Iyv/JjL2L0cO7v94NvsISTH/ak0CXqAgb2LdCOz0JN3txgg+ciZzdVLUP8M7x/bm4HjMcUVaxS0HZw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-sso": {
-      "version": "3.95.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.95.0.tgz",
-      "integrity": "sha512-YIzBBWUKkazvoM8CsCbf4YIs5ENtOr5KXUd6e993c3oRMNsUykOtf/AUBN6G3HItuyxoA8vW/8M6tKX44cRCAg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.287.0.tgz",
+      "integrity": "sha512-aJGV4zIFOPWn6PQRjduI3jX+cPCtDtqTNefmsdpw+BIdWFwFINDwoCKfkodnkzxGrB0n35wkGEiddJlwlMwROA==",
       "requires": {
-        "@aws-sdk/client-sso": "3.95.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/client-sso": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/token-providers": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.78.0.tgz",
-      "integrity": "sha512-9/IvqHdJaVqMEABA8xZE3t5YF1S2PepfckVu0Ws9YUglj6oO+2QyVX6aRgMF1xph6781+Yc31TDh8/3eaDja7w==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.272.0.tgz",
+      "integrity": "sha512-ImrHMkcgneGa/HadHAQXPwOrX26sAKuB8qlMxZF/ZCM2B55u8deY+ZVkVuraeKb7YsahMGehPFOfRAF6mvFI5Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/fetch-http-handler": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.78.0.tgz",
-      "integrity": "sha512-cR6r2h2kJ1DNEZSXC6GknQB7OKmy+s9ZNV+g3AsNqkrUmNNOaHpFoSn+m6SC3qaclcGd0eQBpqzSu/TDn23Ihw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.282.0.tgz",
+      "integrity": "sha512-RTd53UzKtUucIEdVLGGgtlbVwp0QkOt3ZfHuA/A1lOH7meChSh1kz7B5z3p4HQDpXO+MQ1Y6Ble9Vg2fh1zwJQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/querystring-builder": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-base64-browser": "3.58.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-base64": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/hash-node": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.78.0.tgz",
-      "integrity": "sha512-ev48yXaqZVtMeuKy52LUZPHCyKvkKQ9uiUebqkA+zFxIk+eN8SMPFHmsififIHWuS6ZkXBUSctjH9wmLebH60A==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.272.0.tgz",
+      "integrity": "sha512-40dwND+iAm3VtPHPZu7/+CIdVJFk2s0cWZt1lOiMPMSXycSYJ45wMk7Lly3uoqRx0uWfFK5iT2OCv+fJi5jTng==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-buffer-from": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/invalid-dependency": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.78.0.tgz",
-      "integrity": "sha512-zUo+PbeRMN/Mzj6y+6p9qqk/znuFetT1gmpOcZGL9Rp2T+b9WJWd+daq5ktsL10sVCzIt2UvneJRz6b+aU+bfw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.272.0.tgz",
+      "integrity": "sha512-ysW6wbjl1Y78txHUQ/Tldj2Rg1BI7rpMO9B9xAF6yAX3mQ7t6SUPQG/ewOGvH2208NBIl3qP5e/hDf0Q6r/1iw==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/is-array-buffer": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
-      "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-content-length": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.78.0.tgz",
-      "integrity": "sha512-5MpKt6lB9TdFy25/AGrpOjPY0iDHZAKpEHc+jSOJBXLl6xunXA7qHdiYaVqkWodLxy70nIckGNHqQ3drabidkA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.282.0.tgz",
+      "integrity": "sha512-SDgMLRRTMr9LlHSNk4bXUXynYnkT4oNMqE+FxhjsdbT8hK36eS4AadM58R7nPwgjR3EuWRW4ZRRawLWatpWspA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.282.0.tgz",
+      "integrity": "sha512-8U9Mv/Sbdo1KI6/ip7IIUdBl5pgmalFbfkYAyO+AtmkEvawI9ipdWFs5HB0Dwd1BGVup5choY72Ik/7sCAAFTQ==",
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/url-parser": "3.272.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-host-header": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.78.0.tgz",
-      "integrity": "sha512-1zL8uaDWGmH50c8B8jjz75e0ePj6/3QeZEhjJgTgL6DTdiqvRt32p3t+XWHW+yDI14fZZUYeTklAaLVxqFrHqQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.282.0.tgz",
+      "integrity": "sha512-90dfYow4zh4tCatTOnqB3nE/dIAucQLZnMqwN/WBPu0fUqjymzpsNkPchqWBPnSWdNE8w3PiKMqqD9rjYwqw4Q==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-logger": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.78.0.tgz",
-      "integrity": "sha512-GBhwxNjhCJUIeQQDaGasX/C23Jay77al2vRyGwmxf8no0DdFsa4J1Ik6/2hhIqkqko+WM4SpCnpZrY4MtnxNvA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.287.0.tgz",
+      "integrity": "sha512-YZe/3Qs3IelJGK/mUYrCAzTIP1iu6uN4NZCofRP113UXrbipSF+wG2rZWPYyJ/cfAXL1kG4SWtdcKvLiwVEn0g==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.282.0.tgz",
+      "integrity": "sha512-cSLq/daEaTEucbP/TgAXIOcpwLu7Bfw3VGzH1U56ngDjI4KWvUheF16JiB6OqKQXduPBPsdZ9dVmkDVKddmCRw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-retry": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.80.0.tgz",
-      "integrity": "sha512-CTk+tA4+WMUNOcUfR6UQrkhwvPYFpnMsQ1vuHlpLFOGG3nCqywA2hueLMRQmVcDXzP0sGeygce6dzRI9dJB/GA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.287.0.tgz",
+      "integrity": "sha512-pXIAWuwGpWRWjIIJwbkNQGbhOGoOYVaO5WZZ+65PgKkOVDLeCYU0O26PD5cHw2ksUye8dKGfIXHTbe4CmxDveA==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/service-error-classification": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-middleware": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-retry": "3.272.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.78.0.tgz",
-      "integrity": "sha512-Lu/kN0J0/Kt0ON1hvwNel+y8yvf35licfIgtedHbBCa/ju8qQ9j+uL9Lla6Y5Tqu29yVaye1JxhiIDhscSwrLA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.282.0.tgz",
+      "integrity": "sha512-Qe20mtJcF6lxt7280FhTFD2IpBDn39MEXmbm/zIkXR2/cAmvji8YhcxhNrq1l7XiuMM6SokBDC/f3dlF1oOC6g==",
       "requires": {
-        "@aws-sdk/middleware-signing": "3.78.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/middleware-signing": "3.282.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-serde": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.78.0.tgz",
-      "integrity": "sha512-4DPsNOxsl1bxRzfo1WXEZjmD7OEi7qGNpxrDWucVe96Fqj2dH08jR8wxvBIVV1e6bAad07IwdPuCGmivNvwRuQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.272.0.tgz",
+      "integrity": "sha512-kW1uOxgPSwtXPB5rm3QLdWomu42lkYpQL94tM1BjyFOWmBLO2lQhk5a7Dw6HkTozT9a+vxtscLChRa6KZe61Hw==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-signing": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.78.0.tgz",
-      "integrity": "sha512-OEjJJCNhHHSOprLZ9CzjHIXEKFtPHWP/bG9pMhkV3/6Bmscsgcf8gWHcOnmIrjqX+hT1VALDNpl/RIh0J6/eQw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.282.0.tgz",
+      "integrity": "sha512-eE5qMDcqqxZPdSwybUEph/knrA2j2cHjW+B2ddROw3Ojg0XLjep5hOhithAudgBREQhYF9pdsBr6mUMynUIrKw==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/signature-v4": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/signature-v4": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-middleware": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-stack": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.78.0.tgz",
-      "integrity": "sha512-UoNfRh6eAJN3BJHlG1eb+KeuSe+zARTC2cglroJRyHc2j7GxH2i9FD3IJbj5wvzopJEnQzuY/VCs6STFkqWL1g==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.272.0.tgz",
+      "integrity": "sha512-jhwhknnPBGhfXAGV5GXUWfEhDFoP/DN8MPCO2yC5OAxyp6oVJ8lTPLkZYMTW5VL0c0eG44dXpF4Ib01V+PlDrQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/middleware-user-agent": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.78.0.tgz",
-      "integrity": "sha512-wdN5uoq8RxxhLhj0EPeuDSRFuXfUwKeEqRzCKMsYAOC0cAm+PryaP2leo0oTGJ9LUK8REK7zyfFcmtC4oOzlkA==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.282.0.tgz",
+      "integrity": "sha512-P1ealsSrUALo0w0Qu5nBKsNQwsmqIfsoNtFWpaznjIcXE5rRMlZL69zb0KnGbQCBfEXsgaMOWjeGT8I3/XbOHQ==",
       "requires": {
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-config-provider": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.80.0.tgz",
-      "integrity": "sha512-vyTOMK04huB7n10ZUv0thd2TE6KlY8livOuLqFTMtj99AJ6vyeB5XBNwKnQtJIt/P7CijYgp8KcFvI9fndOmKg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.287.0.tgz",
+      "integrity": "sha512-+AO5dy6JEDvgtH9fcuCNnAQd6ilZjww8d/HNTCb5xOhiW1/pKSNMRhouGfn47uxq61WwDN/qUnv2nlVN83RB6w==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/shared-ini-file-loader": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/node-http-handler": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.94.0.tgz",
-      "integrity": "sha512-g9q6k+PS+BrtOzt8jrBWr9D543uB3ZoYZ2JCriwuCwnP4uIHlMf9wAOGcOgqgykfUAPBOLvz2rTwVs3Xl8GUmQ==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.282.0.tgz",
+      "integrity": "sha512-LIA4lsSKA/l1kTR5ERkJG2gARveB7Y40MR6yDwtIuhXeVu7Xo9m4BJFanCYIbyc093W0T53x438bwoBR+R+/fw==",
       "requires": {
-        "@aws-sdk/abort-controller": "3.78.0",
-        "@aws-sdk/protocol-http": "3.78.0",
-        "@aws-sdk/querystring-builder": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/abort-controller": "3.272.0",
+        "@aws-sdk/protocol-http": "3.282.0",
+        "@aws-sdk/querystring-builder": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/property-provider": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.78.0.tgz",
-      "integrity": "sha512-PZpLvV0hF6lqg3CSN9YmphrB/t5LVJVWGJLB9d9qm7sJs5ksjTYBb5bY91OQ3zit0F4cqBMU8xt2GQ9J6d4DvQ==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.272.0.tgz",
+      "integrity": "sha512-V1pZTaH5eqpAt8O8CzbItHhOtzIfFuWymvwZFkAtwKuaHpnl7jjrTouV482zoq8AD/fF+VVSshwBKYA7bhidIw==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/protocol-http": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.78.0.tgz",
-      "integrity": "sha512-SQB26MhEK96yDxyXd3UAaxLz1Y/ZvgE4pzv7V3wZiokdEedM0kawHKEn1UQJlqJLEZcQI9QYyysh3rTvHZ3fyg==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.282.0.tgz",
+      "integrity": "sha512-aOPv5DhsbG06WKfeh2g0H8RGnaeI8pLhaA+Mq1BvzXcghhlDu+FM9K/GjC/f1lWk1UNryfevOR7SdQm95ciHQg==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-builder": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.78.0.tgz",
-      "integrity": "sha512-aib6RW1WAaTQDqVgRU1Ku9idkhm90gJKbCxVaGId+as6QHNUqMChEfK2v+0afuKiPNOs5uWmqvOXI9+Gt+UGDg==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.272.0.tgz",
+      "integrity": "sha512-ndo++7GkdCj5tBXE6rGcITpSpZS4PfyV38wntGYAlj9liL1omk3bLZRY6uzqqkJpVHqbg2fD7O2qHNItzZgqhw==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/querystring-parser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.78.0.tgz",
-      "integrity": "sha512-csaH8YTyN+KMNczeK6fBS8l7iJaqcQcKOIbpQFg5upX4Ly5A56HJn4sVQhY1LSgfSk4xRsNfMy5mu6BlsIiaXA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.272.0.tgz",
+      "integrity": "sha512-5oS4/9n6N1LZW9tI3qq/0GnCuWoOXRgcHVB+AJLRBvDbEe+GI+C/xK1tKLsfpDNgsQJHc4IPQoIt4megyZ/1+A==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/service-error-classification": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.78.0.tgz",
-      "integrity": "sha512-x7Lx8KWctJa01q4Q72Zb4ol9L/era3vy2daASu8l2paHHxsAPBE0PThkvLdUSLZSzlHSVdh3YHESIsT++VsK4w=="
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.272.0.tgz",
+      "integrity": "sha512-REoltM1LK9byyIufLqx9znhSolPcHQgVHIA2S0zu5sdt5qER4OubkLAXuo4MBbisUTmh8VOOvIyUb5ijZCXq1w=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.80.0.tgz",
-      "integrity": "sha512-3d5EBJjnWWkjLK9skqLLHYbagtFaZZy+3jUTlbTuOKhlOwe8jF7CUM3j6I4JA6yXNcB3w0exDKKHa8w+l+05aA==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.287.0.tgz",
+      "integrity": "sha512-CxZp6R11uC12lNg+vKXc8bU7mqIrM43ZY2BbLRZ4tBlc7RLQpcJyccpEwEQAmJq0PA+rDUNod0gYnrM5DOUCLg==",
       "requires": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/signature-v4": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.78.0.tgz",
-      "integrity": "sha512-eePjRYuzKoi3VMr/lgrUEF1ytLeH4fA/NMCykr/uR6NMo4bSJA59KrFLYSM7SlWLRIyB0UvJqygVEvSxFluyDw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.282.0.tgz",
+      "integrity": "sha512-rnSL3UyF/No7+O2EMtN1sTCiqL1a+odbfnfo3wCSl8DH5PEYINt2kZgVEvT1Fgaffk1pUggBBOZoR+arPIIDJA==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
-        "@aws-sdk/types": "3.78.0",
-        "@aws-sdk/util-hex-encoding": "3.58.0",
-        "@aws-sdk/util-middleware": "3.78.0",
-        "@aws-sdk/util-uri-escape": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.272.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.272.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "@aws-sdk/util-utf8": "3.254.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/smithy-client": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.85.0.tgz",
-      "integrity": "sha512-Ox/yQEAnANzhpJMyrpuxWtF/i3EviavENczT7fo4uwSyZTz/sfSBQNjs/YAG1UeA6uOI3pBP5EaFERV5hr2fRA==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.279.0.tgz",
+      "integrity": "sha512-ZcYWUQDGAYN6NXRpJuSn46PetrpPCA6TrDVwP9+3pERzTXZ66npXoG2XhHjNrOXy/Ted5A3OxKrM4/zLu9tK3A==",
       "requires": {
-        "@aws-sdk/middleware-stack": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/middleware-stack": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.287.0.tgz",
+      "integrity": "sha512-RuqgncuQpLD5+W84RbTj/pgJmrjxSPJG0GBAtnISXrc39mGoc0ArOzQUTKIs+cLqDY+WS1/pqXlnQmKvmw3TQw==",
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/shared-ini-file-loader": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/types": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.78.0.tgz",
-      "integrity": "sha512-I9PTlVNSbwhIgMfmDM5as1tqRIkVZunjVmfogb2WVVPp4CaX0Ll01S0FSMSLL9k6tcQLXqh45pFRjrxCl9WKdQ=="
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.272.0.tgz",
+      "integrity": "sha512-MmmL6vxMGP5Bsi+4wRx4mxYlU/LX6M0noOXrDh/x5FfG7/4ZOar/nDxqDadhJtNM88cuWVHZWY59P54JzkGWmA==",
+      "requires": {
+        "tslib": "^2.3.1"
+      }
     },
     "@aws-sdk/url-parser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.78.0.tgz",
-      "integrity": "sha512-iQn2AjECUoJE0Ae9XtgHtGGKvUkvE8hhbktGopdj+zsPBe4WrBN2DgVxlKPPrBonG/YlcL1D7a5EXaujWSlUUw==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.272.0.tgz",
+      "integrity": "sha512-vX/Tx02PlnQ/Kgtf5TnrNDHPNbY+amLZjW0Z1d9vzAvSZhQ4i9Y18yxoRDIaDTCNVRDjdhV8iuctW+05PB5JtQ==",
       "requires": {
-        "@aws-sdk/querystring-parser": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/querystring-parser": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.58.0.tgz",
-      "integrity": "sha512-0ebsXIZNpu/fup9OgsFPnRKfCFbuuI9PPRzvP6twzLxUB0c/aix6Co7LGHFKcRKHZdaykoJMXArf8eHj2Nzv1Q==",
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
-      "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
-      "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-body-length-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
-      "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-buffer-from": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
-      "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
       "requires": {
-        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-config-provider": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
-      "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.85.0.tgz",
-      "integrity": "sha512-oqK/e2pHuMWrvTJWtDBzylbj232ezlTay5dCq4RQlyi3LPPVBQ08haYD1Mk2ikQ/qa0XvbSD6YVhjpTlvwRNjw==",
+      "version": "3.279.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.279.0.tgz",
+      "integrity": "sha512-RnchYRrpapTT5Hu23LOfk6e8RMVq0kUzho6xA6TJj1a4uGxkcRMvgzPipCq1P5uHu0mrkQBg9pGPEVNOUs38/Q==",
       "requires": {
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.85.0.tgz",
-      "integrity": "sha512-KDNl4H8jJJLh6y7I3MSwRKe4plKbFKK8MVkS0+Fce/GJh4EnqxF0HzMMaSeNUcPvO2wHRq2a60+XW+0d7eWo1A==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.287.0.tgz",
+      "integrity": "sha512-ZGpbPvUA+m+Lf01eTDHkXmulEPT4LphffEt6M9cHPMhwEZfzxhXLyNXyGRunraoBBzB62hKBbFM2atsoHpuIZA==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.80.0",
-        "@aws-sdk/credential-provider-imds": "3.81.0",
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/property-provider": "3.78.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/config-resolver": "3.287.0",
+        "@aws-sdk/credential-provider-imds": "3.287.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/property-provider": "3.272.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.272.0.tgz",
+      "integrity": "sha512-c4MPUaJt2G6gGpoiwIOqDfUa98c1J63RpYvf/spQEKOtC/tF5Gfqlxuq8FnAl5lHnrqj1B9ZXLLxFhHtDR0IiQ==",
+      "requires": {
+        "@aws-sdk/types": "3.272.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-hex-encoding": {
-      "version": "3.58.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
-      "integrity": "sha512-Rl+jXUzk/FJkOLYfUVYPhKa2aUmTpeobRP31l8IatQltSzDgLyRHO35f6UEs7Ztn5s1jbu/POatLAZ2WjbgVyg==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-      "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-middleware": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.78.0.tgz",
-      "integrity": "sha512-Hi3wv2b0VogO4mzyeEaeU5KgIt4qeo0LXU5gS6oRrG0T7s2FyKbMBkJW3YDh/Y8fNwqArZ+/QQFujpP0PIKwkA==",
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.272.0.tgz",
+      "integrity": "sha512-Abw8m30arbwxqmeMMha5J11ESpHUNmCeSqSzE8/C4B8jZQtHY4kq7f+upzcNIQ11lsd+uzBEzNG3+dDRi0XOJQ==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-retry": {
+      "version": "3.272.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.272.0.tgz",
+      "integrity": "sha512-Ngha5414LR4gRHURVKC9ZYXsEJhMkm+SJ+44wlzOhavglfdcKKPUsibz5cKY1jpUV7oKECwaxHWpBB8r6h+hOg==",
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@aws-sdk/util-uri-escape": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
-      "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
       "requires": {
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-browser": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.78.0.tgz",
-      "integrity": "sha512-diGO/Bf4ggBOEnfD7lrrXaaXOwOXGz0bAJ0HhpizwEMlBld5zfDlWXjNpslh+8+u3EHRjPJQ16KGT6mp/Dm+aw==",
+      "version": "3.282.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.282.0.tgz",
+      "integrity": "sha512-Z639oyTa5fZfyi4Xr64+eiAwBCxfpe9Op4Vhnr1z/RwonQM/qywydv6Ttpeq1q5uQ0nG4wTkOMpfh39g+VqIgw==",
       "requires": {
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/types": "3.272.0",
         "bowser": "^2.11.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-user-agent-node": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.80.0.tgz",
-      "integrity": "sha512-QV26qIXws1m6sZXg65NS+XrQ5NhAzbDVQLtEVE4nC39UN8fuieP6Uet/gZm9mlLI9hllwvcV7EfgBM3GSC7pZg==",
+      "version": "3.287.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.287.0.tgz",
+      "integrity": "sha512-yXg0C3WyxyRkQstR4VCTgnEPQd/ViRz+9rEPkYNIWXPvp1l8hPygk5q9tmSD09Lg8wzm6jR6V0MSyJnbwdzq+g==",
       "requires": {
-        "@aws-sdk/node-config-provider": "3.80.0",
-        "@aws-sdk/types": "3.78.0",
+        "@aws-sdk/node-config-provider": "3.287.0",
+        "@aws-sdk/types": "3.272.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.254.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+      "integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
         "tslib": "^2.3.1"
       }
     },
     "@aws-sdk/util-utf8-browser": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
-      "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
-      "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
       }
     },
@@ -12185,9 +12422,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-xml-parser": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
-      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -14356,9 +14596,9 @@
       "integrity": "sha512-ZXUSQYTHdl3uS7IuCehYfMzKyIDBNoAuUblvy5oGO5UJSUTmStUUVPXbA9Qxd173Bgre53yCQczQuHgRWAdvJQ=="
     },
     "retry-as-promised": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-5.0.0.tgz",
-      "integrity": "sha512-6S+5LvtTl2ggBumk04hBo/4Uf6fRJUwIgunGZ7CYEBCeufGFW1Pu6ucUf/UskHeWOIsUcLOGLFXPig5tR5V1nA=="
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
     },
     "reusify": {
       "version": "1.0.4",
@@ -14453,9 +14693,9 @@
       "dev": true
     },
     "sequelize": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.21.2.tgz",
-      "integrity": "sha512-K0c6j/Y6yfucBL9XYHMVWqYGFShPsj6ZzMrQcOAjqzyE+a1XMBOoTXXjRvJS+fz6cKeh2D3ZqhYDRwN8nfvOMQ==",
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.29.1.tgz",
+      "integrity": "sha512-EL7HAPtOFyi2h3O4lVdetAzDK0AkLQkK608CRRKB8U9o2swx+4MQKgxAIdcJsB0vud6LqKdVLL7Vfc51glgTYA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/validator": "^13.7.1",
@@ -14464,9 +14704,9 @@
         "inflection": "^1.13.2",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "moment-timezone": "^0.5.34",
+        "moment-timezone": "^0.5.35",
         "pg-connection-string": "^2.5.0",
-        "retry-as-promised": "^5.0.0",
+        "retry-as-promised": "^7.0.3",
         "semver": "^7.3.5",
         "sequelize-pool": "^7.1.0",
         "toposort-class": "^1.0.1",
@@ -14712,6 +14952,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@aws-sdk/client-sns": "3.95.0",
+    "@aws-sdk/client-sns": "3.287.0",
     "@types/bcrypt": "3.0.0",
     "@types/cheerio": "^0.22.31",
     "@types/validator": "13.1.3",
@@ -35,7 +35,7 @@
     "nodemailer": "6.6.2",
     "pg": "8.5.1",
     "reflect-metadata": "0.1.13",
-    "sequelize": "6.21.2",
+    "sequelize": "6.29.1",
     "sequelize-typescript": "2.1.3",
     "source-map-support": "0.5.19",
     "telegraf": "3.38.0",


### PR DESCRIPTION
Upgrading dependencies based on Snyk security warnings

To-dos:
- [ ] Deploy to staging at 3pm or so
  - Per [this PR](https://github.com/opengovsg/postmangovsg/pull/1952#issuecomment-1459615158):
    - End-to-end tests will automatically run tx email API 
    - Cypress tests will no longer run automatically
- [ ] Manually run Cypress tests for encrypted email and SMSes
  - [ ] Verify that SMS campaigns are actually sent
- [ ] **[Optional]** Verify that regular email campaigns actually work by clicking through the frontend

If all goes well, then merge this in