### PR TITLE
feat: allow searching Govsg messages by recipient name or mobile number

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -10,7 +10,8 @@ const generateSearchOptions = (search: string) => {
   // TODO: Use an OR operation
   if (!search) {
     return {}
-  } else if (search.match(/^\d{1,10}$/)) {
+  }
+  if (search.match(/^\d{1,10}$/)) {
     return {
       recipient: {
         [Op.like]: `%${search}%`,

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -4,16 +4,38 @@ import { GovsgMessage } from '@govsg/models'
 import { GovsgVerification } from '@govsg/models/govsg-verification'
 import { WhatsAppApiClient } from '@shared/clients/whatsapp-client.class/types'
 import { sendPasscodeCreationMessage } from '@govsg/services/govsg-verification-service'
+import { Op } from 'sequelize'
+
+const generateSearchOptions = (search: string) => {
+  if (!search) {
+    return {}
+  } else if (search.match(/\d{1,8}/)) {
+    return {
+      recipient: {
+        [Op.like]: `%${search}%`,
+      },
+    }
+  }
+  return {
+    params: {
+      recipient_name: {
+        [Op.like]: `%${search}%`,
+      },
+    },
+  }
+}
 
 export const listMessages = async (
   req: Request,
   res: Response
 ): Promise<Response | void> => {
   const { campaignId } = req.params
-  const { offset, limit } = req.query
+  const { offset, limit, search } = req.query
+  const searchOptions = generateSearchOptions(search as string)
   const { rows, count } = await GovsgMessage.findAndCountAll({
     where: {
       campaignId: +campaignId,
+      ...searchOptions,
     },
     offset: +(offset as string),
     limit: +(limit as string),

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -19,7 +19,7 @@ const generateSearchOptions = (search: string) => {
   return {
     params: {
       recipient_name: {
-        [Op.like]: `%${search}%`,
+        [Op.iLike]: `%${search}%`,
       },
     },
   }

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -7,9 +7,10 @@ import { sendPasscodeCreationMessage } from '@govsg/services/govsg-verification-
 import { Op } from 'sequelize'
 
 const generateSearchOptions = (search: string) => {
+  // TODO: Use an OR operation
   if (!search) {
     return {}
-  } else if (search.match(/\d{1,8}/)) {
+  } else if (search.match(/^\d{1,10}$/)) {
     return {
       recipient: {
         [Op.like]: `%${search}%`,

--- a/backend/src/govsg/routes/govsg-campaign.routes.ts
+++ b/backend/src/govsg/routes/govsg-campaign.routes.ts
@@ -1,4 +1,3 @@
-import { GovsgMessageStatus } from '@core/constants'
 import {
   CampaignMiddleware,
   JobMiddleware,
@@ -133,7 +132,7 @@ router.get(
     [Segments.QUERY]: Joi.object({
       limit: Joi.number().integer().min(1).max(100).default(10),
       offset: Joi.number().integer().min(0).default(0),
-      status: Joi.string().valid(...Object.values(GovsgMessageStatus)),
+      search: Joi.string(),
     }),
   }),
   GovsgVerificationMiddleware.listMessages

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -1,9 +1,11 @@
 import axios from 'axios'
 
 import { useContext, useEffect, useState } from 'react'
+import cx from 'classnames'
 
 import Moment from 'react-moment'
 
+import overrideStylesTextInput from '../../campaigns/OverrideTextInput.module.scss'
 import overrideStylesTitleBar from '../../campaigns/OverrideTitleBar.module.scss'
 
 import styles from './GovsgMessages.module.scss'
@@ -11,7 +13,7 @@ import styles from './GovsgMessages.module.scss'
 import NoMatchDashboardImg from 'assets/img/no-match-dashboard.png'
 
 import { Campaign } from 'classes'
-import { ConfirmModal, Pagination, TitleBar } from 'components/common'
+import { ConfirmModal, Pagination, TextInput, TitleBar } from 'components/common'
 import { StatusIconText } from 'components/common/StatusIconText/StatusIconText'
 
 import { PasscodeBadge } from 'components/common/StyledText/PasscodeBadge'
@@ -37,15 +39,20 @@ interface GovsgMessagesProps {
 }
 
 export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
-  const [govsgMessagesDisplayed, setGovsgMessagesDisplayed] = useState([])
+  const [govsgMessagesDisplayed, setGovsgMessagesDisplayed] = useState<
+    GovsgMessage[]
+  >([])
   const [selectedPage, setSelectedPage] = useState(0)
   const [govsgMessageCount, setGovsgMessageCount] = useState(0)
+  const [search, setSearch] = useState('')
   const modalContext = useContext(ModalContext)
 
-  const fetchGovsgMessages = async (selectedPage: number) => {
+  const fetchGovsgMessages = async (selectedPage: number, search?: string) => {
+    const searchOptions = search ? { search } : {}
     const options = {
       offset: selectedPage * ITEMS_PER_PAGE,
       limit: ITEMS_PER_PAGE,
+      ...searchOptions,
     }
     const response = await axios.get(`/campaign/${campaignId}/govsg/messages`, {
       params: {
@@ -83,6 +90,11 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
 
   const handlePageChange = (index: number) => {
     void fetchGovsgMessages(index)
+  }
+
+  const handleSearch = async (newSearch: string) => {
+    setSearch(newSearch)
+    await fetchGovsgMessages(0, newSearch)
   }
 
   const columns = [
@@ -237,7 +249,18 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         <TitleBar
           title={govsgMessageCount + ' Messages'}
           overrideStyles={overrideStylesTitleBar}
-        />
+        >
+          <TextInput
+            value={search}
+            type="text"
+            placeholder="Search for a message"
+            onChange={handleSearch}
+            iconLabel={
+              <i className={cx('bx bx-search', overrideStylesTextInput.icon)} />
+            }
+            overrideStyles={overrideStylesTextInput}
+          />
+        </TitleBar>
         <div className={styles.tableContainer}>
           <table className={styles.govsgMessageTable}>
             <thead>

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -258,7 +258,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
           <TextInput
             value={search}
             type="text"
-            placeholder="Search for a message"
+            placeholder="Search for a message by recipient name or mobile number"
             onChange={handleSearch}
             iconLabel={
               <i className={cx('bx bx-search', overrideStylesTextInput.icon)} />

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -44,12 +44,12 @@ interface GovsgMessagesProps {
 }
 
 export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
+  const [govsgMessageCount, setGovsgMessageCount] = useState(0)
   const [govsgMessagesDisplayed, setGovsgMessagesDisplayed] = useState<
     GovsgMessage[]
   >([])
-  const [selectedPage, setSelectedPage] = useState(0)
-  const [govsgMessageCount, setGovsgMessageCount] = useState(0)
   const [search, setSearch] = useState('')
+  const [selectedPage, setSelectedPage] = useState(0)
   const modalContext = useContext(ModalContext)
 
   const fetchGovsgMessages = async (search: string, selectedPage: number) => {
@@ -90,8 +90,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
 
   useEffect(() => {
     void fetchGovsgMessages(search, selectedPage)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedPage])
+  }, [])
 
   const handlePageChange = (index: number) => {
     void fetchGovsgMessages(search, index)

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
-import { useContext, useEffect, useState } from 'react'
 import cx from 'classnames'
+import { useContext, useEffect, useState } from 'react'
 
 import Moment from 'react-moment'
 
@@ -13,7 +13,12 @@ import styles from './GovsgMessages.module.scss'
 import NoMatchDashboardImg from 'assets/img/no-match-dashboard.png'
 
 import { Campaign } from 'classes'
-import { ConfirmModal, Pagination, TextInput, TitleBar } from 'components/common'
+import {
+  ConfirmModal,
+  Pagination,
+  TextInput,
+  TitleBar,
+} from 'components/common'
 import { StatusIconText } from 'components/common/StatusIconText/StatusIconText'
 
 import { PasscodeBadge } from 'components/common/StyledText/PasscodeBadge'

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -89,12 +89,12 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   }
 
   useEffect(() => {
-    void fetchGovsgMessages(selectedPage)
+    void fetchGovsgMessages(selectedPage, search)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPage])
 
   const handlePageChange = (index: number) => {
-    void fetchGovsgMessages(index)
+    void fetchGovsgMessages(index, search)
   }
 
   const handleSearch = async (newSearch: string) => {

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -52,7 +52,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   const [search, setSearch] = useState('')
   const modalContext = useContext(ModalContext)
 
-  const fetchGovsgMessages = async (selectedPage: number, search?: string) => {
+  const fetchGovsgMessages = async (search: string, selectedPage: number) => {
     const searchOptions = search ? { search } : {}
     const options = {
       offset: selectedPage * ITEMS_PER_PAGE,
@@ -89,17 +89,17 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   }
 
   useEffect(() => {
-    void fetchGovsgMessages(selectedPage, search)
+    void fetchGovsgMessages(search, selectedPage)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedPage])
 
   const handlePageChange = (index: number) => {
-    void fetchGovsgMessages(index, search)
+    void fetchGovsgMessages(search, index)
   }
 
   const handleSearch = async (newSearch: string) => {
     setSearch(newSearch)
-    await fetchGovsgMessages(0, newSearch)
+    await fetchGovsgMessages(newSearch, 0)
   }
 
   const columns = [


### PR DESCRIPTION
## Problem

Postman users need a way to search through Govsg messages by recipient name or recipient mobile number.

Closes [SGC-174](https://linear.app/ogp/issue/SGC-174/implement-search-by-recipient-name-or-mobile-number)

## Solution

- Allow the `listMessages` middleware that sits behind `/messages` (full path: `/campaign/${campaignId}/govsg/messages`) to accept a search query parameter.
- Run the search.
  - If the search term contains only 1 to 10 digits, search by mobile number. Else, search by recipient name.
  - I should explore if I can hand this over to the ORM through the use of an OR operation.

## Screenshots

<img width="1512" alt="Screenshot 2023-08-03 at 11 57 46 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/76bf9254-cb4b-4097-967c-60af6825331c">
<img width="1512" alt="Screenshot 2023-08-03 at 11 58 10 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/dfec7734-ac5e-4464-b861-a4fd6b3ffc5f">
<img width="1512" alt="Screenshot 2023-08-03 at 11 59 02 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/22fe7827-825b-4d1c-b951-e88b67b558ab">

## Other notes

We should pull `recipient_name` out into its own column in `govsg_messages` since we are searching by this field. I will checkout this branch and create the necessary migration there.