### PR TITLE
feat: Introducing phonebook service to modularize worker & backend usage

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -154,6 +154,12 @@ interface ConfigSchema {
     maxAttachmentNum: number
     maxCumulativeAttachmentsSize: number
   }
+
+  phonebook: {
+    endpointUrl: string
+    apiKey: string
+    version: string
+  }
 }
 
 convict.addFormats({
@@ -695,6 +701,26 @@ const config: Config<ConfigSchema> = convict({
       default: 10 * 1024 * 1024,
       env: 'FILE_ATTACHMENT_MAX_CUMULATIVE_SIZE',
       format: Number,
+    },
+  },
+  phonebook: {
+    endpointUrl: {
+      doc: 'Endpoint url of phonebook server',
+      default: 'http://localhost:8080',
+      env: 'PHONEBOOK_URL',
+      format: 'required-string',
+    },
+    apiKey: {
+      doc: 'API key to make requests to Phonebook',
+      default: 'API_KEY',
+      env: 'PHONEBOOK_API_KEY',
+      format: 'required-string',
+    },
+    version: {
+      doc: 'Version number of Phonebook',
+      default: '1',
+      env: 'PHONEBOOK_VERSION',
+      format: 'required-string',
     },
   },
 })

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -158,7 +158,6 @@ interface ConfigSchema {
   phonebook: {
     endpointUrl: string
     apiKey: string
-    version: string
   }
 }
 
@@ -714,12 +713,6 @@ const config: Config<ConfigSchema> = convict({
       doc: 'API key to make requests to Phonebook',
       default: 'API_KEY',
       env: 'PHONEBOOK_API_KEY',
-      format: 'required-string',
-    },
-    version: {
-      doc: 'Version number of Phonebook',
-      default: '1',
-      env: 'PHONEBOOK_VERSION',
       format: 'required-string',
     },
   },

--- a/backend/src/core/services/phonebook.service.ts
+++ b/backend/src/core/services/phonebook.service.ts
@@ -1,0 +1,61 @@
+import { loggerWithLabel } from '@core/logger'
+import { ChannelType } from '@core/constants'
+import PhonebookClient from '@shared/clients/phonebook-client.class'
+import config from '@core/config'
+import { User } from '@core/models'
+
+const logger = loggerWithLabel(module)
+
+const phonebookClient: PhonebookClient = new PhonebookClient(
+  config.get('phonebook.endpointUrl'),
+  config.get('phonebook.apiKey')
+)
+
+const getPhonebookLists = async ({
+  userId,
+  channel,
+}: {
+  userId: number
+  channel: ChannelType
+}): Promise<{ id: number; name: string }[]> => {
+  try {
+    const user = await User.findOne({
+      where: { id: userId },
+      attributes: ['email'],
+    })
+    if (!user) {
+      logger.error('invalid user making request!')
+      return []
+    }
+    const res = await phonebookClient.getManagedLists(user.email, channel)
+
+    return res
+  } catch (err) {
+    logger.error({
+      action: 'getPhonebookLists',
+      message: err,
+    })
+    throw err
+  }
+}
+
+const getPhonebookListById = async ({
+  listId,
+}: {
+  listId: number
+}): Promise<{ s3Key: string; etag: string; filename: string }> => {
+  try {
+    return await phonebookClient.getManagedListById(listId)
+  } catch (err) {
+    logger.error({
+      action: 'getPhonebookListById',
+      message: err,
+    })
+    throw err
+  }
+}
+
+export const PhonebookService = {
+  getPhonebookLists,
+  getPhonebookListById,
+}

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -8,6 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/nodemailer": "6.4.0",
+        "axios": "^1.4.0",
         "cheerio": "1.0.0-rc.10",
         "dd-trace": "2.12.2",
         "lodash": "4.17.21",
