### PR TITLE
hotfix: priotise showing reschedule header for scheduled campaigns

### DIFF
--- a/frontend/src/components/dashboard/create/email/EmailDetail.tsx
+++ b/frontend/src/components/dashboard/create/email/EmailDetail.tsx
@@ -45,7 +45,14 @@ const EmailDetail = () => {
   }
 
   function renderProgressHeader() {
-    if (stats.waitTime && stats.waitTime > 0) {
+    if (campaign.status === Status.Scheduled) {
+      return (
+        <CampaignScheduledInfo
+          campaign={campaign}
+          updateCampaign={updateCampaign}
+        />
+      )
+    } else if (stats.waitTime && stats.waitTime > 0) {
       const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <StepHeader title="Other campaigns are queued ahead of this campaign.">
@@ -66,13 +73,6 @@ const EmailDetail = () => {
             the Campaigns tab.
           </p>
         </StepHeader>
-      )
-    } else if (campaign.status === Status.Scheduled) {
-      return (
-        <CampaignScheduledInfo
-          campaign={campaign}
-          updateCampaign={updateCampaign}
-        />
       )
     } else {
       return (

--- a/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSDetail.tsx
@@ -53,7 +53,14 @@ const SMSDetail = () => {
   }, [isDemo, setModalContent, stats.status])
 
   function renderProgressHeader() {
-    if (stats.waitTime && stats.waitTime > 0) {
+    if (campaign.status === Status.Scheduled) {
+      return (
+        <CampaignScheduledInfo
+          campaign={campaign}
+          updateCampaign={updateCampaign}
+        />
+      )
+    } else if (stats.waitTime && stats.waitTime > 0) {
       const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <StepHeader title="Other campaigns are queued ahead of this campaign.">
@@ -74,13 +81,6 @@ const SMSDetail = () => {
             the Campaigns tab.
           </p>
         </StepHeader>
-      )
-    } else if (campaign.status === Status.Scheduled) {
-      return (
-        <CampaignScheduledInfo
-          campaign={campaign}
-          updateCampaign={updateCampaign}
-        />
       )
     } else {
       return (

--- a/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramDetail.tsx
@@ -52,7 +52,14 @@ const TelegramDetail = () => {
   }, [isDemo, setModalContent, stats.status])
 
   function renderProgressHeader() {
-    if (stats.waitTime && stats.waitTime > 0) {
+    if (campaign.status === Status.Scheduled) {
+      return (
+        <CampaignScheduledInfo
+          campaign={campaign}
+          updateCampaign={updateCampaign}
+        />
+      )
+    } else if (stats.waitTime && stats.waitTime > 0) {
       const waitMin = Math.ceil(stats.waitTime / 60)
       return (
         <StepHeader title="Other campaigns are queued ahead of this campaign.">
@@ -73,13 +80,6 @@ const TelegramDetail = () => {
             the Campaigns tab.
           </p>
         </StepHeader>
-      )
-    } else if (campaign.status === Status.Scheduled) {
-      return (
-        <CampaignScheduledInfo
-          campaign={campaign}
-          updateCampaign={updateCampaign}
-        />
       )
     } else {
       return (


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/Incorrect-waitTime-estimation-for-scheduled-campaign-89b5ff2d44bd4f7bb3433c81601d2588?pvs=4)

This solution simply moves the check for schedule sending up top, as scheduled messages do not directly 'join the sending queue', so the wait time logic is not applicable to scheduled campaigns. 

Another uglier solution considered was to change the wait time conditional to `campaign.status !== Status.Scheduled && stats.waitTime && stats.waitTime > 0`.