### PR TITLE
fix: handle RateLimitError on tx SMS endpoint properly

### DIFF
--- a/backend/src/core/errors/transactional.errors.ts
+++ b/backend/src/core/errors/transactional.errors.ts
@@ -1,11 +1,3 @@
-export class RateLimitError extends Error {
-  constructor(message = 'Too Many Requests') {
-    super(message)
-    Object.setPrototypeOf(this, new.target.prototype) // Restore prototype chain
-    Error.captureStackTrace(this)
-  }
-}
-
 export const EMPTY_SANITIZED_EMAIL =
   'Email subject and/or body empty after removing invalid HTML tags'
 

--- a/backend/src/sms/middlewares/sms-transactional.middleware.ts
+++ b/backend/src/sms/middlewares/sms-transactional.middleware.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import { SmsTransactionalService } from '@sms/services'
 import { loggerWithLabel } from '@core/logger'
-import { InvalidRecipientError, RateLimitError } from '@core/errors'
+import { InvalidRecipientError } from '@core/errors'
 import {
   SmsMessageTransactional,
   TransactionalSmsMessageStatus,
@@ -14,6 +14,7 @@ import {
 import {
   AuthenticationError,
   InvalidPhoneNumberError,
+  RateLimitError,
 } from '@shared/clients/twilio-client.class/errors'
 
 const logger = loggerWithLabel(module)

--- a/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
+++ b/backend/src/sms/routes/tests/sms-transactional.routes.test.ts
@@ -3,7 +3,7 @@ import { Sequelize } from 'sequelize-typescript'
 
 import { Credential, User, UserCredential } from '@core/models'
 import { ChannelType } from '@core/constants'
-import { InvalidRecipientError, RateLimitError } from '@core/errors'
+import { InvalidRecipientError } from '@core/errors'
 import { SmsService } from '@sms/services'
 
 import { mockSecretsManager } from '@mocks/aws-sdk'
@@ -11,6 +11,7 @@ import initialiseServer from '@test-utils/server'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { SmsMessageTransactional } from '@sms/models'
 import { CredentialService } from '@core/services'
+import { RateLimitError } from '@shared/clients/twilio-client.class/errors'
 
 const TEST_TWILIO_CREDENTIALS = {
   accountSid: '',

--- a/shared/src/clients/twilio-client.class/errors.ts
+++ b/shared/src/clients/twilio-client.class/errors.ts
@@ -9,3 +9,9 @@ export class InvalidPhoneNumberError extends Error {
     super(message)
   }
 }
+
+export class RateLimitError extends Error {
+  constructor(message = 'Too Many Requests') {
+    super(message)
+  }
+}

--- a/shared/src/clients/twilio-client.class/index.ts
+++ b/shared/src/clients/twilio-client.class/index.ts
@@ -1,7 +1,11 @@
 import { MessageCountryPricing, TwilioCredentials } from './interfaces'
 import twilio from 'twilio'
 import { getSha256Hash } from '../../utils/crypto'
-import { AuthenticationError, InvalidPhoneNumberError } from './errors'
+import {
+  AuthenticationError,
+  InvalidPhoneNumberError,
+  RateLimitError,
+} from './errors'
 
 export * from './interfaces'
 
@@ -64,6 +68,9 @@ export default class TwilioClient {
         }
         if (/Authenticate/i.test(error.message)) {
           return Promise.reject(new AuthenticationError(error.message))
+        }
+        if (/Too Many Requests/i.test(error.message)) {
+          return Promise.reject(new RateLimitError())
         }
         return Promise.reject(new Error(error.message))
       })


### PR DESCRIPTION
[Incident on Sentry](https://open-government-products-re.sentry.io/issues/4032341530/)

Fix: throw 429 error when rate limit is hit