### PR TITLE
hotfix: also delete queued jobs when deleting campaign

### DIFF
--- a/backend/src/core/middlewares/campaign.middleware.ts
+++ b/backend/src/core/middlewares/campaign.middleware.ts
@@ -2,11 +2,11 @@ import { NextFunction, Request, Response } from 'express'
 import { loggerWithLabel } from '@core/logger'
 import {
   CampaignSortField,
+  CampaignStatus,
   ChannelType,
   Ordering,
-  CampaignStatus,
 } from '@core/constants'
-import { CampaignService, UploadService } from '@core/services'
+import { CampaignService, JobService, UploadService } from '@core/services'
 import { Campaign } from '@core/models'
 
 const logger = loggerWithLabel(module)
@@ -200,6 +200,9 @@ const deleteCampaign = async (
         .status(404)
         .json({ message: `Campaign ${campaignId} not found` })
     }
+    // also delete any related job_queues, possible cases include
+    // scheduled campaigns, and campaigns that queue up due to high load.
+    await JobService.cancelJobQueues(campaignId)
 
     res.json({})
   } catch (e) {

--- a/backend/src/core/middlewares/job.middleware.ts
+++ b/backend/src/core/middlewares/job.middleware.ts
@@ -128,7 +128,7 @@ const cancelScheduledCampaign = async (
       message: 'Cancel Scheduled Campaign...',
       logMeta,
     })
-    await JobService.cancelScheduledCampaign(+campaignId)
+    await JobService.cancelJobQueues(+campaignId)
     return res.status(200).json({ campaignId })
   } catch (err) {
     return next(err)

--- a/backend/src/core/services/job.service.ts
+++ b/backend/src/core/services/job.service.ts
@@ -162,7 +162,7 @@ const updateScheduledCampaign = async (
   return jobCount
 }
 // indiscriminately delete JobQueue records that have the campaignId
-const cancelScheduledCampaign = async (campaignId: number) => {
+const cancelJobQueues = async (campaignId: number) => {
   await JobQueue.destroy({ where: { campaignId } })
 }
 
@@ -172,5 +172,5 @@ export const JobService = {
   stopCampaign,
   retryCampaign,
   updateScheduledCampaign,
-  cancelScheduledCampaign,
+  cancelJobQueues,
 }


### PR DESCRIPTION
A recently reported bug in [thread](https://opengovproducts.slack.com/archives/CT8D1FESY/p1680242246348529), that affects specifically two types of campaigns.
1. Scheduled campaigns
2. Campaigns sent out that are queued due to high load

After queueing the jobs, if the user decides to abandon the campaign and deletes the entire campaign, the relevant job_queues were not cleaned up as expected.


Included in this release:
- When deleting campaigns, also delete any relevant job_queue entities tied to it
- Rename cancelScheduledCampaigns to cancelJobQueues to make it more intuitive