@@ -1777,15 +1778,29 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -2196,7 +2211,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2459,7 +2473,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4872,7 +4885,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4881,7 +4893,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -5428,6 +5439,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -6230,6 +6246,14 @@
       },
       "engines": {
         "node": ">=14.0"
+      }
+    },
+    "node_modules/twilio/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/type-check": {
@@ -7958,15 +7982,28 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-jest": {
@@ -8275,7 +8312,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -8486,8 +8522,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -10305,14 +10340,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -10713,6 +10746,11 @@
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",
@@ -11307,6 +11345,16 @@
         "scmp": "^2.1.0",
         "url-parse": "^1.5.9",
         "xmlbuilder": "^13.0.2"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
       }
     },
     "type-check": {

--- a/shared/package.json
+++ b/shared/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@types/nodemailer": "6.4.0",
+    "axios": "^1.4.0",
     "cheerio": "1.0.0-rc.10",
     "dd-trace": "2.12.2",
     "lodash": "4.17.21",

--- a/shared/src/clients/phonebook-client.class/index.ts
+++ b/shared/src/clients/phonebook-client.class/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import * as http from 'http'
 
 export default class PhonebookClient {
@@ -20,7 +20,10 @@ export default class PhonebookClient {
     })
   }
 
-  private request(options: AxiosRequestConfig, body?: any): Promise<any> {
+  private request<TBody>(
+    options: AxiosRequestConfig<TBody>,
+    body?: TBody
+  ): Promise<AxiosResponse> {
     const defaultOptions: AxiosRequestConfig = {
       method: 'post', // default method will be post
     }

--- a/shared/src/clients/phonebook-client.class/index.ts
+++ b/shared/src/clients/phonebook-client.class/index.ts
@@ -34,7 +34,10 @@ export default class PhonebookClient {
     })
   }
 
