### PR TITLE
fix(amplify): use node version 16

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -13,7 +13,7 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm install
+        - nvm install 16
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
           export REACT_APP_SENTRY_ENVIRONMENT="production";


### PR DESCRIPTION
## Problem

AML2 image (default image of amplify) doesn't have the underlying required glibc version to run node 18

## Solution

- Remove repo-wide requirement to use node 18 (i.e. removing .nvmrc in root)
- Force use node v16 in amplify

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A
