### PR TITLE
fix(frontend): correct sentAt ts and status for scheduled campaigns

### DIFF
--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -302,6 +302,7 @@ const listCampaigns = ({
             'status',
             ['created_at', 'sent_at'],
             ['updated_at', 'status_updated_at'],
+            'visible_at',
           ],
         },
         {

--- a/frontend/src/classes/Campaign.ts
+++ b/frontend/src/classes/Campaign.ts
@@ -69,7 +69,16 @@ export class Campaign {
     this.demoMessageLimit = input['demo_message_limit']
     this.costPerMessage = input['cost_per_message']
     this.shouldSaveList = input['should_save_list']
-    this.visibleAt = input['visible_at']
+    this.visibleAt = input['visibleAt']
+    // override sentAt if it's a scheduled campaign
+    if (this.visibleAt) {
+      if (new Date(this.visibleAt) > new Date()) {
+        // don't show sent at if it's scheduled but not sent out yet
+        this.sentAt = undefined
+      } else {
+        this.sentAt = this.visibleAt
+      }
+    }
     if (this.status === Status.Scheduled) {
       const jobs = input['job_queue'] as Array<{ visible_at: string }>
       const jobsVisibleTime = jobs


### PR DESCRIPTION
## Problem

[Ticket](https://www.notion.so/opengov/Campaign-list-table-showing-incorrect-status-for-SCHEDULED-campaigns-250dba9218d34b19adce13877a30e894?pvs=4) and [Ticket](https://www.notion.so/opengov/Fix-Scheduled-Sending-Sent-At-UI-b9f543197e9c4bf0b955405d2e065d35?pvs=4)

## Solution

- return missing `visible_at` from backend for listing campaign
- recalculate `sentAt` on the frontend based on whether campaign is a scheduled one

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A
