### PR TITLE
refactor(backend): refactor api errors declaration and handling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -200,7 +200,7 @@
         "filename": "backend/src/core/middlewares/auth.middleware.ts",
         "hashed_secret": "159500287c06851df741128ec4b073ea394414b6",
         "is_verified": false,
-        "line_number": 18
+        "line_number": 19
       }
     ],
     "backend/src/email/services/tests/email-template.service.test.ts": [

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -190,13 +190,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - id
-                properties:
-                  id:
-                    type: string
-                    example: '20'
+                $ref: '#/components/schemas/CampaignIdObject'
         '401':
           description: Unauthorized
         '404':
@@ -307,13 +301,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required:
-                  - id
-                properties:
-                  id:
-                    type: string
-                    example: '20'
+                $ref: '#/components/schemas/CampaignIdObject'
         '401':
           description: Unauthorized
         '500':
@@ -361,23 +349,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmailCampaign'
-        '400':
-          description: Invalid campaign type or not owned by user
         '401':
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -485,17 +460,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -565,17 +529,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -631,23 +584,16 @@ paths:
       responses:
         '202':
           description: Accepted. The uploaded file is being processed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignIdObject'
         '400':
           description: Bad Request
         '401':
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -736,17 +682,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -785,23 +720,16 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignIdObject'
         '401':
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -857,23 +785,18 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - message
+                properties:
+                  message:
+                    type: string
+                    example: 'OK'
         '400':
           description: Bad Request
         '401':
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -945,17 +868,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1014,80 +926,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
-        '500':
-          description: Internal Server Error
-          content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
-  /campaign/{campaignId}/email/stop:
-    post:
-      security:
-        - bearerAuth: []
-      tags:
-        - Email
-      summary: Stop sending campaign
-      parameters:
-        - name: campaignId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  campaign_id:
-                    type: integer
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1140,17 +978,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden as there is a job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1208,17 +1035,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1276,17 +1092,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1348,17 +1153,6 @@ paths:
           description: Forbidden, campaign not owned by user
         '410':
           description: Campaign has been redacted
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -4744,6 +4538,14 @@ components:
         - EMAIL
         - TELEGRAM
 
+    CampaignIdObject:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: '20'
     CampaignMeta:
       type: object
       properties:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -89,19 +89,6 @@ paths:
                     type: integer
         '401':
           description: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -157,19 +144,6 @@ paths:
                 $ref: '#/components/schemas/CampaignMeta'
         '401':
           description: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -214,24 +188,21 @@ paths:
         '200':
           description: Successfully deleted
           content:
-            schema: {} # TODO
+            application/json:
+              schema:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                    example: '20'
         '401':
           description: Unauthorized
         '404':
           description: Campaign not found
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -291,19 +262,6 @@ paths:
           description: Unauthorized
         '404':
           description: Not found
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -344,23 +302,20 @@ paths:
           schema:
             type: string
       responses:
-        '201':
+        '200':
           description: Successfully cancelled the campaign
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                    example: '20'
+        '401':
+          description: Unauthorized
         '500':
           description: Internal Server Error
           content:
@@ -1769,8 +1724,7 @@ paths:
                 classification:
                   type: string
                   nullable: true
-                  enum:
-                    [URGENT, FOR_ACTION, FOR_INFO]
+                  enum: [URGENT, FOR_ACTION, FOR_INFO]
                 tag:
                   type: string
                   nullable: true
@@ -1802,8 +1756,7 @@ paths:
                 classification:
                   type: string
                   nullable: true
-                  enum:
-                    [URGENT, FOR_ACTION, FOR_INFO]
+                  enum: [URGENT, FOR_ACTION, FOR_INFO]
                 tag:
                   type: string
                   nullable: true

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -3001,17 +3001,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3100,17 +3089,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3178,17 +3156,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3251,17 +3218,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3329,17 +3285,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden as there is a job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3384,17 +3329,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden as there is a job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3452,17 +3386,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3536,17 +3459,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3615,17 +3527,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3693,17 +3594,8 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
+        '404':
+          description: Not Found
         '500':
           description: Internal Server Error
           content:
@@ -3776,81 +3668,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
-        '500':
-          description: Internal Server Error
-          content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
-
-  /campaign/{campaignId}/telegram/stop:
-    post:
-      security:
-        - bearerAuth: []
-      tags:
-        - Telegram
-      summary: Stop sending campaign
-      parameters:
-        - name: campaignId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  campaign_id:
-                    type: integer
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3904,17 +3721,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3966,17 +3772,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -4003,7 +3798,7 @@ paths:
         '526':
           description: Invalid SSL certificate
 
-  /campaign/{campaignId}/telegram/update-stats:
+  /campaign/{campaignId}/telegram/refresh-stats:
     post:
       security:
         - bearerAuth: []
@@ -4028,17 +3823,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -4094,17 +3878,6 @@ paths:
           description: Forbidden, campaign not owned by user
         '410':
           description: Campaign has been redacted
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -4165,17 +3938,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1833,17 +1833,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1931,17 +1920,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2008,17 +1986,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2080,17 +2047,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2172,23 +2128,12 @@ paths:
           schema:
             type: string
       responses:
-        200:
+        '200':
           description: Success
         '401':
           description: Unauthorized
         '403':
           description: Forbidden as there is a job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2263,17 +2208,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2342,17 +2276,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2409,17 +2332,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2489,80 +2401,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
-        '500':
-          description: Internal Server Error
-          content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
-  /campaign/{campaignId}/sms/stop:
-    post:
-      security:
-        - bearerAuth: []
-      tags:
-        - SMS
-      summary: Stop sending campaign
-      parameters:
-        - name: campaignId
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  campaign_id:
-                    type: integer
-        '401':
-          description: Unauthorized
-        '403':
-          description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2615,17 +2453,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user or job in progress
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2675,17 +2502,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2735,17 +2551,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2800,17 +2605,6 @@ paths:
           description: Forbidden, campaign not owned by user
         '410':
           description: Campaign has been redacted
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2871,17 +2665,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -2937,17 +2720,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3117,19 +2889,6 @@ paths:
           content:
             text/plain:
               example: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -3187,17 +2946,6 @@ paths:
           description: Forbidden. Request violates firewall rules.
         '404':
           description: Not Found. No transactional message with such ID found
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -988,6 +988,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error403Response'
+        '410':
+          description: Data No Longer Available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error410Response'
         '500':
           description: Internal Server Error
           content:
@@ -1169,6 +1175,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error403Response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
@@ -1446,12 +1458,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401Response'
-        '403':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
@@ -1491,12 +1497,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401Response'
-        '403':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error403Response'
         '404':
           description: Not Found
           content:
@@ -1536,36 +1536,24 @@ paths:
                     properties:
                       cost_per_message:
                         type: number
-
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/template:
     put:
       security:
@@ -1624,35 +1612,34 @@ paths:
                           type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/upload/start:
     get:
       security:
@@ -1690,35 +1677,28 @@ paths:
                     type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/upload/complete:
     post:
       security:
@@ -1751,35 +1731,28 @@ paths:
           description: Accepted. The uploaded file is being processed.
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/upload/status:
     get:
       security:
@@ -1817,12 +1790,28 @@ paths:
                         type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden as there is a job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
     delete:
       security:
         - bearerAuth: []
@@ -1839,34 +1828,23 @@ paths:
         '200':
           description: Success
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden as there is a job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/new-credentials:
     post:
       security:
@@ -1912,35 +1890,28 @@ paths:
                     example: OK
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/credentials:
     post:
       security:
@@ -1980,35 +1951,28 @@ paths:
                     example: OK
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/preview:
     get:
       security:
@@ -2037,34 +2001,23 @@ paths:
                       body:
                         type: string
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/send:
     post:
       security:
@@ -2105,35 +2058,28 @@ paths:
                       type: number
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/retry:
     post:
       security:
@@ -2158,34 +2104,23 @@ paths:
                   campaign_id:
                     type: integer
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/stats:
     get:
       security:
@@ -2207,34 +2142,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignStats'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/refresh-stats:
     post:
       security:
@@ -2256,34 +2180,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignStats'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/export:
     get:
       security:
@@ -2308,36 +2221,29 @@ paths:
                 items:
                   $ref: '#/components/schemas/CampaignRecipient'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '410':
-          description: Campaign has been redacted
+          description: Data No Longer Available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error410Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/duplicate:
     post:
       security:
@@ -2370,34 +2276,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignDuplicateMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/sms/select-list:
     post:
       security:
@@ -2425,34 +2326,23 @@ paths:
         '201':
           description: A duplicate of the campaign was created
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /transactional/sms/send:
     post:
       security:
@@ -2484,12 +2374,28 @@ paths:
                 $ref: '#/components/schemas/SmsMessageTransactional'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '429':
-          description: Too many requests. Please try again later.
+          description: Rate limit exceeded. Too many requests.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error429Response'
         '500':
           description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /transactional/sms:
     get:
       security:
@@ -2591,37 +2497,23 @@ paths:
                     items:
                       $ref: '#/components/schemas/SmsMessageTransactional'
         '400':
-          description: Bad Request. Failed parameter validations.
-        '401':
-          description: Unauthorized.
+          description: Bad Request
           content:
-            text/plain:
-              example: Unauthorized
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
+        '401':
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /transactional/sms/{smsId}:
     get:
       security:
@@ -2644,41 +2536,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/SmsMessageTransactional'
         '400':
-          description: Bad Request. Failed parameter validations.
-        '401':
-          description: Unauthorized.
+          description: Bad Request
           content:
-            text/plain:
-              example: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
+        '401':
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '404':
-          description: Not Found. No transactional message with such ID found
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/telegram:
     get:
       security:
@@ -4172,6 +4052,18 @@ components:
         message:
           type: string
           example: Phone number 84206920 is invalid
+    Error410Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['campaign_redacted']
+        message:
+          type: string
+          example: Campaign 20 has been redacted
     Error413Response:
       type: object
       required:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1225,17 +1225,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1310,17 +1299,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1382,17 +1360,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1451,17 +1418,6 @@ paths:
           description: Unauthorized
         '403':
           description: Forbidden, campaign not owned by user
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1766,19 +1722,6 @@ paths:
           content:
             text/plain:
               example: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -1832,21 +1775,8 @@ paths:
           content:
             text/plain:
               example: Unauthorized
-        '403':
-          description: Forbidden. Request violates firewall rules.
         '404':
           description: Not Found. No transactional message with such ID found
-        '429':
-          description: Rate limit exceeded. Too many requests.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
         '500':
           description: Internal Server Error
           content:
@@ -4648,6 +4578,8 @@ components:
       type: object
       properties:
         message:
+          type: string
+        code:
           type: string
     ErrorStatus:
       type: object

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2586,34 +2586,23 @@ paths:
                   num_recipients:
                     type: number
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/template:
     put:
@@ -2673,35 +2662,28 @@ paths:
                           type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/upload/start:
     get:
@@ -2740,35 +2722,28 @@ paths:
                     type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/upload/complete:
     post:
@@ -2802,35 +2777,28 @@ paths:
           description: Accepted. The uploaded file is being processed.
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/upload/status:
     get:
@@ -2869,35 +2837,28 @@ paths:
                         type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden as there is a job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
     delete:
       security:
         - bearerAuth: []
@@ -2914,34 +2875,23 @@ paths:
         200:
           description: Success
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden as there is a job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/preview:
     get:
@@ -2971,34 +2921,23 @@ paths:
                       body:
                         type: string
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/new-credentials:
     post:
@@ -3043,35 +2982,28 @@ paths:
                     example: OK
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/credentials:
     post:
@@ -3111,35 +3043,28 @@ paths:
                     example: OK
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/credentials/verify:
     post:
@@ -3178,37 +3103,34 @@ paths:
                     example: OK
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '404':
           description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/send:
     post:
@@ -3252,35 +3174,28 @@ paths:
                       type: number
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/retry:
     post:
@@ -3306,34 +3221,23 @@ paths:
                   campaign_id:
                     type: integer
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user or job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/stats:
     get:
@@ -3357,34 +3261,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignStats'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/refresh-stats:
     post:
@@ -3408,34 +3301,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignStats'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/export:
     get:
@@ -3461,36 +3343,29 @@ paths:
                 items:
                   $ref: '#/components/schemas/CampaignRecipient'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '410':
-          description: Campaign has been redacted
+          description: Data No Longer Available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error410Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/telegram/duplicate:
     post:
@@ -3523,34 +3398,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignDuplicateMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
 components:
   securitySchemes:
@@ -3646,39 +3516,6 @@ components:
         - SENT
         - STOPPED
         - LOGGED
-
-    ValidationError:
-      description: any one of the params failed validation
-      type: object
-      properties:
-        statusCode:
-          type: integer
-          example: 400
-        error:
-          type: string
-          example: Bad Request
-        message:
-          type: string
-          example: |-
-            "from" must be a valid email
-        validation:
-          type: object
-          properties:
-            source:
-              type: string
-              example: body
-            keys:
-              type: array
-              items:
-                type: string
-                example: from
-    Error:
-      type: object
-      properties:
-        message:
-          type: string
-        code:
-          type: string
     ErrorStatus:
       type: object
       properties:

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -88,32 +88,17 @@ paths:
                   total_count:
                     type: integer
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
     post:
       security:
         - bearerAuth: []
@@ -143,32 +128,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaigns/{campaignId}:
     delete:
       security:
@@ -192,36 +163,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignIdObject'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '404':
-          description: Campaign not found
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
     put:
       security:
         - bearerAuth: []
@@ -253,34 +217,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '404':
-          description: Not found
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaigns/{campaignId}/cancel:
     post:
@@ -303,32 +256,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignIdObject'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/email:
     get:
       security:
@@ -350,34 +289,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmailCampaign'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/email/template:
     put:
       security:
@@ -456,35 +385,29 @@ paths:
                         type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/email/upload/start:
     get:
       security:
@@ -525,35 +448,29 @@ paths:
                     type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/email/upload/complete:
     post:
       security:
@@ -590,35 +507,29 @@ paths:
                 $ref: '#/components/schemas/CampaignIdObject'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/email/upload/status:
     get:
       security:
@@ -678,35 +589,28 @@ paths:
                         type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
     delete:
       security:
         - bearerAuth: []
@@ -727,34 +631,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignIdObject'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/email/credentials:
     post:
@@ -793,35 +686,28 @@ paths:
                     example: 'OK'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /campaign/{campaignId}/email/preview:
     get:
@@ -865,34 +751,23 @@ paths:
                       themed_body:
                         type: string
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/send:
     post:
       security:
@@ -920,37 +795,24 @@ paths:
                     type: array
                     items:
                       type: number
-        '400':
-          description: Bad Request
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/retry:
     post:
       security:
@@ -975,34 +837,23 @@ paths:
                   campaign_id:
                     type: integer
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden as there is a job in progress
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/stats:
     get:
       security:
@@ -1032,34 +883,23 @@ paths:
                       unsubscribed:
                         type: number
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/refresh-stats:
     post:
       security:
@@ -1089,34 +929,23 @@ paths:
                       unsubscribed:
                         type: number
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/export:
     get:
       security:
@@ -1148,36 +977,23 @@ paths:
                         'unsubscriber.reason':
                           type: string
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
-        '410':
-          description: Campaign has been redacted
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/protect/upload/start:
     get:
       security:
@@ -1218,38 +1034,30 @@ paths:
                     type: array
                     items:
                       type: string
-
         '400':
-          description: Invalid campaign type, not owned by user
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/protect/upload/complete:
     post:
       security:
@@ -1295,35 +1103,28 @@ paths:
                     type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/duplicate:
     post:
       security:
@@ -1357,34 +1158,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignDuplicateMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /campaign/{campaignId}/email/select-list:
     post:
       security:
@@ -1415,34 +1205,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/CampaignMeta'
         '401':
-          description: Unauthorized
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
         '403':
-          description: Forbidden, campaign not owned by user
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
 
   /transactional/email/send:
     post:
@@ -1518,102 +1297,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmailMessageTransactional'
         '400':
-          description: Bad Request. Failed parameter validations, message is malformed, or attachments are rejected.
+          description: Bad Request
           content:
-            text/plain:
-              examples:
-                InvalidRecipientError:
-                  value: Recipient email is blacklisted
-                TemplateError:
-                  value: Message is invalid as the subject or body only contains invalid HTML tags.
-                MaliciousFileError:
-                  value: 'Error: One or more attachments may be potentially malicious. Please check the attached files.'
-                UnsupportedFileTypeError:
-                  value: 'Error: One or more attachments may be an unsupported file type. Please check the attached files.'
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/ValidationError'
-                  - $ref: '#/components/schemas/Error'
-              examples:
-                ValidationError:
-                  value:
-                    statusCode: 400
-                    error: Bad Request
-                    message: |-
-                      "from" must be a valid email
-                    validation: { source: body, keys: [from] }
-                FromError:
-                  # align with message in backend/src/email/middlewares/email.middleware.ts
-                  value:
-                    {
-                      message: Invalid 'from' email address,
-                      which must be either the default donotreply@mail.postman.gov.sg or the user's email (which requires setup with Postman team). Contact us to learn more.,
-                    }
-
+                $ref: '#/components/schemas/Error400Response'
         '401':
-          description: Unauthorized.
-          content:
-            text/plain:
-              example: Unauthorized
-        '403':
-          description: Forbidden. Request comes from an invalid `from` address, violates firewall rules.
+          description: Unauthenticated
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                FromError:
-                  value: { message:  Attachments cannot be sent from the default @mail.postman.gov.sg domain }
+                $ref: '#/components/schemas/Error401Response'
+        '403':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '413':
           description: Number of attachments or size of attachments exceeded limit.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                AttachmentQtyLimit:
-                  value: { message: Number of attachments exceeds limit }
-                AttachmentSizeLimit:
-                  value: { message: Size of one or more attachments exceeds limit }
-                CumulativeAttachmentSizeLimit:
-                  value: { message: Cumulative attachment size exceeds limit }
+                $ref: '#/components/schemas/Error413Response'
         '429':
           description: Rate limit exceeded. Too many requests.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorStatus'
-              example:
-                {
-                  status: 429,
-                  message: Too many requests. Please try again later.,
-                }
+                $ref: '#/components/schemas/Error429Response'
         '500':
-          description: Internal Server Error (includes error such as custom domain passed email validation but is incorrect; see https://github.com/opengovsg/postmangovsg/issues/1837)
+          description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /transactional/email:
     get:
       security:
@@ -1716,37 +1435,29 @@ paths:
                     items:
                       $ref: '#/components/schemas/EmailMessageTransactional'
         '400':
-          description: Bad Request. Failed parameter validations.
-        '401':
-          description: Unauthorized.
+          description: Bad Request
           content:
-            text/plain:
-              example: Unauthorized
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
+        '401':
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
+        '403':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
   /transactional/email/{emailId}:
     get:
       security:
@@ -1769,39 +1480,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/EmailMessageTransactional'
         '400':
-          description: Bad Request. Failed parameter validations.
-        '401':
-          description: Unauthorized.
+          description: Bad Request
           content:
-            text/plain:
-              example: Unauthorized
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400Response'
+        '401':
+          description: Unauthenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401Response'
+        '403':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403Response'
         '404':
-          description: Not Found. No transactional message with such ID found
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error404Response'
         '500':
           description: Internal Server Error
           content:
-            text/plain:
-              example: Internal Server Error
-        '502':
-          description: Bad Gateway
-        '504':
-          description: Gateway Timeout
-        '503':
-          description: Service Temporarily Unavailable
-        '520':
-          description: Web Server Returns An Unknown Error
-        '521':
-          description: Web Server Is Down
-        '522':
-          description: Connection Timed Out
-        '523':
-          description: Origin Is Unreachable
-        '524':
-          description: A Timeout occurred
-        '525':
-          description: SSL handshake failed
-        '526':
-          description: Invalid SSL certificate
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500Response'
+
   /campaign/{campaignId}/sms:
     get:
       security:
@@ -4394,3 +4102,97 @@ components:
               type: array
               items:
                 type: string
+    Error401Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['unathenticated']
+        message:
+          type: string
+          example: Unauthenticated request. Please try again with correct authentication
+    Error500Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['internal_server']
+        message:
+          type: string
+          example: Intetnal server error. Please try again later
+    Error404Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['not_found']
+        message:
+          type: string
+          example: Campaign with ID 20 not found.
+    Error403Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['unauthorized', 'already_sent']
+        message:
+          type: string
+          example: Campaign can't be edited at the moment as there're ongoing uploads or jobs
+    Error400Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum:
+            [
+              'api_validation',
+              'invalid_recipient',
+              'invalid_credentials',
+              'malformed',
+              'invalid_parameters',
+              'invalid_from_address',
+              'invalid_template',
+              'invalid_credential_label',
+            ]
+        message:
+          type: string
+          example: Phone number 84206920 is invalid
+    Error413Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['attachment_limit']
+        message:
+          type: string
+          example: Size of attachments exceeds limit
+    Error429Response:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          enum: ['rate_limit']
+        message:
+          type: string
+          example: Too many requests. Please try again later.

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -1,0 +1,33 @@
+export class RestApiError extends Error {
+  readonly httpStatusCode: number
+  readonly errorCode: string
+  constructor(httpStatusCode: number, errorCode: string, message: string) {
+    super(message)
+    this.httpStatusCode = httpStatusCode
+    this.errorCode = errorCode
+  }
+}
+
+export class ApiValidationError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'api_validation', message)
+  }
+}
+
+export class ApiInvalidRecipientError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_recipient', message)
+  }
+}
+
+export class ApiInvalidSmsCredentialsError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_sms_credentials', message)
+  }
+}
+
+export class ApiNotFoundError extends RestApiError {
+  constructor(message: string) {
+    super(404, 'not_found', message)
+  }
+}

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -97,3 +97,9 @@ export class ApiAttachmentLimitError extends RestApiError {
     super(413, 'attachment_limit', message)
   }
 }
