### PR TITLE
fix: index message_id column of transactional SMS

### DIFF
--- a/backend/src/database/migrations/20230705102914-index-sms-transactional-message-id-column.js
+++ b/backend/src/database/migrations/20230705102914-index-sms-transactional-message-id-column.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, _) => {
+    await queryInterface.addIndex(
+      'sms_messages_transactional',
+      ['message_id'],
+      {
+        name: 'sms_messages_transactional_message_id_key',
+        unique: true,
+        concurrently: true,
+      }
+    )
+  },
+  down: async (queryInterface, _) => {
+    await queryInterface.removeIndex(
+      'sms_messages_transactional',
+      'sms_messages_transactional_message_id_key'
+    )
+  },
+}

--- a/backend/src/sms/models/sms-message-transactional.ts
+++ b/backend/src/sms/models/sms-message-transactional.ts
@@ -44,6 +44,7 @@ export class SmsMessageTransactional extends Model<SmsMessageTransactional> {
   @Column({ type: DataType.TEXT, allowNull: false })
   body: string
 
+  // indexed for faster search
   @Column({ type: DataType.STRING, allowNull: true })
   messageId: string | null
 


### PR DESCRIPTION
[Issue](https://opengovproducts.slack.com/archives/C015VQQ3HMG/p1688552733333679?thread_ts=1688542528.385169&cid=C015VQQ3HMG)

Solution: create index concurrently

Deployment notes:
- [x] Test on local
- [x] Test on staging