### PR TITLE
feat: insert `cid` field in attachments conditionally

### DIFF
--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -71,11 +71,12 @@ async function sendMessage({
     )
     throw new MessageError()
   }
-
+  const bodyContainsCidTags = EmailTemplateService.client.containsCidTags(body)
   const sanitizedAttachments = attachments
     ? await FileAttachmentService.sanitizeFiles(
         attachments,
-        emailMessageTransactionalId
+        emailMessageTransactionalId,
+        bodyContainsCidTags
       )
     : undefined
 

--- a/shared/src/templating/template-client.ts
+++ b/shared/src/templating/template-client.ts
@@ -39,6 +39,14 @@ export class TemplateClient {
   }
 
   /**
+   * Check whether input contains cid tags
+   * @param value input to be checked
+   */
+  containsCidTags(value: string): boolean {
+    return value.includes('src="cid:')
+  }
+
+  /**
    * Removes non-whitelisted html tags
    * Replaces new lines with html <br> so that the new lines can be displayed on the front-end
    * @param value


### PR DESCRIPTION
[issue](https://opengovproducts.slack.com/archives/CT8D1FESY/p1688463934513269)

Including `cid` field in attachments that are not meant to be content-id images has negatively impacted how such emails are rendered on iOS's Mail app. This code change is intended to mitigate this problem

- [x] Tested on local
- [ ] Test on staging

Deployment notes: N/A