+
+export class ApiInvalidCredentialLabelError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_credential_label', message)
+  }
+}

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -49,3 +49,9 @@ export class ApiAuthorizationError extends RestApiError {
     super(403, 'unauthorized', message)
   }
 }
+
+export class ApiInvalidParametersError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_parameters', message)
+  }
+}

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -31,3 +31,21 @@ export class ApiNotFoundError extends RestApiError {
     super(404, 'not_found', message)
   }
 }
+
+export class ApiAuthenticationError extends RestApiError {
+  constructor(message: string) {
+    super(401, 'unauthenticated', message)
+  }
+}
+
+export class ApiMalformError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'malformed', message)
+  }
+}
+
+export class ApiAuthorizationError extends RestApiError {
+  constructor(message: string) {
+    super(403, 'unauthorized', message)
+  }
+}

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -20,9 +20,9 @@ export class ApiInvalidRecipientError extends RestApiError {
   }
 }
 
-export class ApiInvalidSmsCredentialsError extends RestApiError {
+export class ApiInvalidCredentialsError extends RestApiError {
   constructor(message: string) {
-    super(400, 'invalid_sms_credentials', message)
+    super(400, 'invalid_credentials', message)
   }
 }
 
@@ -53,5 +53,35 @@ export class ApiAuthorizationError extends RestApiError {
 export class ApiInvalidParametersError extends RestApiError {
   constructor(message: string) {
     super(400, 'invalid_parameters', message)
+  }
+}
+
+export class ApiInvalidFromAddressError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_from_address', message)
+  }
+}
+
+export class ApiInvalidTemplateError extends RestApiError {
+  constructor(message: string) {
+    super(400, 'invalid_template', message)
+  }
+}
+
+export class ApiInternalServerError extends RestApiError {
+  constructor(message: string) {
+    super(500, 'internal_server', message)
+  }
+}
+
+export class ApiAlreadySentError extends RestApiError {
+  constructor(message: string) {
+    super(403, 'already_sent', message)
+  }
+}
+
+export class ApiCampaignRedactedError extends RestApiError {
+  constructor(message: string) {
+    super(410, 'campaign_redacted', message)
   }
 }

