### PR TITLE
feat: update guide link to use GoGovSG

### DIFF
--- a/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
+++ b/frontend/src/components/dashboard/settings/api-key/ApiKey.tsx
@@ -95,8 +95,8 @@ const ApiKey: FunctionComponent = () => {
         You can create an API key to access our programmatic email and
         programmatic SMS APIs. For more information, go to our{' '}
         <OutboundLink
-          eventLabel="https://guide.postman.gov.sg/developer-guide/api-doc"
-          to="https://guide.postman.gov.sg/developer-guide/api-doc"
+          eventLabel="https://go.gov.sg/postman-api"
+          to="https://go.gov.sg/postman-api"
           target="_blank"
         >
           API Guide


### PR DESCRIPTION
As a general rule, we should use GoGovSG links, so we can change what the links direct to without code change. (And I guess adds visibility/usage to our sister product.)

As part of API guide revamping, ticket [here](https://www.notion.so/opengov/Weekly-Updates-d526fabd8de543e79c4bae55041f986d?p=ba104566522a4ba3b832d2ed2afac392&pm=s)

