### PR TITLE
feat: remove attachment per file size and max number limit

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -150,8 +150,6 @@ interface ConfigSchema {
     checkStalledInterval: number
   }
   file: {
-    maxAttachmentSize: number
-    maxAttachmentNum: number
     maxCumulativeAttachmentsSize: number
   }
   commonAttachments: {
@@ -682,18 +680,6 @@ const config: Config<ConfigSchema> = convict({
     },
   },
   file: {
-    maxAttachmentSize: {
-      doc: 'Maximum accepted file attachment size in bytes',
-      default: 2 * 1024 * 1024,
-      env: 'FILE_ATTACHMENT_MAX_SIZE',
-      format: Number,
-    },
-    maxAttachmentNum: {
-      doc: 'Maximum number of file attachments',
-      default: 10,
-      env: 'FILE_ATTACHMENT_MAX_NUM',
-      format: Number,
-    },
     maxCumulativeAttachmentsSize: {
       doc: 'Maximum cumulative size of all file attachments in bytes',
       default: 10 * 1024 * 1024,

--- a/backend/src/core/middlewares/file-attachment.middleware.ts
+++ b/backend/src/core/middlewares/file-attachment.middleware.ts
@@ -14,7 +14,6 @@ import { CommonAttachment } from '@email/models/common-attachment'
 import { v4 as uuidv4 } from 'uuid'
 import { Readable } from 'stream'
 
-const FILE_ATTACHMENT_MAX_NUM = config.get('file.maxAttachmentNum')
 const TOTAL_ATTACHMENT_SIZE_LIMIT = config.get(
   'file.maxCumulativeAttachmentsSize'
 )
@@ -49,16 +48,6 @@ function preprocessPotentialIncomingFile(
   if (req.files?.attachments) {
     const { attachments } = req.files
     req.body.attachments = ensureAttachmentsFieldIsArray(attachments)
-    /**
-     * Throw explicit error for exceeding num files.
-     * express-fileupload does not throw error if num files
-     * exceeded, instead truncates array to specified num
-     */
-    if (req.body.attachments.length > FILE_ATTACHMENT_MAX_NUM) {
-      throw new ApiAttachmentLimitError(
-        `Number of attachments exceeds limit of ${FILE_ATTACHMENT_MAX_NUM}`
-      )
-    }
   }
   next()
 }

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -90,8 +90,9 @@ export const InitEmailTransactionalRoute = (
     '/send',
     emailTransactionalMiddleware.rateLimit,
     FileAttachmentMiddleware.getFileUploadHandler(
-      // this limit is on a per-file basis, that's why subsequent check is required
-      config.get('file.maxAttachmentSize') as number,
+      // this limit applies on a per-file basis, not a cumulative basis
+      // but we apply maxCumulativeAttachmentsSize since each file size cannot exceed this limit
+      config.get('file.maxCumulativeAttachmentsSize') as number,
       // this is necessary as express-fileupload relies on busboy, which has a
       // default field size limit of 1MB and does not throw any error
       // by setting the limit to be 1 byte above the max, any request with

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -787,38 +787,6 @@ describe(`${emailTransactionalRoute}/send`, () => {
     ])
   })
 
-  test('Email with more than ten attachments should fail', async () => {
-    mockSendEmail = jest.spyOn(EmailService, 'sendEmail')
-    await EmailFromAddress.create({
-      email: user.email,
-      name: 'Agency ABC',
-    } as EmailFromAddress)
-
-    const res = await request(app)
-      .post(endpoint)
-      .set('Authorization', `Bearer ${apiKey}`)
-      .field('recipient', validApiCallAttachment.recipient)
-      .field('subject', validApiCallAttachment.subject)
-      .field('body', validApiCallAttachment.body)
-      .field('from', validApiCallAttachment.from)
-      .field('reply_to', validApiCallAttachment.reply_to)
-      .attach('attachments', validAttachment, validAttachmentName)
-      .attach('attachments', generateRandomSmallFile(), 'attachment2')
-      .attach('attachments', generateRandomSmallFile(), 'attachment3')
-      .attach('attachments', generateRandomSmallFile(), 'attachment4')
-      .attach('attachments', generateRandomSmallFile(), 'attachment5')
-      .attach('attachments', generateRandomSmallFile(), 'attachment6')
-      .attach('attachments', generateRandomSmallFile(), 'attachment7')
-      .attach('attachments', generateRandomSmallFile(), 'attachment8')
-      .attach('attachments', generateRandomSmallFile(), 'attachment9')
-      .attach('attachments', generateRandomSmallFile(), 'attachment10')
-      .attach('attachments', generateRandomSmallFile(), 'attachment11')
-
-    expect(res.status).toBe(413)
-    expect(mockSendEmail).not.toBeCalled()
-    // no need to check EmailMessageTransactional since this is rejected before db record is saved
-  })
-
   test('Requests should be rate limited and metadata and error code is saved correctly in db', async () => {
     mockSendEmail = jest
       .spyOn(EmailService, 'sendEmail')


### PR DESCRIPTION
takeaway from today's meeting with customer:
- they might need to send >10 attachments
- from our perspective, costs are based on total file size of attachments; as such, as long as cumulative file size applies, we can remove "2MB per file" and "10 attachments max" limit]

to-do:
- [x] fix backend tests
- [x] test on staging
  - [x] send single attachment larger than 2MB
  - [x] attachments cumulatively larger than 10MB still get blocked
  - [x] more than 10 attachments cumulatively smaller than 10MB can be sent

^@stanleynguyen dk whether there is value in making these part of the e2e tests...