### PR TITLE
feat(backend): add endpoint to generate new api key

### DIFF
--- a/backend/src/core/middlewares/api-key.middleware.ts
+++ b/backend/src/core/middlewares/api-key.middleware.ts
@@ -1,44 +1,66 @@
 import { loggerWithLabel } from '@core/logger'
-import { Request, Response } from 'express'
-import { ApiKeyService } from '@core/services'
+import { Handler, Request, Response } from 'express'
+import { ApiKeyService, CredentialService } from '@core/services'
 
 const logger = loggerWithLabel(module)
 
-const listApiKeys = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  const userId = req.session?.user?.id
-  const apiKeys = await ApiKeyService.getApiKeys(userId.toString())
-  return res.status(200).json(apiKeys)
+export interface ApiKeyMiddleware {
+  listApiKeys: Handler
+  deleteApiKey: Handler
+  generateApiKey: Handler
 }
-const deleteApiKey = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  const { apiKeyId } = req.params
-  const userId = req.session?.user?.id
 
-  const deletedRows = await ApiKeyService.deleteApiKey(
-    userId.toString(),
-    +apiKeyId
-  )
-  if (deletedRows == 0) {
-    return res.status(404).json({
-      code: 'not_found',
-      message: `Could not find API key to delete`,
+export const InitApikeyMiddleware = (
+  credentialService: CredentialService
+): ApiKeyMiddleware => {
+  const listApiKeys = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    const userId = req.session?.user?.id
+    const apiKeys = await ApiKeyService.getApiKeys(userId.toString())
+    return res.status(200).json(apiKeys)
+  }
+  const deleteApiKey = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    const { apiKeyId } = req.params
+    const userId = req.session?.user?.id
+
+    const deletedRows = await ApiKeyService.deleteApiKey(
+      userId.toString(),
+      +apiKeyId
+    )
+    if (deletedRows == 0) {
+      return res.status(404).json({
+        code: 'not_found',
+        message: 'Could not find API key to delete',
+      })
+    }
+    logger.info({
+      message: 'Successfully deleted api key',
+      action: 'deleteApiKey',
+    })
+    return res.status(200).json({
+      api_key_id: apiKeyId,
     })
   }
-  logger.info({
-    message: 'Successfully deleted api key',
-    action: 'deleteApiKey',
-  })
-  return res.status(200).json({
-    api_key_id: apiKeyId,
-  })
-}
+  const generateApiKey = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    const userId = req.session?.user?.id
+    const apiKey = await credentialService.generateApiKey(
+      +userId,
+      req.body.label
+    )
+    return res.status(201).json(apiKey)
+  }
 
-export const ApiKeyMiddleware = {
-  listApiKeys,
-  deleteApiKey,
+  return {
+    listApiKeys,
+    deleteApiKey,
+    generateApiKey,
+  }
 }

--- a/backend/src/core/middlewares/api-key.middleware.ts
+++ b/backend/src/core/middlewares/api-key.middleware.ts
@@ -32,7 +32,7 @@ export const InitApikeyMiddleware = (
       userId.toString(),
       +apiKeyId
     )
