### PR TITLE
feat(backend): include OTP in OTP email subject

### DIFF
--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -228,7 +228,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     void MailService.mailClient.sendMail({
       from: config.get('mailFrom'),
       recipients: [email],
-      subject: `One-Time Password (OTP) for ${appName}`,
+      subject: `One-Time Password (OTP) for ${appName} - ${otp}`,
       body: `Your OTP is <b>${otp}</b>. It will expire in ${Math.floor(
         OTP_EXPIRY / 60
       )} minutes.

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -18,10 +18,10 @@ async function exportOTPLoginState() {
 
   const emails = await checkGmail({
     from: POSTMAN_FROM,
-    subject: 'One-Time Password (OTP) for Postman.gov.sg',
     to: MAILBOX,
   });
-  const otpMailContent = emails[0].body?.html as string;
+  const emailsWithOtp = emails.filter((email) => email.subject.match(/^(One-Time Password (OTP) for Postman.gov.sg - )[A-Z0-9]{6}$/))
+  const otpMailContent = emailsWithOtp[0].body?.html as string;
   const otp = (otpMailContent.match(/\<b\>([^]+)\<\/b\>/) as string[])[1];
   await page.locator('input[type=text]').fill(otp);
   await page.locator('button[type=submit]').click();

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -20,7 +20,7 @@ async function exportOTPLoginState() {
     from: POSTMAN_FROM,
     to: MAILBOX,
   });
-  const emailsWithOtp = emails.filter((email) => email.subject.match(/^(One-Time Password (OTP) for Postman.gov.sg - )[A-Z0-9]{6}$/))
+  const emailsWithOtp = emails.filter((email) => email.subject.match(/^(One-Time Password \(OTP\) for Postman.gov.sg - )[A-Z0-9]{6}$/))
   const otpMailContent = emailsWithOtp[0].body?.html as string;
   const otp = (otpMailContent.match(/\<b\>([^]+)\<\/b\>/) as string[])[1];
   await page.locator('input[type=text]').fill(otp);

--- a/e2e/gmail-check.ts
+++ b/e2e/gmail-check.ts
@@ -8,7 +8,7 @@ export const checkGmail = async ({
 }: {
   from: string;
   to: string;
-  subject: string;
+  subject?: string;
 }): Promise<Email[]> => {
   // slient unnecessary logging from the library
   const oldLog = console.log;


### PR DESCRIPTION
## Problem

3.2.0 Add Email OTP to email subject line - P1

Closes [SGC-153](https://linear.app/ogp/issue/SGC-153/320-add-email-otp-to-email-subject-line-p1)

## Solution

Please refer to commit.

## Deployment Checklist

N/A
