### PR TITLE
fix(frontend): allow overriding of image server url

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -16,7 +16,8 @@ frontend:
         - nvm install 16
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
-          export REACT_APP_SENTRY_ENVIRONMENT="production";
+          export REACT_APP_SENTRY_ENVIRONMENT="production" &&
+          export REACT_APP_IMG_SERVER_URL="https://postman.gov.sg/v1";
           elif [ "${AWS_BRANCH}" = "momgovsg" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION_MOM} &&
           export REACT_APP_SENTRY_ENVIRONMENT="production-02";

--- a/frontend/src/services/attachment.service.ts
+++ b/frontend/src/services/attachment.service.ts
@@ -1,5 +1,9 @@
 import axios from 'axios'
 
+// Use REACT_APP_IMG_SERVER_URL to override the BACKEND URL if we need to proxy
+const imageServerUrl =
+  process.env.REACT_APP_IMG_SERVER_URL || process.env.REACT_APP_BACKEND_URL
+
 export async function uploadCommonCampaignAttachment(
   file: File
 ): Promise<string> {
@@ -8,5 +12,5 @@ export async function uploadCommonCampaignAttachment(
   const res = await axios.post('/attachments', data, {
     headers: { 'Content-Type': 'multipart/form-data' },
   })
-  return `${process.env.REACT_APP_BACKEND_URL}/attachments/${res.data.id}/${res.data.original_file_name}`
+  return `${imageServerUrl}/attachments/${res.data.id}/${res.data.original_file_name}`
 }


### PR DESCRIPTION
## Problem

We need to have a way to use a custom image server URL if needed

## Solution

Add an extra env var for frontend with fallback on BACKEND_URL

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] N/A