-  public async getManagedLists(email: string, channel: string) {
+  public async getManagedLists(
+    email: string,
+    channel: string
+  ): Promise<{ id: number; name: string }[]> {
     try {
       const res = await this.request({
         method: 'get',
@@ -50,7 +53,9 @@ export default class PhonebookClient {
     }
   }
 
-  public async getManagedListById(listId: number) {
+  public async getManagedListById(
+    listId: number
+  ): Promise<{ s3Key: string; etag: string; filename: string }> {
     try {
       const res = await this.request({
         method: 'get',

--- a/shared/src/clients/phonebook-client.class/index.ts
+++ b/shared/src/clients/phonebook-client.class/index.ts
@@ -1,0 +1,62 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+
+export default class PhonebookClient {
+  private client: AxiosInstance
+  private baseUrl: string
+  private apiKey: string
+  private version: string
+
+  constructor(baseUrl: string, apiKey: string, version: string) {
+    this.baseUrl = baseUrl
+    this.apiKey = apiKey
+    this.version = version
+    this.client = axios.create({
+      baseURL: this.baseUrl,
+      timeout: 5000,
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+      },
+    })
+  }
+
+  private request(options: AxiosRequestConfig, body?: any): Promise<any> {
+    options.url = `/api/v${this.version}/${options.url}`
+    const defaultOptions: AxiosRequestConfig = {
+      method: 'post', // default method will be post
+    }
+    return this.client.request({
+      ...defaultOptions,
+      ...options,
+      data: { ...body },
+    })
+  }
+
+  public async getManagedLists(email: string, channel: string) {
+    try {
+      const res = await this.request({
+        method: 'get',
+        url: `managed-list`,
+        params: {
+          owner: email,
+          channel,
+        },
+      })
+      return res.data
+    } catch (err) {
+      throw new Error(err as any)
+    }
+  }
+
+  public async getManagedListById(listId: number) {
+    try {
+      const res = await this.request({
+        method: 'get',
+        url: `managed-list/${listId}/members/s3`,
+      })
+      return res.data
+    } catch (err) {
+      throw new Error(err as any)
+    }
+  }
+}

--- a/shared/src/clients/phonebook-client.class/index.ts
+++ b/shared/src/clients/phonebook-client.class/index.ts
@@ -1,15 +1,14 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios'
+import * as http from 'http'
 
 export default class PhonebookClient {
   private client: AxiosInstance
   private baseUrl: string
   private apiKey: string
-  private version: string
 
-  constructor(baseUrl: string, apiKey: string, version: string) {
+  constructor(baseUrl: string, apiKey: string) {
     this.baseUrl = baseUrl
     this.apiKey = apiKey
-    this.version = version
     this.client = axios.create({
       baseURL: this.baseUrl,
       timeout: 5000,
@@ -17,11 +16,11 @@ export default class PhonebookClient {
         'Content-Type': 'application/json',
         'x-api-key': this.apiKey,
       },
+      httpAgent: new http.Agent({ keepAlive: true }),
     })
   }
 
   private request(options: AxiosRequestConfig, body?: any): Promise<any> {
-    options.url = `/api/v${this.version}/${options.url}`
     const defaultOptions: AxiosRequestConfig = {
       method: 'post', // default method will be post
     }
@@ -36,7 +35,7 @@ export default class PhonebookClient {
     try {
       const res = await this.request({
         method: 'get',
-        url: `managed-list`,
+        url: `/managed-list`,
         params: {
           owner: email,
           channel,
@@ -52,7 +51,7 @@ export default class PhonebookClient {
     try {
       const res = await this.request({
         method: 'get',
-        url: `managed-list/${listId}/members/s3`,
+        url: `/managed-list/${listId}/members/s3`,
       })
       return res.data
     } catch (err) {

--- a/shared/src/clients/phonebook-client.class/index.ts
+++ b/shared/src/clients/phonebook-client.class/index.ts
@@ -43,7 +43,7 @@ export default class PhonebookClient {
       })
       return res.data
     } catch (err) {
-      throw new Error(err as any)
+      throw new Error('Could not get managed lists')
     }
   }
 
@@ -55,7 +55,7 @@ export default class PhonebookClient {
       })
       return res.data
     } catch (err) {
-      throw new Error(err as any)
+      throw new Error('Could not get managed list by id')
     }
   }
 }

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -85,7 +85,6 @@ export interface ConfigSchema {
     enabled: boolean
     endpointUrl: string
     apiKey: string
-    version: string
   }
 }
 
@@ -357,12 +356,6 @@ const config: Config<ConfigSchema> = convict({
       doc: 'API key to make requests to Phonebook',
       default: 'API_KEY',
       env: 'PHONEBOOK_API_KEY',
-      format: 'required-string',
-    },
-    version: {
-      doc: 'Version number of Phonebook',
-      default: '1',
-      env: 'PHONEBOOK_VERSION',
       format: 'required-string',
     },
   },

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -82,6 +82,7 @@ export interface ConfigSchema {
   }
 
   phonebook: {
+    enabled: boolean
     endpointUrl: string
     apiKey: string
     version: string
@@ -341,6 +342,11 @@ const config: Config<ConfigSchema> = convict({
     },
   },
   phonebook: {
+    enabled: {
+      doc: 'Kill switch of phonebook related features',
+      default: false,
+      env: 'PHONEBOOK_FEATURE_ENABLE',
+    },
     endpointUrl: {
       doc: 'Endpoint url of phonebook server',
       default: 'http://localhost:8080',

--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -80,6 +80,12 @@ export interface ConfigSchema {
     url: string
     apiKey: string
   }
+
+  phonebook: {
+    endpointUrl: string
+    apiKey: string
+    version: string
+  }
 }
 
 const config: Config<ConfigSchema> = convict({
@@ -331,6 +337,26 @@ const config: Config<ConfigSchema> = convict({
       doc: 'API key for Phonebook contact preferences api',
       default: 'somekey',
       env: 'PHONEBOOK_API_KEY',
+      format: 'required-string',
+    },
+  },
+  phonebook: {
+    endpointUrl: {
+      doc: 'Endpoint url of phonebook server',
+      default: 'http://localhost:8080',
+      env: 'PHONEBOOK_URL',
+      format: 'required-string',
+    },
+    apiKey: {
+      doc: 'API key to make requests to Phonebook',
+      default: 'API_KEY',
+      env: 'PHONEBOOK_API_KEY',
+      format: 'required-string',
+    },
+    version: {
+      doc: 'Version number of Phonebook',
+      default: '1',
+      env: 'PHONEBOOK_VERSION',
       format: 'required-string',
     },
   },


### PR DESCRIPTION
in this release: 
- Introduce a new client service to connect with phonebook and make it reusable between worker & backend. 
- changes that are not invoked at the moment, simply to break down further PRs
- kill switch on worker side to make sure we can halt any phonebook related functionality even after job has been queued.


To note:
- There are some older configs used by phonebook v1. They will be removed once we have deprecated the older functionalities that reference these configs
- The older configs are duplicates of newer ones, but now we keep the naming consistent and renamed them to be more intuitive. 
- There is no kill switch in backend as we can control the display on the client side.

Before deployment
- [ ] Add these config values into aws secrets manager
- [ ] Update 1Password shared env file
