### PR TITLE
feat: added endpoint to get api key list

### DIFF
--- a/backend/src/core/middlewares/api-key.middleware.ts
+++ b/backend/src/core/middlewares/api-key.middleware.ts
@@ -4,6 +4,14 @@ import { ApiKeyService } from '@core/services'
 
 const logger = loggerWithLabel(module)
 
+const listApiKeys = async (
+  req: Request,
+  res: Response
+): Promise<Response | void> => {
+  const userId = req.session?.user?.id
+  const apiKeys = await ApiKeyService.getApiKeys(userId.toString())
+  return res.status(200).json(apiKeys)
+}
 const deleteApiKey = async (
   req: Request,
   res: Response
@@ -31,5 +39,6 @@ const deleteApiKey = async (
 }
 
 export const ApiKeyMiddleware = {
+  listApiKeys,
   deleteApiKey,
 }

--- a/backend/src/core/routes/api-key.routes.ts
+++ b/backend/src/core/routes/api-key.routes.ts
@@ -3,5 +3,7 @@ import { ApiKeyMiddleware } from '@core/middlewares/api-key.middleware'
 
 const router = Router()
 
+router.get('/', ApiKeyMiddleware.listApiKeys)
+
 router.delete('/:apiKeyId', ApiKeyMiddleware.deleteApiKey)
 export default router

--- a/backend/src/core/routes/tests/api-key.routes.test.ts
+++ b/backend/src/core/routes/tests/api-key.routes.test.ts
@@ -49,3 +49,47 @@ describe('DELETE /api-key/:apiKeyId', () => {
     expect(res.body.api_key_id).toBe('1')
   })
 })
+
+describe('GET /api-key/', () => {
+  test('Attempting to get list without valid cookie', async () => {
+    const res = await request(app).get('/api-key')
+    expect(res.status).toBe(401)
+  })
+  test('Getting api key list when there are no api keys', async () => {
+    await User.create({ id: 1, email: 'user@agency.gov.sg' } as User)
+    const res = await request(appWithUserSession).get('/api-key')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(0)
+  })
+  test('Getting api key list with a few api keys', async () => {
+    await User.create({ id: 1, email: 'user@agency.gov.sg' } as User)
+    await ApiKey.create({
+      id: 1,
+      userId: '1',
+      hash: 'hash',
+      label: 'label',
+      lastFive: '12345',
+    } as ApiKey)
+    await ApiKey.create({
+      id: 2,
+      userId: '1',
+      hash: 'hash1',
+      label: 'label1',
+      lastFive: '22345',
+    } as ApiKey)
+    await ApiKey.create({
+      id: 3,
+      userId: '1',
+      hash: 'hash2',
+      label: 'label2',
+      lastFive: '32345',
+    } as ApiKey)
+    const res = await request(appWithUserSession).get('/api-key')
+    expect(res.status).toBe(200)
+    expect(res.body).toHaveLength(3)
+    // should be arranged according to what was created most recently
+    expect(res.body[0].id).toBe(3)
+    expect(res.body[1].id).toBe(2)
+    expect(res.body[2].id).toBe(1)
+  })
+})

--- a/backend/src/core/services/api-key.service.ts
+++ b/backend/src/core/services/api-key.service.ts
@@ -44,6 +44,15 @@ const getApiKeyRecord = async (hash: string): Promise<ApiKey | null> => {
   })
 }
 
+const getApiKeys = async (userId: string): Promise<ApiKey[] | null> => {
+  return await ApiKey.findAll({
+    where: {
+      userId,
+    },
+    order: [['createdAt', 'DESC']],
+  })
+}
+
 const deleteApiKey = async (
   userId: string,
   apiKeyId: number
@@ -61,5 +70,6 @@ export const ApiKeyService = {
   getApiKeyHash,
   hasValidApiKey,
   getApiKeyRecord,
+  getApiKeys,
   deleteApiKey,
 }


### PR DESCRIPTION
As per [ticket](https://www.notion.so/opengov/List-API-keys-endpoint-af0d9d82748b4c38bdd4f3fca5a5bf64?pvs=4)

Included in this PR:
- Building on previous PR after middleware and services are initiated
- Creating a new endpoint with api key routing to decouple from user settings
- Implement API Key list endpoint, sorted by created date DESC, only accessible by cookie
- Test cases for this use case