### PR TITLE
docs: serve openapi.yaml statically

### DIFF
--- a/backend/src/core/loaders/swagger.loader.ts
+++ b/backend/src/core/loaders/swagger.loader.ts
@@ -1,4 +1,5 @@
 import express, { Application, Request, Response, NextFunction } from 'express'
+import cors from 'cors'
 import path from 'path'
 import swaggerUi from 'swagger-ui-express'
 import YAML from 'yamljs'
@@ -36,6 +37,10 @@ const swaggerLoader = ({ app }: { app: Application }): void => {
   )
   app.use(
     '/openapi.yaml',
+    cors({
+      origin: '*',
+      methods: ['GET'],
+    }),
     express.static(path.resolve(__dirname, '../../../openapi.yaml'))
   )
   logger.info({

--- a/backend/src/core/loaders/swagger.loader.ts
+++ b/backend/src/core/loaders/swagger.loader.ts
@@ -1,4 +1,4 @@
-import { Application, Request, Response, NextFunction } from 'express'
+import express, { Application, Request, Response, NextFunction } from 'express'
 import path from 'path'
 import swaggerUi from 'swagger-ui-express'
 import YAML from 'yamljs'
@@ -33,6 +33,10 @@ const swaggerLoader = ({ app }: { app: Application }): void => {
     removeCspHeader,
     swaggerUi.serve,
     swaggerUi.setup(swaggerDocument, swaggerUiOptions)
+  )
+  app.use(
+    '/openapi.yaml',
+    express.static(path.resolve(__dirname, '../../../openapi.yaml'))
   )
   logger.info({
     message: 'Swagger docs generated.',


### PR DESCRIPTION
## Problem

I want to expose the `openapi.yaml` file directly so that I can read it directly from the GitBook guide and expose the API methods.

See screenshot for more info:

<img width="940" alt="image" src="https://user-images.githubusercontent.com/67887489/236441764-6daee470-d122-40e5-bc89-bbfd2333dce7.png">

Currently, the domain is wrong

## Solution

Serve the file statically by adding another loader in Express

UPDATE: not sure why, GitBook is able to [pick this up](https://raw.githubusercontent.com/opengovsg/postmangovsg/master/backend/openapi.yaml), but [not this](https://api-staging.postman.gov.sg/openapi.yaml). Going to open a customer support ticket with GitBook

UPDATE 2: turns out to be a CORS issue, have fixed with the second commit.

## Deployment Checklist
- [x] Test in staging (CI/CD failed due to flaky frontend test, can ignore. served successfully [here](https://api-staging.postman.gov.sg/openapi.yaml))