### PR TITLE
feat: new attachment limits setup

### DIFF
--- a/backend/.platform/nginx/conf.d/client_max_body_size.conf
+++ b/backend/.platform/nginx/conf.d/client_max_body_size.conf
@@ -1,1 +1,1 @@
-client_max_body_size    10M;
+client_max_body_size    11M;

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1854,7 +1854,14 @@ paths:
             text/plain:
               example: Unauthorized
         '403':
-          description: Forbidden. Request violates firewall rules.
+          description: Forbidden. Request comes from an invalid `from` address, violates firewall rules.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                FromError:
+                  value: { message:  Attachments cannot be sent from the default @mail.postman.gov.sg domain }
         '413':
           description: Number of attachments or size of attachments exceeded limit.
           content:
@@ -1865,7 +1872,9 @@ paths:
                 AttachmentQtyLimit:
                   value: { message: Number of attachments exceeds limit }
                 AttachmentSizeLimit:
-                  value: { message: Size of attachments exceeds limit }
+                  value: { message: Size of one or more attachments exceeds limit }
+                CumulativeAttachmentSizeLimit:
+                  value: { message: Cumulative attachment size exceeds limit }
         '429':
           description: Rate limit exceeded. Too many requests.
           content:

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -152,6 +152,7 @@ interface ConfigSchema {
   file: {
     maxAttachmentSize: number
     maxAttachmentNum: number
+    maxCumulativeAttachmentsSize: number
   }
 }
 
@@ -685,8 +686,14 @@ const config: Config<ConfigSchema> = convict({
     },
     maxAttachmentNum: {
       doc: 'Maximum number of file attachments',
-      default: 5,
+      default: 10,
       env: 'FILE_ATTACHMENT_MAX_NUM',
+      format: Number,
+    },
+    maxCumulativeAttachmentsSize: {
+      doc: 'Maximum cumulative size of all file attachments in bytes',
+      default: 10 * 1024 * 1024,
+      env: 'FILE_ATTACHMENT_MAX_CUMULATIVE_SIZE',
       format: Number,
     },
   },

--- a/backend/src/core/middlewares/file-attachment.middleware.ts
+++ b/backend/src/core/middlewares/file-attachment.middleware.ts
@@ -3,7 +3,6 @@ import fileUpload from 'express-fileupload'
 import config from '@core/config'
 import { ensureAttachmentsFieldIsArray } from '@core/utils/attachment'
 import { isDefaultFromAddress } from '@core/utils/from-address'
-import bytes from 'bytes'
 
 const FILE_ATTACHMENT_MAX_NUM = config.get('file.maxAttachmentNum')
 const FILE_ATTACHMENT_MAX_SIZE = config.get('file.maxAttachmentSize')
@@ -25,7 +24,9 @@ const fileUploadHandler = fileUpload({
   },
   abortOnLimit: true,
   limitHandler: function (_: Request, res: Response) {
-    res.status(413).json({ message: 'Size of attachments exceeds limit' })
+    res
+      .status(413)
+      .json({ message: 'Size of one or more attachments exceeds limit' })
   },
 })
 
@@ -82,12 +83,9 @@ async function checkAttachmentValidity(
     (acc, attachment) => acc + attachment.size,
     0
   )
-  const totalAttachmentsSizeLimit = `${bytes.format(
-    TOTAL_ATTACHMENT_SIZE_LIMIT
-  )}`
   if (totalAttachmentsSize > TOTAL_ATTACHMENT_SIZE_LIMIT) {
     res.status(413).json({
-      message: `Cumulative attachment size exceeds limit of ${totalAttachmentsSizeLimit}`,
+      message: 'Cumulative attachment size exceeds limit',
     })
     return
   }

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -92,7 +92,7 @@ export const InitEmailTransactionalRoute = (
     FileAttachmentMiddleware.fileUploadHandler,
     FileAttachmentMiddleware.preprocessPotentialIncomingFile,
     celebrate(sendValidator),
-    FileAttachmentMiddleware.checkAttachmentPermission,
+    FileAttachmentMiddleware.checkAttachmentValidity,
     emailTransactionalMiddleware.saveMessage,
     emailMiddleware.isFromAddressAccepted,
     emailMiddleware.existsFromAddress, // future todo: put a cache to reduce db hits

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -645,6 +645,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
       email: user.email,
       name: 'Agency ABC',
     } as EmailFromAddress)
