### PR TITLE
feat: increase list email to 1000 and search by tag

### DIFF
--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -214,7 +214,7 @@ export const InitEmailTransactionalMiddleware = (
   async function listMessages(req: Request, res: Response): Promise<void> {
     // validation from Joi doesn't carry over into type safety here
     // following code transforms query params into type-safe arguments for EmailTransactionalService
-    const { limit, offset, status, created_at, sort_by } = req.query
+    const { limit, offset, status, created_at, sort_by, tag } = req.query
     const userId: string = req.session?.user?.id.toString() // id is number in session; convert to string for tests to pass (weird)
     const filter = created_at ? { createdAt: created_at } : undefined
     const sortBy = sort_by?.toString().replace(/[+-]/, '')
@@ -229,6 +229,7 @@ export const InitEmailTransactionalMiddleware = (
       orderBy,
       status: status as TransactionalEmailMessageStatus,
       filterByTimestamp: filter as TimestampFilter,
+      tag: tag as string,
     })
     res.status(200).json({
       has_more: hasMore,

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -64,6 +64,7 @@ export const InitEmailTransactionalRoute = (
     [Segments.QUERY]: Joi.object({
       limit: Joi.number().integer().min(1).max(1000).default(10),
       offset: Joi.number().integer().min(0).default(0),
+      tag: Joi.string().max(255),
       status: Joi.string()
         .uppercase()
         .valid(...Object.values(TransactionalEmailMessageStatus)),

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -62,7 +62,7 @@ export const InitEmailTransactionalRoute = (
 
   const listMessagesValidator = {
     [Segments.QUERY]: Joi.object({
-      limit: Joi.number().integer().min(1).max(100).default(10),
+      limit: Joi.number().integer().min(1).max(1000).default(10),
       offset: Joi.number().integer().min(0).default(0),
       status: Joi.string()
         .uppercase()

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -1043,7 +1043,7 @@ describe(`GET ${emailTransactionalRoute}`, () => {
       .set('Authorization', `Bearer ${apiKey}`)
     expect(resInvalidLimit.status).toBe(400)
     const resInvalidLimitTooLarge = await request(app)
-      .get(`${endpoint}?limit=1000`)
+      .get(`${endpoint}?limit=1001`)
       .set('Authorization', `Bearer ${apiKey}`)
     expect(resInvalidLimitTooLarge.status).toBe(400)
     const resInvalidOffset = await request(app)

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -211,6 +211,7 @@ async function listMessages({
   orderBy,
   status,
   filterByTimestamp,
+  tag,
 }: {
   userId: string
   limit?: number
@@ -219,16 +220,20 @@ async function listMessages({
   orderBy?: Ordering
   status?: TransactionalEmailMessageStatus
   filterByTimestamp?: TimestampFilter
+  tag?: string
 }): Promise<{ hasMore: boolean; messages: EmailMessageTransactional[] }> {
   limit = limit || 10
   offset = offset || 0
   sortBy = sortBy || TransactionalEmailSortField.Created
   orderBy = orderBy || Ordering.DESC
   const order: Order = [[sortBy, orderBy]]
-  const where = ((userId, status, filterByTimestamp) => {
+  const where = ((userId, status, filterByTimestamp, tag) => {
     const where: WhereOptions = { userId } // pre-fill with userId for authentication
     if (status) {
       where.status = status
+    }
+    if (tag) {
+      where.tag = tag
     }
     if (filterByTimestamp) {
       if (filterByTimestamp.createdAt) {
@@ -248,7 +253,7 @@ async function listMessages({
       }
     }
     return where
-  })(userId, status, filterByTimestamp)
+  })(userId, status, filterByTimestamp, tag)
   const { count, rows } = await EmailMessageTransactional.findAndCountAll({
     limit,
     offset,


### PR DESCRIPTION
[Ticket](https://opengovproducts.slack.com/archives/CT8D1FESY/p1689148321589049)

- [x] Test on staging

Deployment notes: N/A

Usage notes: if there is spacing in the tag (e.g. `hello world`), the query parameter should replace it with `%20` instead. E.g. `/transactional/email?tag=hello%world`