--- a/backend/src/core/errors/rest-api.errors.ts
+++ b/backend/src/core/errors/rest-api.errors.ts
@@ -85,3 +85,15 @@ export class ApiCampaignRedactedError extends RestApiError {
     super(410, 'campaign_redacted', message)
   }
 }
+
+export class ApiRateLimitError extends RestApiError {
+  constructor(message: string) {
+    super(429, 'rate_limit', message)
+  }
+}
+
+export class ApiAttachmentLimitError extends RestApiError {
+  constructor(message: string) {
+    super(413, 'attachment_limit', message)
+  }
+}

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -9,6 +9,7 @@ import { InitV1Route } from '@core/routes'
 import { loggerWithLabel } from '@core/logger'
 import { ensureAttachmentsFieldIsArray } from '@core/utils/attachment'
 import helmet from 'helmet'
+import { ApiValidationError, RestApiError } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 const FRONTEND_URL = config.get('frontendUrl')
@@ -184,18 +185,37 @@ const expressApp = ({ app }: { app: express.Application }): void => {
     (
       err: Error,
       _req: express.Request,
-      res: express.Response,
+      _res: express.Response,
       next: express.NextFunction
-    ): express.Response | void => {
+    ) => {
       if (isCelebrate(err)) {
-        return res.status(400).json({
-          code: 'api_validation',
-          message: err.message,
-        })
+        throw new ApiValidationError(err.message)
+      } else if (err) {
+        return next(err)
       }
       next()
     }
   )
