### PR TITLE
refactor: ease search by recipient name

### DIFF
--- a/backend/src/database/migrations/20230621062632-create-enqueue-messages-govsg-function.js
+++ b/backend/src/database/migrations/20230621062632-create-enqueue-messages-govsg-function.js
@@ -25,6 +25,7 @@ module.exports = {
           id,
           campaign_id,
           recipient,
+          recipient_name,
           params,
           dequeued_at,
           created_at,

--- a/backend/src/database/migrations/20230621062632-create-enqueue-messages-govsg-function.js
+++ b/backend/src/database/migrations/20230621062632-create-enqueue-messages-govsg-function.js
@@ -25,7 +25,6 @@ module.exports = {
           id,
           campaign_id,
           recipient,
-          recipient_name,
           params,
           dequeued_at,
           created_at,

--- a/backend/src/database/migrations/20230803061141-add-recipient-name-to-govsg-messages.js
+++ b/backend/src/database/migrations/20230803061141-add-recipient-name-to-govsg-messages.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.addColumn('govsg_messages', 'recipient_name', Sequelize.DataTypes.STRING, { transaction })
+      await queryInterface.sequelize.query(`
+        UPDATE govsg_messages
+        SET recipient_name = params->>'recipient_name';
+      `, { transaction });
+      transaction.commit()
+    } catch (e) {
+      transaction.rollback()
+      throw e
+    }
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    const transaction = await queryInterface.sequelize.transaction()
+    try {
+      await queryInterface.removeColumn('govsg_messages', 'recipient_name')
+      transaction.commit()
+    } catch (e) {
+      transaction.rollback()
+      throw e
+    }
+  },
+};

--- a/backend/src/govsg/models/govsg-message.ts
+++ b/backend/src/govsg/models/govsg-message.ts
@@ -37,6 +37,9 @@ export class GovsgMessage extends Model<GovsgMessage> {
   @Column(DataType.STRING)
   recipient: string
 
+  @Column(DataType.STRING)
+  recipientName: string
+
   @Column(DataType.JSONB)
   params: object
 

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -127,6 +127,7 @@ export function uploadCompleteOnChunk({
       return {
         campaignId,
         recipient: entry.recipient.trim(),
+        recipientName: entry.recipientName.trim(),
         params: entry,
       }
     })
@@ -175,6 +176,7 @@ export async function processSingleRecipientCampaign(
     await GovsgMessage.create({
       campaignId,
       recipient: data.recipient,
+      recipientName: data.recipientName,
       params: data,
     } as GovsgMessage)
     await StatsService.setNumRecipients(campaignId, 1, transaction)


### PR DESCRIPTION
## Note

Please review and merge #2143 first.

## Problem

In #2143, we search recipient name via the `params` JSONB.

Search is going to be a rather frequent operation and JSONB types aren't optimised for search. We foresee unnecessary load and potential bugs.

We should copy recipient name to a proper column of its own.

## Solution

- New migration: Add column, run mass update query
- Find all the spots where `GovsgMessage.*create` is called and ensure `recipientName` is defined.

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] Run migration in staging
- [ ] Run migration in prod
