### PR TITLE
build(ci): update deprecated GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - run: npm ci --ignore-scripts
@@ -52,9 +52,9 @@ jobs:
         working-directory: ./backend
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 
@@ -77,9 +77,9 @@ jobs:
         working-directory: ./shared
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - run: npm ci
@@ -94,9 +94,9 @@ jobs:
         working-directory: ./worker
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 
@@ -117,9 +117,9 @@ jobs:
         working-directory: ./frontend
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
 

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -171,7 +171,7 @@ jobs:
           CURRENT_VERSION_LABEL=$(aws elasticbeanstalk describe-environments --application-name $APP_NAME --environment-names $EB_ENV_NAME --max-items 1 | jq .Environments[0].VersionLabel)
           echo "revert_cmd=aws elasticbeanstalk update-environment --application-name $APP_NAME --environment-name $EB_ENV_NAME --version-label $CURRENT_VERSION_LABEL" >> $GITHUB_OUTPUT
       - name: Deploy to EB
-        uses: einaregilsson/beanstalk-deploy@v20
+        uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -204,7 +204,7 @@ jobs:
           CURRENT_VERSION_LABEL=$(aws elasticbeanstalk describe-environments --application-name $APP_NAME --environment-names $EB_ENV_NAME --max-items 1 | jq .Environments[0].VersionLabel)
           echo "revert_cmd=aws elasticbeanstalk update-environment --application-name $APP_NAME --environment-name $EB_ENV_NAME --version-label $CURRENT_VERSION_LABEL" >> $GITHUB_OUTPUT
       - name: Deploy to EB
-        uses: einaregilsson/beanstalk-deploy@v20
+        uses: einaregilsson/beanstalk-deploy@v21
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -50,9 +50,9 @@ jobs:
         options: --entrypoint redis-server
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: cd $DIRECTORY && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Lint and test app code
@@ -80,9 +80,9 @@ jobs:
       image_tag: ${{ steps.set-image-tag.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version-file: .nvmrc
       - name: Before deploy
         env:
           SECRET_ID: ${{ vars.SECRET_ID }}
@@ -119,7 +119,7 @@ jobs:
       - name: Create and push EB config files
         run: |
           sed -i -e "s|@TAG|$IMAGE_TAG|g" Dockerrun.aws.json
-          sed -i -e "s|@REPO|$ECR_REPOSITORY|g" Dockerrun.aws.json 
+          sed -i -e "s|@REPO|$ECR_REPOSITORY|g" Dockerrun.aws.json
           zip -r "$IMAGE_TAG.zip" .ebextensions .platform Dockerrun.aws.json
         working-directory: ${{ env.DIRECTORY }}
         env:

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -94,7 +94,7 @@ jobs:
           sed -i -e "s#@DD_API_KEY#$DD_API_KEY#g" .ebextensions/99datadog.config
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version-file: .nvmrc
       - name: Lint lock file
         run: cd $DIRECTORY && npx lockfile-lint --type npm --path package-lock.json -o "https:" -o "file:" --allowed-hosts npm
       - name: Lint app code
@@ -58,9 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version-file: .nvmrc
       - name: Build shared package
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -74,7 +74,7 @@ jobs:
           cp -R ../shared ./
           sed -i -e "s#@SECRET_ID#$SECRET_ID#g" docker-entrypoint.sh
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -22,9 +22,9 @@ jobs:
         run: |
           echo "Running on branch ${{ github.ref }}"
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            echo "::set-output name=current_env::production"
+            echo "current_env=production" >> $GITHUB_OUTPUT
           else
-             echo "::set-output name=current_env::staging"
+            echo "current_env=staging" >> $GITHUB_OUTPUT
           fi
 
   lint-test:
@@ -57,7 +57,7 @@ jobs:
           aws-region: "${{ vars.AWS_DEFAULT_REGION }}"
       - name: Set function name according to environment
         id: function-name
-        run: echo "::set-output name=value::$FUNCTION-${{ needs.set_environment.outputs.current_env }}"
+        run: echo "value=$FUNCTION-${{ needs.set_environment.outputs.current_env }}" >> $GITHUB_OUTPUT
       - name: Build
         id: build-lambda
         env:
@@ -68,7 +68,7 @@ jobs:
           npm run build
           npm prune --production
           sudo zip -qr "$ZIP_FILE" build package.json node_modules/
-          echo "::set-output name=zip_path::$DIRECTORY/$ZIP_FILE"
+          echo "zip_path=$DIRECTORY/$ZIP_FILE" >> $GITHUB_OUTPUT
 
       - name: Check if lambda can be updated (1)
         run: |

--- a/.github/workflows/deploy.serverless.eb-env-update.yml
+++ b/.github/workflows/deploy.serverless.eb-env-update.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: "16"
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: "${{ secrets.AWS_ACCESS_KEY_ID }}"
           aws-secret-access-key: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
@@ -64,7 +64,7 @@ jobs:
           ZIP_FILE: code.zip
         run: |
           cd "$DIRECTORY"
-          npm ci 
+          npm ci
           npm run build
           npm prune --production
           sudo zip -qr "$ZIP_FILE" build package.json node_modules/

--- a/.github/workflows/non-serverless-deploy.yml
+++ b/.github/workflows/non-serverless-deploy.yml
@@ -112,7 +112,7 @@ jobs:
     if: always()
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Get rid of warnings in GitHub Actions. 
For more info on changes made:
- `setup-node`, `einaregilsson/beanstalk-deploy` and `configure-aws-credential`: [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12)
- [`set-output`](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Did not update:
- Lambda functions because they will be refactored away
- `db-migration.yml` workflow (not sure about the status, doesn't seem to be in use) @stanleynguyen 
- Warnings from ECS task definitions
  - If I understand the setup properly, our GitHub Actions are pulling the task definitions from ECS and then using to deploy the new image
  - However, in doing so, it is actually pulling fields that are strictly not necessary and are ignored by the CI, such as `compatibilities`, `taskDefinitionArn`, `requiresAttributes`, `revision`, `status`, `registeredAt`
  - In theory, we could modify the bash command to remove these fields, but it seems more effort than it's worth, so I'm gonna ignore this for now

- [x] Test on staging