-    if (deletedRows == 0) {
+    if (deletedRows === 0) {
       return res.status(404).json({
         code: 'not_found',
         message: 'Could not find API key to delete',
@@ -43,7 +43,7 @@ export const InitApikeyMiddleware = (
       action: 'deleteApiKey',
     })
     return res.status(200).json({
-      api_key_id: apiKeyId,
+      id: apiKeyId,
     })
   }
   const generateApiKey = async (

--- a/backend/src/core/middlewares/api-key.middleware.ts
+++ b/backend/src/core/middlewares/api-key.middleware.ts
@@ -1,6 +1,7 @@
 import { loggerWithLabel } from '@core/logger'
 import { Handler, Request, Response } from 'express'
 import { ApiKeyService, CredentialService } from '@core/services'
+import { ApiKey } from '@core/models'
 
 const logger = loggerWithLabel(module)
 
@@ -19,7 +20,7 @@ export const InitApikeyMiddleware = (
   ): Promise<Response> => {
     const userId = req.session?.user?.id
     const apiKeys = await ApiKeyService.getApiKeys(userId.toString())
-    return res.status(200).json(apiKeys)
+    return res.status(200).json(apiKeys.map(convertApiKeyModelToResponse))
   }
   const deleteApiKey = async (
     req: Request,
@@ -55,7 +56,18 @@ export const InitApikeyMiddleware = (
       +userId,
       req.body.label
     )
-    return res.status(201).json(apiKey)
+    return res.status(201).json(convertApiKeyModelToResponse(apiKey))
+  }
+
+  function convertApiKeyModelToResponse(
+    key: ApiKey & { plainTextKey?: string }
+  ) {
+    return {
+      id: key.id,
+      last_five: key.lastFive,
+      label: key.label,
+      plain_text_key: key.plainTextKey,
+    }
   }
 
   return {

--- a/backend/src/core/routes/api-key.routes.ts
+++ b/backend/src/core/routes/api-key.routes.ts
@@ -1,9 +1,20 @@
 import { Router } from 'express'
 import { ApiKeyMiddleware } from '@core/middlewares/api-key.middleware'
+import { celebrate, Joi, Segments } from 'celebrate'
 
-const router = Router()
+export const InitApiKeyRoute = (apiKeyMiddleware: ApiKeyMiddleware): Router => {
+  const router = Router()
+  router.post(
+    '/',
+    celebrate({
+      [Segments.BODY]: Joi.object({
+        label: Joi.string().max(255).required(),
+      }),
+    }),
+    apiKeyMiddleware.generateApiKey
+  )
+  router.get('/', apiKeyMiddleware.listApiKeys)
 
-router.get('/', ApiKeyMiddleware.listApiKeys)
-
-router.delete('/:apiKeyId', ApiKeyMiddleware.deleteApiKey)
-export default router
+  router.delete('/:apiKeyId', apiKeyMiddleware.deleteApiKey)
+  return router
+}

--- a/backend/src/core/routes/index.ts
+++ b/backend/src/core/routes/index.ts
@@ -43,7 +43,8 @@ import {
   InitEmailTransactionalMiddleware,
 } from '@email/middlewares'
 import { InitTelegramMiddleware } from '@telegram/middlewares'
-import apiKeyRoutes from '@core/routes/api-key.routes'
+import { InitApiKeyRoute } from '@core/routes/api-key.routes'
+import { InitApikeyMiddleware } from '@core/middlewares/api-key.middleware'
 
 export const InitV1Route = (app: Application): Router => {
   const logger = loggerWithLabel(module)
@@ -91,6 +92,8 @@ export const InitV1Route = (app: Application): Router => {
     telegramMiddleware,
     settingsMiddleware
   )
+  const apiKeyMiddleware = InitApikeyMiddleware((app as any).credentialService)
+  const apiKeyRoutes = InitApiKeyRoute(apiKeyMiddleware)
 
   const CHANNEL_ROUTES = Object.values(ChannelType).map(
     (route) => `/${route.toLowerCase()}`

--- a/backend/src/core/routes/tests/api-key.routes.test.ts
+++ b/backend/src/core/routes/tests/api-key.routes.test.ts
@@ -46,7 +46,7 @@ describe('DELETE /api-key/:apiKeyId', () => {
     } as ApiKey)
     const res = await request(appWithUserSession).delete('/api-key/1')
     expect(res.status).toBe(200)
-    expect(res.body.api_key_id).toBe('1')
+    expect(res.body.id).toBe('1')
     const softDeletedApiKey = await ApiKey.findByPk(1)
     expect(softDeletedApiKey?.deletedAt).not.toBeNull()
   })

--- a/backend/src/core/services/api-key.service.ts
+++ b/backend/src/core/services/api-key.service.ts
@@ -44,8 +44,8 @@ const getApiKeyRecord = async (hash: string): Promise<ApiKey | null> => {
   })
 }
 
-const getApiKeys = async (userId: string): Promise<ApiKey[] | null> => {
-  return await ApiKey.findAll({
+const getApiKeys = async (userId: string): Promise<ApiKey[]> => {
+  return ApiKey.findAll({
     where: {
       userId,
     },

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -68,7 +68,7 @@ export interface CredentialService {
   generateApiKey(
     userId: number,
     label: string
-  ): Promise<ApiKey & { key: string }>
+  ): Promise<ApiKey & { plainTextKey: string }>
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -380,21 +380,21 @@ export const InitCredentialService = (redisService: RedisService) => {
   const generateApiKey = async (
     userId: number,
     label: string
-  ): Promise<ApiKey & { key: string }> => {
+  ): Promise<ApiKey & { plainTextKey: string }> => {
     const user = await User.findByPk(userId)
     if (!user) {
       throw new Error('User not found')
     }
     const name = user.email.split('@')[0].replace(/[^a-zA-Z0-9]/g, '')
-    const apiKeyPlainText = ApiKeyService.generateApiKeyFromName(name)
-    const apiKeyHash = await ApiKeyService.getApiKeyHash(apiKeyPlainText)
+    const plainTextKey = ApiKeyService.generateApiKeyFromName(name)
+    const apiKeyHash = await ApiKeyService.getApiKeyHash(plainTextKey)
     const apiKey = await ApiKey.create({
       userId: user.id.toString(),
       hash: apiKeyHash,
-      lastFive: apiKeyPlainText.slice(-5),
+      lastFive: plainTextKey.slice(-5),
       label,
     } as ApiKey)
-    return Object.assign({}, apiKey.toJSON(), { key: apiKeyPlainText })
+    return Object.assign({}, apiKey.toJSON(), { plainTextKey })
   }
 
   const updateDemoDisplayed = async (

--- a/backend/src/core/services/credential.service.ts
+++ b/backend/src/core/services/credential.service.ts
@@ -68,7 +68,7 @@ export interface CredentialService {
   generateApiKey(
     userId: number,
     label: string
-  ): Promise<ApiKey & { api_key: string }>
+  ): Promise<ApiKey & { key: string }>
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -380,7 +380,7 @@ export const InitCredentialService = (redisService: RedisService) => {
   const generateApiKey = async (
     userId: number,
     label: string
-  ): Promise<ApiKey & { api_key: string }> => {
+  ): Promise<ApiKey & { key: string }> => {
     const user = await User.findByPk(userId)
     if (!user) {
       throw new Error('User not found')
@@ -394,7 +394,7 @@ export const InitCredentialService = (redisService: RedisService) => {
       lastFive: apiKeyPlainText.slice(-5),
       label,
     } as ApiKey)
-    return Object.assign({}, apiKey.toJSON(), { api_key: apiKeyPlainText })
+    return Object.assign({}, apiKey.toJSON(), { key: apiKeyPlainText })
   }
 
   const updateDemoDisplayed = async (


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Generate-API-key-endpoint-39e2e9a06c7f44e083599e06fc4c8abe?pvs=4)

## Solution

Implement the endpoint.
- [x] Tested to make sure that newly created API key works with existing auth check

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A