### PR TITLE
fix(backend): account for timezone in insert_jobs function

### DIFF
--- a/backend/src/database/migrations/20230512043333-fix-insert-jobs-scheduled-timezone.js
+++ b/backend/src/database/migrations/20230512043333-fix-insert-jobs-scheduled-timezone.js
@@ -14,7 +14,7 @@ module.exports = {
       'plpgsql',
       `
 INSERT INTO job_queue ("campaign_id", "send_rate", "status", "created_at", "updated_at", "visible_at")
-VALUES (selected_campaign_id, selected_send_rate, 'READY', clock_timestamp(), clock_timestamp(), scheduled_timing::timestamp)
+VALUES (selected_campaign_id, selected_send_rate, 'READY', clock_timestamp(), clock_timestamp(), scheduled_timing::timestamptz)
 RETURNING id INTO selected_job_id;
 `,
       [],
@@ -30,13 +30,14 @@ RETURNING id INTO selected_job_id;
       [
         { type: 'integer', name: 'selected_campaign_id' },
         { type: 'integer', name: 'selected_send_rate' },
+        { type: Sequelize.DataTypes.STRING(255), name: 'scheduled_timing' },
         { type: 'integer', direction: 'OUT', name: 'selected_job_id' },
       ],
       'integer',
       'plpgsql',
       `
-INSERT INTO job_queue ("campaign_id", "send_rate", "status", "created_at", "updated_at")
-VALUES (selected_campaign_id, selected_send_rate, 'READY', clock_timestamp(), clock_timestamp())
+INSERT INTO job_queue ("campaign_id", "send_rate", "status", "created_at", "updated_at", "visible_at")
+VALUES (selected_campaign_id, selected_send_rate, 'READY', clock_timestamp(), clock_timestamp(), scheduled_timing::timestamp)
 RETURNING id INTO selected_job_id;
 `,
       [],


### PR DESCRIPTION
## Problem

Our `Send Now` feature is not working in local with the campaign always being marked as scheduled for a later time, however, this feature is working fine in our prod.
It is because : Currently, our `insert_jobs` function is casting the received string value for `scheduled_time` to `timestamp`, which doesn't account in timezone information in the string and hence defaulting to UTC time => This results in it working in our prod as our prod application's locale is UTC while not working in local as local application's local is not UTC

## Solution

Update the `insert_jobs` db function

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] Run DB migrations