+
+  app.use(
+    (
+      err: Error,
+      _req: express.Request,
+      res: express.Response,
+      next: express.NextFunction
+    ): express.Response | void => {
+      if (err instanceof RestApiError) {
+        return res.status(err.httpStatusCode).json({
+          code: err.errorCode,
+          message: err.message,
+        })
+      } else if (err) {
+        return next(err)
+      }
+      next()
+    }
+  )
+
   app.use(Sentry.Handlers.errorHandler())
 
   app.use(

--- a/backend/src/core/loaders/express.loader.ts
+++ b/backend/src/core/loaders/express.loader.ts
@@ -3,13 +3,18 @@ import { isCelebrate } from 'celebrate'
 import express, { Request, Response, NextFunction } from 'express'
 import expressWinston from 'express-winston'
 import * as Sentry from '@sentry/node'
+import tracer from 'dd-trace'
 
 import config from '@core/config'
 import { InitV1Route } from '@core/routes'
 import { loggerWithLabel } from '@core/logger'
 import { ensureAttachmentsFieldIsArray } from '@core/utils/attachment'
 import helmet from 'helmet'
-import { ApiValidationError, RestApiError } from '@core/errors/rest-api.errors'
+import {
+  ApiMalformError,
+  ApiValidationError,
+  RestApiError,
+} from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 const FRONTEND_URL = config.get('frontendUrl')
@@ -201,6 +206,29 @@ const expressApp = ({ app }: { app: express.Application }): void => {
     (
       err: Error,
       _req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction
+    ) => {
+      if (isBodyParserError(err as ErrorWithType)) {
+        logger.info({
+          message: 'Malformed request',
+          error: {
+            message: err.message,
+            type: (err as ErrorWithType).type,
+          },
+        })
+        throw new ApiMalformError('Malformed request body')
+      } else if (err) {
+        return next(err)
+      }
+      next()
+    }
+  )
+
+  app.use(
+    (
+      err: Error,
+      _req: express.Request,
       res: express.Response,
       next: express.NextFunction
     ): express.Response | void => {
@@ -225,15 +253,10 @@ const expressApp = ({ app }: { app: express.Application }): void => {
       res: express.Response,
       _next: express.NextFunction
     ) => {
-      if (isBodyParserError(err as ErrorWithType)) {
-        logger.info({
-          message: 'Malformed request',
-          error: {
-            message: err.message,
-            type: (err as ErrorWithType).type,
-          },
-        })
-        return res.status(400).json({ message: 'Malformed request body' })
+      const traceId = tracer.scope().active()?.context().toTraceId()
+      let message = 'Internal Server Error.'
+      if (traceId) {
+        message = `Internal Server Error. Please reach out to us with tracking ID ${traceId} for more info.`
       }
       logger.error({
         message: 'Unexpected error occured',
@@ -243,7 +266,7 @@ const expressApp = ({ app }: { app: express.Application }): void => {
           original: (err as any).original,
         },
       })
-      return res.sendStatus(500)
+      return res.status(500).json({ code: 'internal_server', message })
     }
   )
 

--- a/backend/src/core/middlewares/api-key.middleware.ts
+++ b/backend/src/core/middlewares/api-key.middleware.ts
@@ -2,6 +2,7 @@ import { loggerWithLabel } from '@core/logger'
 import { Handler, Request, Response } from 'express'
 import { ApiKeyService, CredentialService } from '@core/services'
 import { ApiKey } from '@core/models'
+import { ApiNotFoundError } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -35,10 +36,7 @@ export const InitApiKeyMiddleware = (
       +apiKeyId
     )
     if (deletedRows === 0) {
-      return res.status(404).json({
-        code: 'not_found',
-        message: 'Could not find API key to delete',
-      })
+      throw new ApiNotFoundError('Could not find API key to delete')
     }
     logger.info({
       message: 'Successfully deleted api key',

--- a/backend/src/core/middlewares/file-attachment.middleware.ts
+++ b/backend/src/core/middlewares/file-attachment.middleware.ts
@@ -3,6 +3,10 @@ import fileUpload from 'express-fileupload'
 import config from '@core/config'
 import { ensureAttachmentsFieldIsArray } from '@core/utils/attachment'
 import { isDefaultFromAddress } from '@core/utils/from-address'
+import {
+  ApiAttachmentLimitError,
+  ApiAuthorizationError,
+} from '@core/errors/rest-api.errors'
 
 const FILE_ATTACHMENT_MAX_NUM = config.get('file.maxAttachmentNum')
 const FILE_ATTACHMENT_MAX_SIZE = config.get('file.maxAttachmentSize')
@@ -23,10 +27,10 @@ const fileUploadHandler = fileUpload({
     fieldSize: BODY_SIZE_LIMIT + 1,
   },
   abortOnLimit: true,
-  limitHandler: function (_: Request, res: Response) {
-    res
-      .status(413)
-      .json({ message: 'Size of one or more attachments exceeds limit' })
+  limitHandler: function (_: Request, _res: Response, _next: NextFunction) {
+    throw new ApiAttachmentLimitError(
+      'Size of one or more attachments exceeds limit'
+    )
   },
 })
 
@@ -36,7 +40,7 @@ const fileUploadHandler = fileUpload({
  */
 function preprocessPotentialIncomingFile(
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ): void {
   if (req.files?.attachments) {
@@ -48,10 +52,9 @@ function preprocessPotentialIncomingFile(
      * exceeded, instead truncates array to specified num
      */
     if (req.body.attachments.length > FILE_ATTACHMENT_MAX_NUM) {
-      res.status(413).json({
-        message: `Number of attachments exceeds limit of ${FILE_ATTACHMENT_MAX_NUM}`,
-      })
-      return
+      throw new ApiAttachmentLimitError(
+        `Number of attachments exceeds limit of ${FILE_ATTACHMENT_MAX_NUM}`
+      )
     }
   }
   next()
@@ -60,7 +63,7 @@ function preprocessPotentialIncomingFile(
 // two checks: (1) must use custom domain for attachment; (2) global attachment size limit respected
 async function checkAttachmentValidity(
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ): Promise<void> {
   // return early if no attachments
@@ -71,11 +74,9 @@ async function checkAttachmentValidity(
   // forbid user from sending attachments from default @mail.postman.gov.sg
   const { from } = req.body
   if (isDefaultFromAddress(from)) {
-    res.status(403).json({
-      message:
-        'Attachments cannot be sent from the default @mail.postman.gov.sg domain',
-    })
-    return
+    throw new ApiAuthorizationError(
+      'Attachments are not allowed for Postman default from email address'
+    )
   }
   // ensuring global attachment size limit is not exceeded
   const attachments = ensureAttachmentsFieldIsArray(req.files.attachments)
@@ -84,10 +85,9 @@ async function checkAttachmentValidity(
     0
   )
   if (totalAttachmentsSize > TOTAL_ATTACHMENT_SIZE_LIMIT) {
-    res.status(413).json({
-      message: 'Cumulative attachment size exceeds limit',
-    })
-    return
+    throw new ApiAttachmentLimitError(
+      'Cumulative attachment size exceeds limit'
+    )
   }
   next()
 }

--- a/backend/src/core/middlewares/job.middleware.ts
+++ b/backend/src/core/middlewares/job.middleware.ts
@@ -118,21 +118,16 @@ const retryCampaign = async (
 
 const cancelScheduledCampaign = async (
   req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const logMeta = { campaignId, action: 'cancelScheduledCampaign' }
-    logger.info({
-      message: 'Cancel Scheduled Campaign...',
-      logMeta,
-    })
-    await JobService.cancelJobQueues(+campaignId)
-    return res.status(200).json({ campaignId })
-  } catch (err) {
-    return next(err)
-  }
+  res: Response
+): Promise<Response> => {
+  const { campaignId } = req.params
+  const logMeta = { campaignId, action: 'cancelScheduledCampaign' }
+  logger.info({
+    message: 'Cancel Scheduled Campaign...',
+    logMeta,
+  })
+  await JobService.cancelJobQueues(+campaignId)
+  return res.status(200).json({ id: campaignId })
 }
 
 export const JobMiddleware = {

--- a/backend/src/core/middlewares/job.middleware.ts
+++ b/backend/src/core/middlewares/job.middleware.ts
@@ -1,6 +1,7 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 import { JobService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
+import { ApiInvalidTemplateError } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -11,79 +12,44 @@ const logger = loggerWithLabel(module)
  * @param res
  * @param next
  */
-const sendCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const userId = req.session?.user?.id
-    const { campaignId } = req.params
-    // also need to retrieve if its to be scheduled
-    const { rate, scheduledTiming } = req.body
-    const logMeta = { action: 'sendCampaign', campaignId }
+const sendCampaign = async (req: Request, res: Response): Promise<Response> => {
+  const userId = req.session?.user?.id
+  const { campaignId } = req.params
+  // also need to retrieve if its to be scheduled
+  const { rate, scheduledTiming } = req.body
+  const logMeta = { action: 'sendCampaign', campaignId }
 
-    // convert scheduled timing to date object
-    // if passed in then convert, if not just pass null
-    const formattedTiming = scheduledTiming ? new Date(scheduledTiming) : null
-    if (await JobService.canSendCampaign(+campaignId)) {
-      let jobIds
-      let jobCount = 0
-      if (formattedTiming) {
-        // this is a scheduled campaign, it is trying to update the existing jobs.
-        // directly update the DB, do not go into sending again.
-        // check if existing jobs exists
-        jobCount = await JobService.updateScheduledCampaign(
-          +campaignId,
-          formattedTiming
-        )
-      }
-      if (jobCount == 0) {
-        jobIds = await JobService.sendCampaign({
-          campaignId: +campaignId,
-          rate: +rate,
-          userId,
-          scheduledTiming: formattedTiming,
-        })
-      }
-      logger.info({ message: 'Sending campaign', jobIds, ...logMeta })
-      return res.status(200).json({ campaign_id: campaignId, job_id: jobIds })
+  // convert scheduled timing to date object
+  // if passed in then convert, if not just pass null
+  const formattedTiming = scheduledTiming ? new Date(scheduledTiming) : null
+  if (await JobService.canSendCampaign(+campaignId)) {
+    let jobIds
+    let jobCount = 0
+    if (formattedTiming) {
+      // this is a scheduled campaign, it is trying to update the existing jobs.
+      // directly update the DB, do not go into sending again.
+      // check if existing jobs exists
+      jobCount = await JobService.updateScheduledCampaign(
+        +campaignId,
+        formattedTiming
+      )
     }
-
-    const errorMessage =
-      'Unable to send campaign due to invalid template, recipients, missing credentials, or campaign has been forcibly halted.'
-    logger.error({ message: errorMessage, ...logMeta })
-    return res.status(400).json({
-      message: errorMessage,
-    })
-  } catch (err) {
-    return next(err)
+    if (jobCount == 0) {
+      jobIds = await JobService.sendCampaign({
+        campaignId: +campaignId,
+        rate: +rate,
+        userId,
+        scheduledTiming: formattedTiming,
+      })
+    }
+    logger.info({ message: 'Sending campaign', jobIds, ...logMeta })
+    return res.status(200).json({ campaign_id: campaignId, job_id: jobIds })
   }
-}
 
-/**
- *  Change the status of existing jobs for that campaign to STOPPED
- * @param req
- * @param res
- * @param next
- */
-const stopCampaign = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    await JobService.stopCampaign(+campaignId)
-    logger.info({
-      message: 'Stopped campaign',
-      campaignId,
-      action: 'stopCampaign',
-    })
-    return res.status(200).json({ campaign_id: campaignId })
-  } catch (err) {
-    return next(err)
-  }
+  const errorMessage =
+    'Unable to send campaign due to invalid template, recipients, missing credentials, or campaign has been forcibly halted.'
+  logger.error({ message: errorMessage, ...logMeta })
+  throw new ApiInvalidTemplateError(errorMessage)
 }
 
 /**
@@ -94,26 +60,19 @@ const stopCampaign = async (
  */
 const retryCampaign = async (
   req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    const logMeta = { campaignId, action: 'retryCampaign' }
-    if (await JobService.canSendCampaign(+campaignId)) {
-      await JobService.retryCampaign(+campaignId)
-      logger.info({ message: 'Retry campaign', ...logMeta })
-      return res.status(200).json({ campaign_id: campaignId })
-    }
-    const errorMessage =
-      'Unable to send campaign due to invalid template, recipients, missing credentials, or campaign has been forcibly halted.'
-    logger.error({ message: errorMessage, ...logMeta })
-    return res.status(400).json({
-      message: errorMessage,
-    })
-  } catch (err) {
-    return next(err)
+  res: Response
+): Promise<Response> => {
+  const { campaignId } = req.params
+  const logMeta = { campaignId, action: 'retryCampaign' }
+  if (await JobService.canSendCampaign(+campaignId)) {
+    await JobService.retryCampaign(+campaignId)
+    logger.info({ message: 'Retry campaign', ...logMeta })
+    return res.status(200).json({ campaign_id: campaignId })
   }
+  const errorMessage =
+    'Unable to send campaign due to invalid template, recipients, missing credentials, or campaign has been forcibly halted.'
+  logger.error({ message: errorMessage, ...logMeta })
+  throw new ApiInvalidTemplateError(errorMessage)
 }
 
 const cancelScheduledCampaign = async (
@@ -132,7 +91,6 @@ const cancelScheduledCampaign = async (
 
 export const JobMiddleware = {
   sendCampaign,
-  stopCampaign,
   retryCampaign,
   cancelScheduledCampaign,
 }

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -1,7 +1,10 @@
 import { Request, Response, NextFunction } from 'express'
 import { ProtectedService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
-import { ApiInvalidTemplateError } from '@core/errors/rest-api.errors'
+import {
+  ApiAuthorizationError,
+  ApiInvalidTemplateError,
+} from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -13,18 +16,15 @@ const logger = loggerWithLabel(module)
  */
 const isProtectedCampaign = async (
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
-): Promise<Response | void> => {
-  try {
-    const { campaignId } = req.params
-    if (await ProtectedService.isProtectedCampaign(+campaignId)) {
-      return next()
-    }
-    return res.sendStatus(403)
-  } catch (err) {
-    return next(err)
+): Promise<void> => {
+  const { campaignId } = req.params
+  if (await ProtectedService.isProtectedCampaign(+campaignId)) {
+    return next()
   }
+
+  throw new ApiAuthorizationError('Campaign is not a protected campaign.')
 }
 
 /**

--- a/backend/src/core/middlewares/protected.middleware.ts
+++ b/backend/src/core/middlewares/protected.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { ProtectedService } from '@core/services'
 import { loggerWithLabel } from '@core/logger'
+import { ApiInvalidTemplateError } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -35,7 +36,7 @@ const isProtectedCampaign = async (
  */
 const verifyTemplate = async (
   req: Request,
-  res: Response,
+  _res: Response,
   next: NextFunction
 ): Promise<Response | void> => {
   try {
@@ -65,7 +66,7 @@ const verifyTemplate = async (
       error: err,
       action: 'verifyTemplate',
     })
-    return res.status(400).json({ message: (err as Error).message })
+    throw new ApiInvalidTemplateError((err as Error).message)
   }
 }
 

--- a/backend/src/core/middlewares/upload.middleware.ts
+++ b/backend/src/core/middlewares/upload.middleware.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express'
 
 import { loggerWithLabel } from '@core/logger'
 import { UploadService, MultipartUploadService } from '@core/services'
+import { ApiInternalServerError } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -33,7 +34,7 @@ const uploadStartHandler = async (
       error: err,
       ...logMeta,
     })
-    return res.status(500).json({ message: 'Unable to generate presigned URL' })
+    throw new ApiInternalServerError('Unable to generate presigned URL')
   }
 }
 

--- a/backend/src/core/services/job.service.ts
+++ b/backend/src/core/services/job.service.ts
@@ -120,17 +120,6 @@ const sendCampaign = async ({
 }
 
 /**
- * @see ../backend/src/database/migrations/20210501121338-create-stop-jobs-function.js
- * @param campaignId
- */
-const stopCampaign = (campaignId: number): Promise<any> | undefined => {
-  return Campaign.sequelize?.query('SELECT stop_jobs(:campaignId);', {
-    replacements: { campaignId },
-    type: QueryTypes.SELECT,
-  })
-}
-
-/**
  * @see ../backend/src/database/migrations/20210501120857-create-retry-jobs-function.js
  * @param campaignId
  */
@@ -169,7 +158,6 @@ const cancelJobQueues = async (campaignId: number) => {
 export const JobService = {
   canSendCampaign,
   sendCampaign,
-  stopCampaign,
   retryCampaign,
   updateScheduledCampaign,
   cancelJobQueues,

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -302,10 +302,10 @@ export const InitEmailTemplateMiddleware = (
   const deleteCsvErrorHandler = async (
     req: Request,
     res: Response
-  ): Promise<Response | void> => {
+  ): Promise<Response> => {
     const { campaignId } = req.params
     await UploadService.deleteS3TempKeys(+campaignId)
-    res.status(200).json({ id: campaignId })
+    return res.status(200).json({ id: campaignId })
   }
 
   // TODO: refactor this handler with uploadCompleteHandler to share the same function

--- a/backend/src/email/middlewares/email-template.middleware.ts
+++ b/backend/src/email/middlewares/email-template.middleware.ts
@@ -226,7 +226,7 @@ export const InitEmailTemplateMiddleware = (
         filename,
       })
 
-      res.sendStatus(202)
+      res.status(202).json({ list_id: listId })
     } catch (err) {
       logger.error({
         message: 'Failed to select managed list',
@@ -240,7 +240,7 @@ export const InitEmailTemplateMiddleware = (
         InvalidRecipientError,
       ]
       if (userErrors.some((errType) => err instanceof errType)) {
-        return res.status(400).json({ message: (err as Error).message })
+        throw new ApiInvalidTemplateError((err as Error).message)
       }
       return next(err)
     }
@@ -357,7 +357,7 @@ export const InitEmailTemplateMiddleware = (
         true
       )
 
-      res.sendStatus(202)
+      res.status(202).json({ transaction_id: transactionId })
     } catch (err) {
       logger.error({
         message: 'Failed to complete upload to s3',
@@ -372,7 +372,7 @@ export const InitEmailTemplateMiddleware = (
       ]
 
       if (userErrors.some((errType) => err instanceof errType)) {
-        return res.status(400).json({ message: (err as Error).message })
+        throw new ApiInvalidTemplateError((err as Error).message)
       }
       return next(err)
     }

--- a/backend/src/email/middlewares/email.middleware.ts
+++ b/backend/src/email/middlewares/email.middleware.ts
@@ -7,7 +7,11 @@ import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { ThemeClient } from '@shared/theme'
 import { EmailMessageTransactional } from '@email/models'
-import { ApiAuthorizationError } from '@core/errors/rest-api.errors'
+import {
+  ApiAuthorizationError,
+  ApiInvalidCredentialsError,
+  ApiInvalidFromAddressError,
+} from '@core/errors/rest-api.errors'
 
 export interface EmailMiddleware {
   isEmailCampaignOwnedByUser: Handler
@@ -83,7 +87,11 @@ export const InitEmailMiddleware = (
         error: err,
         ...logMeta,
       })
-      return res.status(400).json({ message: `${(err as Error).message}` })
+      // This should be 500 instead because we're using the default email creds
+      // for all of our campaigns hence this failure is catastrophic, but we're
+      // keeping it 400 here for consistency and backward compatibility. To
+      // protect the downside, we have alerts on our email service providers
+      throw new ApiInvalidCredentialsError((err as Error).message)
     }
     return res.json({ message: 'OK' })
   }
@@ -239,9 +247,7 @@ export const InitEmailMiddleware = (
           }
         )
       }
-      return res
-        .status(400)
-        .json({ message: INVALID_FROM_ADDRESS_ERROR_MESSAGE })
+      throw new ApiInvalidFromAddressError(INVALID_FROM_ADDRESS_ERROR_MESSAGE)
     }
 
     res.locals.fromName = fromName
@@ -262,35 +268,26 @@ export const InitEmailMiddleware = (
     const { from } = req.body
     if (isDefaultFromAddress(from)) return next()
     const { fromName, fromAddress } = res.locals
-    try {
-      // can only reach here if user supplied own email
-      // if user supplied a different email, error from isFromAddressAccepted will be thrown
-      // therefore, can simply check whether own email is in the list of verified emails
-      // this is not great as the function is impure and relies on the order of middleware...
-      const exists = await CustomDomainService.existsFromAddress(fromAddress)
-      if (!exists) throw new Error(UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE)
-    } catch (err) {
+
+    // can only reach here if user supplied own email
+    // if user supplied a different email, error from isFromAddressAccepted will be thrown
+    // therefore, can simply check whether own email is in the list of verified emails
+    // this is not great as the function is impure and relies on the order of middleware...
+    const exists = await CustomDomainService.existsFromAddress(fromAddress)
+    if (!exists) {
       logger.error({
         message: UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE,
         from,
         defaultEmail: config.get('mailFrom'),
         fromName,
         fromAddress,
-        error: err,
         action: 'existsFromAddress',
       })
-      if (req.body.emailMessageTransactionalId) {
-        void EmailMessageTransactional.update(
-          {
-            errorCode: `Error 400: ${UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE}`,
-          },
-          {
-            where: { id: req.body.emailMessageTransactionalId },
-          }
-        )
-      }
-      return res.status(400).json({ message: (err as Error).message })
+      throw new ApiInvalidFromAddressError(
+        UNVERIFIED_FROM_ADDRESS_ERROR_MESSAGE
+      )
     }
+
     return next()
   }
 
@@ -319,7 +316,7 @@ export const InitEmailMiddleware = (
         error: err,
         action: 'verifyFromAddress',
       })
-      return res.status(400).json({ message: (err as Error).message })
+      throw new ApiInvalidFromAddressError((err as Error).message)
     }
     return next()
   }

--- a/backend/src/email/routes/email-campaign.routes.ts
+++ b/backend/src/email/routes/email-campaign.routes.ts
@@ -146,8 +146,6 @@ export const InitEmailCampaignRoute = (
     JobMiddleware.sendCampaign
   )
 
-  router.post('/stop', JobMiddleware.stopCampaign)
-
   router.post(
     '/retry',
     CampaignMiddleware.canEditCampaign,

--- a/backend/src/sms/middlewares/sms-stats.middleware.ts
+++ b/backend/src/sms/middlewares/sms-stats.middleware.ts
@@ -58,17 +58,12 @@ const updateAndGetStats = async (
  */
 const getDeliveredRecipients = async (
   req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<Response | void> => {
+  res: Response
+): Promise<Response> => {
   const { campaignId } = req.params
-  try {
-    res.set('Content-Type', 'application/json')
-    await SmsStatsService.getDeliveredRecipients(+campaignId, res)
-    return res.end()
-  } catch (err) {
-    next(err)
-  }
+  res.set('Content-Type', 'application/json')
+  await SmsStatsService.getDeliveredRecipients(+campaignId, res)
+  return res.end()
 }
 
 export const SmsStatsMiddleware = {

--- a/backend/src/sms/middlewares/sms-transactional.middleware.ts
+++ b/backend/src/sms/middlewares/sms-transactional.middleware.ts
@@ -18,7 +18,7 @@ import {
 } from '@shared/clients/twilio-client.class/errors'
 import {
   ApiInvalidRecipientError,
-  ApiInvalidSmsCredentialsError,
+  ApiInvalidCredentialsError,
 } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
@@ -108,7 +108,7 @@ async function sendMessage(
     }
 
     if (err instanceof AuthenticationError) {
-      throw new ApiInvalidSmsCredentialsError('Invalid Twilio credentials')
+      throw new ApiInvalidCredentialsError('Invalid Twilio credentials')
     }
 
     if (err instanceof RateLimitError) {

--- a/backend/src/sms/middlewares/sms-transactional.middleware.ts
+++ b/backend/src/sms/middlewares/sms-transactional.middleware.ts
@@ -19,6 +19,8 @@ import {
 import {
   ApiInvalidRecipientError,
   ApiInvalidCredentialsError,
+  ApiRateLimitError,
+  ApiNotFoundError,
 } from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
@@ -117,8 +119,7 @@ async function sendMessage(
         userId: req?.session?.user.id,
         label: credentials.label,
       })
-      res.sendStatus(429)
-      return
+      throw new ApiRateLimitError('Too many requests. Please try again later.')
     }
 
     next(err)
@@ -150,7 +151,7 @@ async function listMessages(req: Request, res: Response): Promise<void> {
   })
 }
 
-async function getById(req: Request, res: Response): Promise<void> {
+async function getById(req: Request, res: Response): Promise<Response> {
   const { smsId } = req.params
   const message = await SmsMessageTransactional.findOne({
     where: {
@@ -159,10 +160,9 @@ async function getById(req: Request, res: Response): Promise<void> {
     },
   })
   if (!message) {
-    res.status(404).json({ message: `Sms message with ID ${smsId} not found.` })
-    return
+    throw new ApiNotFoundError(`Sms message with ID ${smsId} not found.`)
   }
-  res.status(200).json(convertMessageModelToResponse(message))
+  return res.status(200).json(convertMessageModelToResponse(message))
 }
 
 export const SmsTransactionalMiddleware = {

--- a/backend/src/sms/middlewares/sms-transactional.middleware.ts
+++ b/backend/src/sms/middlewares/sms-transactional.middleware.ts
@@ -16,6 +16,10 @@ import {
   InvalidPhoneNumberError,
   RateLimitError,
 } from '@shared/clients/twilio-client.class/errors'
+import {
+  ApiInvalidRecipientError,
+  ApiInvalidSmsCredentialsError,
+} from '@core/errors/rest-api.errors'
 
 const logger = loggerWithLabel(module)
 
@@ -98,19 +102,13 @@ async function sendMessage(
       err instanceof InvalidPhoneNumberError ||
       err instanceof InvalidRecipientError
     ) {
-      res.status(400).json({
-        code: 'invalid_recipient',
-        message: `Phone number ${req.body.recipient} is invalid`,
-      })
-      return
+      throw new ApiInvalidRecipientError(
+        `Phone number ${req.body.recipient} is invalid`
+      )
     }
 
     if (err instanceof AuthenticationError) {
-      res.status(400).json({
-        code: 'invalid_sms_credentials',
-        message: 'Invalid Twilio credentials',
-      })
-      return
+      throw new ApiInvalidSmsCredentialsError('Invalid Twilio credentials')
     }
 
     if (err instanceof RateLimitError) {

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -5,7 +5,11 @@ import { SmsService } from '@sms/services'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
-import { ApiAuthorizationError } from '@core/errors/rest-api.errors'
+import {
+  ApiAuthorizationError,
+  ApiInvalidCredentialsError,
+  ApiNotFoundError,
+} from '@core/errors/rest-api.errors'
 
 export interface SmsMiddleware {
   getCredentialsFromBody: Handler
@@ -57,24 +61,18 @@ export const InitSmsMiddleware = (
    */
   const disabledForDemoCampaign = async (
     req: Request,
-    res: Response,
+    _res: Response,
     next: NextFunction
-  ): Promise<Response | void> => {
-    try {
-      const userId = req.session?.user?.id
-      const campaign = await SmsService.findCampaign(
-        +req.params.campaignId,
-        userId
-      )
-      if (campaign.demoMessageLimit) {
-        return res.status(400).json({
-          message: `Action not allowed for demo campaign`,
-        })
-      }
-      return next()
-    } catch (err) {
-      return next(err)
+  ): Promise<void> => {
+    const userId = req.session?.user?.id
+    const campaign = await SmsService.findCampaign(
+      +req.params.campaignId,
+      userId
+    )
+    if (campaign.demoMessageLimit) {
+      throw new ApiAuthorizationError('Action not allowed for demo campaign')
     }
+    return next()
   }
 
   /**
@@ -137,45 +135,31 @@ export const InitSmsMiddleware = (
     req: Request,
     res: Response,
     next: NextFunction
-  ): Promise<void | Response> => {
+  ): Promise<void> => {
     const { campaignId } = req.params // May be undefined if invoked from settings page
     const { label } = req.body
     const userId = req.session?.user?.id
-    const logMeta = {
-      campaignId,
-      label,
-      action: 'getCredentialsFromLabelCampaign',
-    }
-    try {
-      /* Determine if credential name can be used */
-      const campaign = campaignId
-        ? await SmsService.findCampaign(+campaignId, userId)
-        : null
-      const canUseDemoCredentials =
-        campaign?.demoMessageLimit && campaign?.demoMessageLimit > 0
-      if (!canUseDemoCredentials && label === DefaultCredentialName.SMS) {
-        throw new Error(
-          `Campaign cannot use demo credentials. ${label} is not allowed.`
-        )
-      }
-      const credentialName = canUseDemoCredentials
-        ? getDemoCredentialName(label)
-        : await getCredentialName(label, +userId)
-
-      /* Get credential from the name */
-      res.locals.credentials = await credentialService.getTwilioCredentials(
-        credentialName
+    /* Determine if credential name can be used */
+    const campaign = campaignId
+      ? await SmsService.findCampaign(+campaignId, userId)
+      : null
+    const canUseDemoCredentials =
+      campaign?.demoMessageLimit && campaign?.demoMessageLimit > 0
+    if (!canUseDemoCredentials && label === DefaultCredentialName.SMS) {
+      throw new ApiAuthorizationError(
+        `Campaign cannot use demo credentials. ${label} is not allowed.`
       )
-      res.locals.credentialName = credentialName
-      return next()
-    } catch (err) {
-      const errAsError = err as Error
-      logger.error({
-        ...logMeta,
-        message: `${errAsError.stack}`,
-      })
-      return res.status(400).json({ message: `${errAsError.message}` })
     }
+    const credentialName = canUseDemoCredentials
+      ? getDemoCredentialName(label)
+      : await getCredentialName(label, +userId)
+
+    /* Get credential from the name */
+    res.locals.credentials = await credentialService.getTwilioCredentials(
+      credentialName
+    )
+    res.locals.credentialName = credentialName
+    return next()
   }
 
   const getCredentialsFromLabelTransactional = async (
@@ -205,7 +189,7 @@ export const InitSmsMiddleware = (
         ...logMeta,
         message: `${errAsError.stack}`,
       })
-      return res.status(400).json({ message: `${errAsError.message}` })
+      throw new ApiInvalidCredentialsError(errAsError.message)
     }
   }
 
@@ -252,7 +236,7 @@ export const InitSmsMiddleware = (
         error: err,
         ...logMeta,
       })
-      return res.status(400).json({ message: `${err}` })
+      throw new ApiInvalidCredentialsError((err as Error).message)
     }
     try {
       // Store credentials in AWS secrets manager
@@ -373,9 +357,9 @@ export const InitSmsMiddleware = (
         name,
       })
       if (!campaign) {
-        return res.status(400).json({
-          message: `Unable to duplicate campaign with these parameters`,
-        })
+        throw new ApiNotFoundError(
+          `Cannot duplicate. Campaign ${campaignId} was  not found.`
+        )
       }
       logger.info({
         message: 'Successfully copied campaign',

--- a/backend/src/sms/routes/sms-campaign.routes.ts
+++ b/backend/src/sms/routes/sms-campaign.routes.ts
@@ -148,8 +148,6 @@ export const InitSmsCampaignRoute = (
     JobMiddleware.sendCampaign
   )
 
-  router.post('/stop', JobMiddleware.stopCampaign)
-
   router.post(
     '/retry',
     CampaignMiddleware.canEditCampaign,

--- a/backend/src/telegram/middlewares/telegram-stats.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram-stats.middleware.ts
@@ -12,21 +12,16 @@ const logger = loggerWithLabel(module)
  */
 const getStats = async (
   req: Request,
-  res: Response,
-  next: NextFunction
+  res: Response
 ): Promise<Response | void> => {
   const { campaignId } = req.params
-  try {
-    const stats = await TelegramStatsService.getStats(+campaignId)
-    logger.info({
-      message: 'Retreived telegram stats',
-      campaignId,
-      action: 'getStats',
-    })
-    return res.json(stats)
-  } catch (err) {
-    next(err)
-  }
+  const stats = await TelegramStatsService.getStats(+campaignId)
+  logger.info({
+    message: 'Retreived telegram stats',
+    campaignId,
+    action: 'getStats',
+  })
+  return res.json(stats)
 }
 
 /**

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -4,6 +4,7 @@ import { CredentialService } from '@core/services'
 import { TelegramService } from '@telegram/services'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
+import { ApiAuthorizationError } from '@core/errors/rest-api.errors'
 
 export interface TelegramMiddleware {
   getCredentialsFromBody: Handler
@@ -287,21 +288,19 @@ export const InitTelegramMiddleware = (
    */
   const isTelegramCampaignOwnedByUser = async (
     req: Request,
-    res: Response,
+    _res: Response,
     next: NextFunction
   ): Promise<Response | void> => {
-    try {
-      const { campaignId } = req.params
-      const userId = req.session?.user?.id
-      const campaign = await TelegramService.findCampaign(+campaignId, userId)
-      if (campaign) {
-        return next()
-      } else {
-        return res.sendStatus(403)
-      }
-    } catch (err) {
-      return next(err)
+    const { campaignId } = req.params
+    const userId = req.session?.user?.id
+    const campaign = await TelegramService.findCampaign(+campaignId, userId)
+    if (campaign) {
+      return next()
     }
+
+    throw new ApiAuthorizationError(
+      "User doesn't have access to this campaign."
+    )
   }
 
   /**

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -4,7 +4,13 @@ import { CredentialService } from '@core/services'
 import { TelegramService } from '@telegram/services'
 import { loggerWithLabel } from '@core/logger'
 import { formatDefaultCredentialName } from '@core/utils'
-import { ApiAuthorizationError } from '@core/errors/rest-api.errors'
+import {
+  ApiAuthorizationError,
+  ApiInvalidCredentialLabelError,
+  ApiInvalidCredentialsError,
+  ApiInvalidTemplateError,
+  ApiNotFoundError,
+} from '@core/errors/rest-api.errors'
 
 export interface TelegramMiddleware {
   getCredentialsFromBody: Handler
@@ -36,24 +42,18 @@ export const InitTelegramMiddleware = (
    */
   const disabledForDemoCampaign = async (
     req: Request,
-    res: Response,
+    _res: Response,
     next: NextFunction
-  ): Promise<Response | void> => {
-    try {
-      const userId = req.session?.user?.id
-      const campaign = await TelegramService.findCampaign(
-        +req.params.campaignId,
-        userId
-      )
-      if (campaign.demoMessageLimit) {
-        return res.status(400).json({
-          message: `Action disabled for demo campaign`,
-        })
-      }
-      return next()
-    } catch (err) {
-      return next(err)
+  ): Promise<void> => {
+    const userId = req.session?.user?.id
+    const campaign = await TelegramService.findCampaign(
+      +req.params.campaignId,
+      userId
+    )
+    if (campaign.demoMessageLimit) {
+      throw new ApiAuthorizationError('Action not allowed for demo campaign')
     }
+    return next()
   }
   /**
    * Parse telegram credentials from request body, setting it to res.locals.credentials to be passed downstream
@@ -117,7 +117,7 @@ export const InitTelegramMiddleware = (
     req: Request,
     res: Response,
     next: NextFunction
-  ): Promise<Response | void> => {
+  ): Promise<void> => {
     const { campaignId } = req.params // May be undefined if invoked from settings page
     const { label } = req.body
     const userId = req.session?.user?.id
@@ -147,7 +147,7 @@ export const InitTelegramMiddleware = (
         ...logMeta,
         message: `${errAsError.stack}`,
       })
-      return res.status(400).json({ message: `${errAsError.message}` })
+      throw new ApiInvalidCredentialLabelError(errAsError.message)
     }
   }
 
@@ -161,7 +161,7 @@ export const InitTelegramMiddleware = (
     req: Request,
     res: Response,
     next: NextFunction
-  ): Promise<void | Response> => {
+  ): Promise<void> => {
     const { campaignId } = req.params
     const userId = req.session?.user?.id
     const campaign = await TelegramService.findCampaign(+campaignId, userId)
@@ -174,9 +174,7 @@ export const InitTelegramMiddleware = (
         credName,
         action: 'getCampaignCredential',
       })
-      return res
-        .status(400)
-        .json({ message: 'No credentials found for this campaign.' })
+      throw new ApiNotFoundError('No credentials found for this campaign.')
     }
 
     const telegramBotToken = await credentialService.getTelegramCredential(
@@ -215,7 +213,7 @@ export const InitTelegramMiddleware = (
         error: err,
         ...logMeta,
       })
-      return res.status(400).json({ message: `${err}` })
+      throw new ApiInvalidCredentialsError((err as Error).message)
     }
 
     try {
@@ -276,7 +274,7 @@ export const InitTelegramMiddleware = (
         error: err,
         ...logMeta,
       })
-      return res.status(400).json({ message: `${(err as Error).message}` })
+      throw new ApiInvalidTemplateError((err as Error).message)
     }
   }
 
@@ -331,17 +329,12 @@ export const InitTelegramMiddleware = (
    */
   const previewFirstMessage = async (
     req: Request,
-    res: Response,
-    next: NextFunction
-  ): Promise<Response | void> => {
-    try {
-      const { campaignId } = req.params
-      return res.json({
-        preview: await TelegramService.getHydratedMessage(+campaignId),
-      })
-    } catch (err) {
-      return next(err)
-    }
+    res: Response
+  ): Promise<Response> => {
+    const { campaignId } = req.params
+    return res.json({
+      preview: await TelegramService.getHydratedMessage(+campaignId),
+    })
   }
 
   /**
@@ -352,21 +345,16 @@ export const InitTelegramMiddleware = (
    */
   const setCampaignCredential = async (
     req: Request,
-    res: Response,
-    next: NextFunction
-  ): Promise<Response | void> => {
-    try {
-      const { campaignId } = req.params
-      const { credentialName } = res.locals
-      if (!credentialName) {
-        throw new Error('Credential does not exist')
-      }
-
-      await TelegramService.setCampaignCredential(+campaignId, credentialName)
-      return res.json({ message: 'OK' })
-    } catch (err) {
-      next(err)
+    res: Response
+  ): Promise<Response> => {
+    const { campaignId } = req.params
+    const { credentialName } = res.locals
+    if (!credentialName) {
+      throw new Error('Credential does not exist')
     }
+
+    await TelegramService.setCampaignCredential(+campaignId, credentialName)
+    return res.json({ message: 'OK' })
   }
 
   /**
@@ -388,9 +376,9 @@ export const InitTelegramMiddleware = (
         name,
       })
       if (!campaign) {
-        return res.status(400).json({
-          message: `Unable to duplicate campaign with these parameters`,
-        })
+        throw new ApiNotFoundError(
+          `Cannot duplicate. Campaign ${campaignId} was not found`
+        )
       }
       logger.info({
         message: 'Successfully copied campaign',

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -150,8 +150,6 @@ export const InitTelegramCampaignMiddleware = (
     JobMiddleware.sendCampaign
   )
 
-  router.post('/stop', JobMiddleware.stopCampaign)
-
   router.post(
     '/retry',
     CampaignMiddleware.canEditCampaign,

--- a/frontend/src/components/common/progress-details/ProgressDetails.tsx
+++ b/frontend/src/components/common/progress-details/ProgressDetails.tsx
@@ -25,7 +25,6 @@ const ProgressDetails = ({
 }: {
   stats: CampaignStats
   redacted: boolean
-  handlePause: () => Promise<void>
   handleRetry: () => Promise<void>
 }) => {
   const { campaign } = useContext(CampaignContext)
@@ -63,10 +62,6 @@ const ProgressDetails = ({
       )
     }
 
-    if (!isSent) {
-      // removed pause button for the duration of this experiment to see if anyone uses it
-      return null
-    }
     if (!isComplete) {
       return (
         <PrimaryButton className={styles.retry} onClick={handleRetry}>

--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -14,7 +14,7 @@ import ScheduleDetails from 'components/common/schedule-details'
 import usePollCampaignStats from 'components/custom-hooks/use-poll-campaign-stats'
 import { CampaignContext } from 'contexts/campaign.context'
 
-import { retryCampaign, stopCampaign } from 'services/campaign.service'
+import { retryCampaign } from 'services/campaign.service'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 
 const EmailDetail = () => {
@@ -23,16 +23,6 @@ const EmailDetail = () => {
   const { stats, refreshCampaignStats } = usePollCampaignStats()
 
   const emailCampaign = campaign as EmailCampaign
-
-  async function handlePause() {
-    try {
-      sendUserEvent(GA_USER_EVENTS.PAUSE_SENDING, ChannelType.Email)
-      await stopCampaign(id)
-      await refreshCampaignStats()
-    } catch (err) {
-      console.error(err)
-    }
-  }
 
   async function handleRetry() {
     try {
@@ -107,7 +97,6 @@ const EmailDetail = () => {
           <ProgressDetails
             stats={stats}
             redacted={campaign.redacted}
-            handlePause={handlePause}
             handleRetry={handleRetry}
           />
         )}

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -10,7 +10,7 @@ import CompletedDemoModal from 'components/dashboard/demo/completed-demo-modal'
 import { CampaignContext } from 'contexts/campaign.context'
 import { ModalContext } from 'contexts/modal.context'
 
-import { retryCampaign, stopCampaign } from 'services/campaign.service'
+import { retryCampaign } from 'services/campaign.service'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 
 const SMSDetail = () => {
@@ -19,16 +19,6 @@ const SMSDetail = () => {
   const { id, demoMessageLimit } = campaign
   const isDemo = !!demoMessageLimit
   const { stats, refreshCampaignStats } = usePollCampaignStats()
-
-  async function handlePause() {
-    try {
-      sendUserEvent(GA_USER_EVENTS.PAUSE_SENDING, ChannelType.SMS)
-      await stopCampaign(id)
-      await refreshCampaignStats()
-    } catch (err) {
-      console.error(err)
-    }
-  }
 
   async function handleRetry() {
     try {
@@ -109,7 +99,6 @@ const SMSDetail = () => {
           <ProgressDetails
             stats={stats}
             redacted={campaign.redacted}
-            handlePause={handlePause}
             handleRetry={handleRetry}
           />
         )}

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -9,7 +9,7 @@ import CompletedDemoModal from 'components/dashboard/demo/completed-demo-modal'
 import { CampaignContext } from 'contexts/campaign.context'
 import { ModalContext } from 'contexts/modal.context'
 
-import { retryCampaign, stopCampaign } from 'services/campaign.service'
+import { retryCampaign } from 'services/campaign.service'
 import { GA_USER_EVENTS, sendUserEvent } from 'services/ga.service'
 
 const TelegramDetail = () => {
@@ -18,16 +18,6 @@ const TelegramDetail = () => {
   const { id, demoMessageLimit } = campaign
   const isDemo = !!demoMessageLimit
   const { stats, refreshCampaignStats } = usePollCampaignStats()
-
-  async function handlePause() {
-    try {
-      sendUserEvent(GA_USER_EVENTS.PAUSE_SENDING, ChannelType.Telegram)
-      await stopCampaign(id)
-      await refreshCampaignStats()
-    } catch (err) {
-      console.error(err)
-    }
-  }
 
   async function handleRetry() {
     try {
@@ -108,7 +98,6 @@ const TelegramDetail = () => {
           <ProgressDetails
             stats={stats}
             redacted={campaign.redacted}
-            handlePause={handlePause}
             handleRetry={handleRetry}
           />
         )}

--- a/frontend/src/services/campaign.service.ts
+++ b/frontend/src/services/campaign.service.ts
@@ -188,10 +188,6 @@ export async function sendCampaign(
   await axios.post(`/campaign/${campaignId}/send`, body)
 }
 
-export async function stopCampaign(campaignId: number): Promise<void> {
-  await axios.post(`/campaign/${campaignId}/stop`)
-}
-
 export async function retryCampaign(campaignId: number): Promise<void> {
   await axios.post(`/campaign/${campaignId}/retry`)
 }


### PR DESCRIPTION
## Problem

Related to [this epic](https://www.notion.so/opengov/API-Response-Formats-5174d66bf5ce49a1b3d161630869eb65). As we're introducing consistency in the error format, it's good to standardise how these errors are produced in the code as well.

## Solution

Consolidate our REST API errors to inherit from a common type that can be easily handled with an express error middleware that transforms these errors in to the standardised format json error object.

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A