### PR TITLE
refactor(config): use APP_ENV instead of NODE_ENV

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,14 +259,14 @@
         "filename": "backend/src/test-utils/test-env.ts",
         "hashed_secret": "c237a19676ad55d8904be354990dd54f92f9572c",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 9
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/src/test-utils/test-env.ts",
         "hashed_secret": "5d208377e1d51aa81cc6872275975d741fd7a488",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 10
       }
     ],
     "docs/api-usage.md": [
@@ -381,5 +381,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-20T09:16:08Z"
+  "generated_at": "2023-03-27T07:59:03Z"
 }

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -186,7 +186,7 @@ const config: Config<ConfigSchema> = convict({
     doc: 'The application environment.',
     format: ['production', 'staging', 'development'],
     default: 'production',
-    env: 'NODE_ENV',
+    env: 'APP_ENV',
   },
   APP_NAME: {
     doc: 'Name of the app',

--- a/backend/src/database/seeders/20210422101939-add-default-credentials.js
+++ b/backend/src/database/seeders/20210422101939-add-default-credentials.js
@@ -2,7 +2,7 @@
 
 // todo: find a way to deduplicate the code
 const formatDefaultCredentialName = (name) =>
-  `demo/${process.env.NODE_ENV}/${name}`
+  `demo/${process.env.APP_ENV}/${name}`
 
 const CREDENTIAL_NAMES = [
   'EMAIL_DEFAULT',

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -68,7 +68,7 @@ export const InitTelegramMiddleware = (
     const { telegram_bot_token: telegramBotToken } = req.body
 
     res.locals.credentials = { telegramBotToken }
-    res.locals.credentialName = `${process.env.NODE_ENV}-${botId(
+    res.locals.credentialName = `${process.env.APP_ENV}-${botId(
       telegramBotToken
     )}`
     return next()

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -203,7 +203,7 @@ describe('POST /campaign/{campaignId}/telegram/new-credentials', () => {
 
     expect(res.status).toBe(200)
 
-    const secretName = `${process.env.NODE_ENV}-12345`
+    const secretName = `${process.env.APP_ENV}-12345`
     expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
       expect.objectContaining({
         Name: secretName,

--- a/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
@@ -74,7 +74,7 @@ describe('POST /settings/telegram/credentials', () => {
 
     expect(res.status).toBe(200)
 
-    const secretName = `${process.env.NODE_ENV}-12345`
+    const secretName = `${process.env.APP_ENV}-12345`
     expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
       expect.objectContaining({
         Name: secretName,

--- a/backend/src/telegram/services/telegram-callback.service.ts
+++ b/backend/src/telegram/services/telegram-callback.service.ts
@@ -23,7 +23,7 @@ const verifyBotIdRegistered = async (botId: string): Promise<boolean> => {
       // before this change https://github.com/opengovsg/postmangovsg/pull/1414
       // we used to save only the secret by botId, hence there must be an or condition
       // here to support the legacy credentials as well
-      [Op.or]: [{ name: botId }, { name: `${process.env.NODE_ENV}-${botId}` }],
+      [Op.or]: [{ name: botId }, { name: `${process.env.APP_ENV}-${botId}` }],
     },
   })
   return !!botIdExists

--- a/backend/src/test-utils/test-env.ts
+++ b/backend/src/test-utils/test-env.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt'
 
+process.env.APP_ENV = 'development'
 process.env.REDIS_OTP_URI = 'redis://localhost:6379/3'
 process.env.REDIS_SESSION_URI = 'redis://localhost:6379/4'
 process.env.REDIS_RATE_LIMIT_URI = 'redis://localhost:6379/5'

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -82,7 +82,7 @@ const config: Config<ConfigSchema> = convict({
     doc: 'The application environment.',
     format: ['production', 'staging', 'development'],
     default: 'production',
-    env: 'NODE_ENV',
+    env: 'APP_ENV',
   },
   aws: {
     awsRegion: {


### PR DESCRIPTION
## Problem

Under the latest optimization #1968 , `NODE_ENV` is defaulted to `production` so that we only install production node_modules and also signal to node engines to carry out [optimizations](https://nodejs.dev/en/learn/nodejs-the-difference-between-development-and-production/) (and we want to have this in staging as well for env parity).
However, some of our application code relies on this `ENV` for business logic.

## Solution

Switching to use `APP_ENV` instead of `NODE_ENV`

**Note**: We don't switch these for serverless functions (e.g. redaction-digest, and unsubscribe-digest) as env vars these are set manually through GHA and the performance improvement is probably insignificant

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] set `APP_ENV` in our secret manager for the app