### PR TITLE
fix: handle blacklisted recipient in SST

### DIFF
--- a/sst/packages/core/src/util/email.ts
+++ b/sst/packages/core/src/util/email.ts
@@ -1,5 +1,5 @@
 // to replace with fetch when upgraded to Node 18
-import axios from 'axios'
+import axios, { AxiosError } from 'axios'
 import { Config } from 'sst/node/config'
 
 const SST_STAGE = process.env.SST_STAGE
@@ -25,6 +25,15 @@ export const sendEmail = async (email: Email) => {
       },
     })
     .catch((err) => {
+      if (err instanceof AxiosError && err.response?.status === 400) {
+        const { message } = err.response.data
+        if (message === 'Recipient email is blacklisted') {
+          console.log(
+            `Recipient email ${email.recipient} is blacklisted, skipping`,
+          )
+          return
+        }
+      }
       console.error(err)
       throw err
     })

--- a/sst/stacks/MyStack.ts
+++ b/sst/stacks/MyStack.ts
@@ -5,10 +5,6 @@ export function MyStack({ app, stack }: StackContext) {
   const postmanDbUri = new Config.Secret(stack, 'POSTMAN_DB_URI')
   const postmanApiKey = new Config.Secret(stack, 'POSTMAN_API_KEY')
   const cronitorUrlSuffix = new Config.Secret(stack, 'CRONITOR_URL_SUFFIX')
-  app.addDefaultFunctionEnv({
-    SST_STAGE: app.stage,
-  })
-
   const { vpcName, lookupOptions, sgName, sgId } = getResourceIdentifiers(
     app.stage,
   )


### PR DESCRIPTION
sending to blacklisted recipient (e.g. officer has left service) should not throw error