### PR TITLE
change 'government' to 'Government' in email template

### DIFF
--- a/frontend/src/components/common/export-recipients/ExportRecipients.tsx
+++ b/frontend/src/components/common/export-recipients/ExportRecipients.tsx
@@ -87,7 +87,7 @@ const ExportRecipients = ({
       const exportedAt = moment().format('LLL').replace(',', '')
       const explanation =
         `"Exported ${exportedAt}. Reports are updated as and when Postman receives new notifications about message status."\n` +
-        `"'Read' status may not show up accurately for corporate and Singapore government recipients due to email filtering policies."\n\n`
+        `"'Read' status may not show up accurately for corporate and Singapore Government recipients due to email filtering policies."\n\n`
 
       let content = [explanation]
 

--- a/shared/src/theme/email-theme.mustache
+++ b/shared/src/theme/email-theme.mustache
@@ -176,7 +176,7 @@
             <img width="16" height="16" style="width: 16px;height: 16px; vertical-align: middle; margin-right: 6px" src="https://file.go.gov.sg/masthead-lion.png" alt="Masthead Lion Symbol" >
           </td>
           <td>
-            <span style="vertical-align:middle;line-height:16px">Singapore government emails are sent from .gov.sg addresses</span>
+            <span style="vertical-align:middle;line-height:16px">Singapore Government emails are sent from .gov.sg addresses</span>
           </td>
         </tbody></table>
     <!--[if false]><!-->


### PR DESCRIPTION
## Problem

The standard "A Singapore Government Agency Website" banner at the top of usual Govt websites has Government with a capital G. 

## Solution

Changed "government" to "Government" for consistency. Looks more legitimate too. 

## Deployment Checklist

Nil
