### PR TITLE
feat: support soft delete for api key

### DIFF
--- a/backend/src/core/models/user/api-key.ts
+++ b/backend/src/core/models/user/api-key.ts
@@ -7,7 +7,12 @@ import {
 } from 'sequelize-typescript'
 import { User } from './user'
 
-@Table({ tableName: 'api_keys', underscored: true, timestamps: true })
+@Table({
+  tableName: 'api_keys',
+  underscored: true,
+  timestamps: true,
+  paranoid: true,
+})
 export class ApiKey extends Model<ApiKey> {
   @ForeignKey(() => User)
   @Column({ type: DataType.STRING, allowNull: false })

--- a/backend/src/core/routes/tests/api-key.routes.test.ts
+++ b/backend/src/core/routes/tests/api-key.routes.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
 })
 
 afterEach(async () => {
-  await ApiKey.destroy({ where: {} })
+  await ApiKey.destroy({ where: {}, force: true })
   await User.destroy({ where: {} })
 })
 
@@ -47,6 +47,8 @@ describe('DELETE /api-key/:apiKeyId', () => {
     const res = await request(appWithUserSession).delete('/api-key/1')
     expect(res.status).toBe(200)
     expect(res.body.api_key_id).toBe('1')
+    const softDeletedApiKey = await ApiKey.findByPk(1)
+    expect(softDeletedApiKey?.deletedAt).not.toBeNull()
   })
 })
 

--- a/backend/src/database/migrations/20230322044351-append-delete-at-api-key.js
+++ b/backend/src/database/migrations/20230322044351-append-delete-at-api-key.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn(
+        'api_keys',
+        'deleted_at',
+        {
+          type: Sequelize.DataTypes.DATE,
+          allowNull: true
+        }
+    )
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('api_keys', 'deleted_at')
+  }
+};


### PR DESCRIPTION
As per [slack discussion](https://opengovproducts.slack.com/archives/C049QPXT27M/p1679459330284049?thread_ts=1679389658.985529&cid=C049QPXT27M)

Included in this release:
- Migration file to add deleteAt column
- Paranoid: true on api_keys model 
- Updating of existing test cases to test soft delete


Deployment Checklist

- [x] Running migration file for prod db