+    const onepointnineMbAttachment = generateRandomFileSizeInMb(1.9)
 
     const res = await request(app)
       .post(endpoint)
@@ -654,12 +655,12 @@ describe(`${emailTransactionalRoute}/send`, () => {
       .field('body', validApiCallAttachment.body)
       .field('from', validApiCallAttachment.from)
       .field('reply_to', validApiCallAttachment.reply_to)
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment1')
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment2')
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment3')
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment4')
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment5')
-      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment6')
+      .attach('attachments', onepointnineMbAttachment, 'attachment1')
+      .attach('attachments', onepointnineMbAttachment, 'attachment2')
+      .attach('attachments', onepointnineMbAttachment, 'attachment3')
+      .attach('attachments', onepointnineMbAttachment, 'attachment4')
+      .attach('attachments', onepointnineMbAttachment, 'attachment5')
+      .attach('attachments', onepointnineMbAttachment, 'attachment6')
 
     expect(res.status).toBe(413)
     expect(mockSendEmail).not.toBeCalled()

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -73,13 +73,21 @@ describe(`${emailTransactionalRoute}/send`, () => {
     from: 'Postman <donotreply@mail.postman.gov.sg>',
     reply_to: 'user@agency.gov.sg',
   }
+  const generateRandomSmallFile = () => {
+    const randomFile = Buffer.from(Math.random().toString(36).substring(2))
+    return randomFile
+  }
+  const generateRandomFileSizeInMb = (sizeInMb: number) => {
+    const randomFile = Buffer.alloc(sizeInMb * 1024 * 1024, '.')
+    return randomFile
+  }
 
   // attachment only allowed when sent from user's own email
   const validApiCallAttachment = {
     ...validApiCall,
     from: `User <${userEmail}>`,
   }
-  const validAttachment = Buffer.from('hello world')
+  const validAttachment = generateRandomSmallFile()
   const validAttachmentName = 'hi.txt'
   const validAttachmentHashRegex = /^[a-f0-9]{32}$/ // MD5 32 characters
   const validAttachmentSize = Buffer.byteLength(validAttachment)
@@ -445,7 +453,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
   test('Should throw an error if file type of attachment is not supported and correct error is saved in db', async () => {
     mockSendEmail = jest.spyOn(EmailService, 'sendEmail')
     // not actually an invalid file type; FileExtensionService checks magic number
-    const invalidFileTypeAttachment = Buffer.alloc(1024 * 1024, '.')
+    const invalidFileTypeAttachment = generateRandomFileSizeInMb(1)
     const invalidFileTypeAttachmentName = 'invalid.exe'
     // instead, we just mock the service to return false
     const mockFileTypeCheck = jest
@@ -603,9 +611,9 @@ describe(`${emailTransactionalRoute}/send`, () => {
     ])
   })
 
-  test('Email with attachment that exceeds limit should fail', async () => {
+  test('Email with attachment that exceeds size limit should fail', async () => {
     mockSendEmail = jest.spyOn(EmailService, 'sendEmail')
-    const invalidAttachmentTooBig = Buffer.alloc(1024 * 1024 * 10, '.') // 10MB
+    const invalidAttachmentTooBig = generateRandomFileSizeInMb(10)
     const invalidAttachmentTooBigName = 'too big.txt'
 
     await EmailFromAddress.create({
@@ -631,6 +639,32 @@ describe(`${emailTransactionalRoute}/send`, () => {
     expect(mockSendEmail).not.toBeCalled()
     // no need to check EmailMessageTransactional since this is rejected before db record is saved
   })
+  test('Email with more than 10MB cumulative attachments should fail', async () => {
+    mockSendEmail = jest.spyOn(EmailService, 'sendEmail')
+    await EmailFromAddress.create({
+      email: user.email,
+      name: 'Agency ABC',
+    } as EmailFromAddress)
+
+    const res = await request(app)
+      .post(endpoint)
+      .set('Authorization', `Bearer ${apiKey}`)
+      .field('recipient', validApiCallAttachment.recipient)
+      .field('subject', validApiCallAttachment.subject)
+      .field('body', validApiCallAttachment.body)
+      .field('from', validApiCallAttachment.from)
+      .field('reply_to', validApiCallAttachment.reply_to)
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment1')
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment2')
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment3')
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment4')
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment5')
+      .attach('attachments', generateRandomFileSizeInMb(2), 'attachment6')
+
+    expect(res.status).toBe(413)
+    expect(mockSendEmail).not.toBeCalled()
+    // no need to check EmailMessageTransactional since this is rejected before db record is saved
+  })
 
   test('Should send email with two valid attachments and metadata is saved correctly in db', async () => {
     mockSendEmail = jest
@@ -642,7 +676,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
       name: 'Agency ABC',
     } as EmailFromAddress)
 
-    const validAttachment2 = Buffer.from('wassup dog')
+    const validAttachment2 = generateRandomSmallFile()
     const validAttachment2Name = 'hey.txt'
     const validAttachment2Size = Buffer.byteLength(validAttachment2)
 
@@ -716,25 +750,13 @@ describe(`${emailTransactionalRoute}/send`, () => {
     ])
   })
 
-  test('Email with more than five attachments should fail', async () => {
+  test('Email with more than ten attachments should fail', async () => {
     mockSendEmail = jest.spyOn(EmailService, 'sendEmail')
     await EmailFromAddress.create({
       email: user.email,
       name: 'Agency ABC',
     } as EmailFromAddress)
 
-    // at time of writing this test default value of FILE_ATTACHMENT_MAX_NUM is 5
-    // not sure how to create a variable number of attachments + API call (probably not possible?)
-    const attachment2 = Buffer.from('wassup dog')
-    const attachment2Name = 'hey.txt'
-    const attachment3 = Buffer.from('wassup pal')
-    const attachment3Name = 'hi there.txt'
-    const attachment4 = Buffer.from('hello there')
-    const attachment4Name = 'hello friends.txt'
-    const attachment5 = Buffer.from('hello there')
-    const attachment5Name = 'hello friends.txt'
-    const attachment6 = Buffer.from('hello there')
-    const attachment6Name = 'hello friends.txt'
     const res = await request(app)
       .post(endpoint)
       .set('Authorization', `Bearer ${apiKey}`)
@@ -744,11 +766,16 @@ describe(`${emailTransactionalRoute}/send`, () => {
       .field('from', validApiCallAttachment.from)
       .field('reply_to', validApiCallAttachment.reply_to)
       .attach('attachments', validAttachment, validAttachmentName)
-      .attach('attachments', attachment2, attachment2Name)
-      .attach('attachments', attachment3, attachment3Name)
-      .attach('attachments', attachment4, attachment4Name)
-      .attach('attachments', attachment5, attachment5Name)
-      .attach('attachments', attachment6, attachment6Name)
+      .attach('attachments', generateRandomSmallFile(), 'attachment2')
+      .attach('attachments', generateRandomSmallFile(), 'attachment3')
+      .attach('attachments', generateRandomSmallFile(), 'attachment4')
+      .attach('attachments', generateRandomSmallFile(), 'attachment5')
+      .attach('attachments', generateRandomSmallFile(), 'attachment6')
+      .attach('attachments', generateRandomSmallFile(), 'attachment7')
+      .attach('attachments', generateRandomSmallFile(), 'attachment8')
+      .attach('attachments', generateRandomSmallFile(), 'attachment9')
+      .attach('attachments', generateRandomSmallFile(), 'attachment10')
+      .attach('attachments', generateRandomSmallFile(), 'attachment11')
 
     expect(res.status).toBe(413)
     expect(mockSendEmail).not.toBeCalled()


### PR DESCRIPTION
[Ticket](https://www.notion.so/opengov/Coordinate-change-in-attachment-number-and-attachment-size-13ba040a5f5942b38f8219867e96a6bc)

In this PR:
- Increase number of attachments to 10 (from 5)
- Set a global file attachment limit to 10MB
- Increase Beanstalk's nginx `client_max_body_size` to 11MB (this makes sense since max body size is 1MB + 10MB of attachments → in practice, unlikely to hit this precise limit, user will see our custom error message instead)

- [x] Test on staging
- [x] Update `openapi.yaml`