### PR TITLE
refactor: make webhook server return 200 instead of 400

### DIFF
--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -65,7 +65,6 @@ const parseWebhook = async (
     return
   }
   if ('statuses' in body) {
-    // can delete this after we verified that it all works
     logger.info({
       message: 'Received status webhook from WhatsApp',
       action,
@@ -77,7 +76,6 @@ const parseWebhook = async (
     return
   }
   if ('messages' in body && 'contacts' in body) {
-    // can delete this after we verified that it all works
     logger.info({
       message: 'Received message webhook from WhatsApp',
       action,

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -15,6 +15,7 @@ import {
   WhatsAppWebhookTextMessage,
   WhatsappWebhookMessageType,
 } from '@shared/clients/whatsapp-client.class/types'
+import { MessageIdNotFoundWebhookError } from '@shared/clients/whatsapp-client.class/errors'
 import {
   CampaignGovsgTemplate,
   GovsgMessage,
@@ -35,7 +36,6 @@ import {
   sendPasscodeMessage,
   storePrecreatedPasscode,
 } from './govsg-verification-service'
-import { MessageIdNotFoundWebhookError } from '@shared/clients/whatsapp-client.class/errors'
 
 const logger = loggerWithLabel(module)
 

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -35,6 +35,7 @@ import {
   sendPasscodeMessage,
   storePrecreatedPasscode,
 } from './govsg-verification-service'
+import { MessageIdNotFoundWebhookError } from '@shared/clients/whatsapp-client.class/errors'
 
 const logger = loggerWithLabel(module)
 
@@ -138,6 +139,7 @@ const parseTemplateMessageWebhook = async (
       logger.error({
         message: 'Message ID not found',
       })
+      throw new MessageIdNotFoundWebhookError('Message ID not found')
     }
     return
   }

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -16,10 +16,6 @@ import {
   WhatsappWebhookMessageType,
 } from '@shared/clients/whatsapp-client.class/types'
 import {
-  MessageIdNotFoundWebhookError,
-  UnexpectedWebhookError,
-} from '@shared/clients/whatsapp-client.class/errors'
-import {
   CampaignGovsgTemplate,
   GovsgMessage,
   GovsgMessageTransactional,
@@ -58,7 +54,7 @@ const parseWebhook = async (
   })
   // based on current setup, we expect the shape of body to be either
   // WhatsAppTemplateMessageWebhook or UserMessageWebhook
-  // if it's neither, we should thrown an error
+  // if it's neither, we should log an error and return early
   // ideally, should do full validation of the body using sth like Zod
   if (!body || typeof body !== 'object') {
     logger.error({
@@ -66,7 +62,7 @@ const parseWebhook = async (
       action,
       body,
     })
-    throw new UnexpectedWebhookError('Unexpected webhook body')
+    return
   }
   if ('statuses' in body) {
     // can delete this after we verified that it all works
@@ -103,7 +99,7 @@ const parseWebhook = async (
     action,
     body,
   })
-  throw new UnexpectedWebhookError('Unexpected webhook body')
+  return
 }
 
 const parseTemplateMessageWebhook = async (
@@ -136,12 +132,14 @@ const parseTemplateMessageWebhook = async (
         messageId,
       },
     })
-    // throwing error here to return 400
+    // returning early
     // this is because callbacks could hit this endpoint before the messageId is updated in GovsgOp table
     // only do this for sending as this is unlikely to happen for other statuses
     // this will trigger a retry from WhatsApp, which will hit this endpoint again after messageId is updated
     if (whatsappStatus === WhatsAppMessageStatus.sent) {
-      throw new MessageIdNotFoundWebhookError('Message ID not found')
+      logger.error({
+        message: 'Message ID not found',
+      })
     }
     return
   }
@@ -154,9 +152,7 @@ const parseTemplateMessageWebhook = async (
         messageId,
       },
     })
-    throw new UnexpectedWebhookError(
-      'Received webhook for message that exists in both tables'
-    )
+    return
   }
   // NB unable to abstract further with type safety because Sequelize doesn't
   // play well with TypeScript. I wanted to use GovsgMessage | GovsgMessageTransactional type
@@ -209,7 +205,6 @@ const parseTemplateMessageWebhook = async (
         void govsgMessage?.update(fieldOpts, whereOpts)
         void govsgMessageTransactional?.update(fieldOpts, whereOpts)
         void govsgOp?.update(fieldOpts, whereOpts)
-        // not sure whether need to throw an error hmm probably not?
         return
       }
       const { code, title, details, href } = body.errors[0]
@@ -328,7 +323,10 @@ const parseTemplateMessageWebhook = async (
     }
     default: {
       const exhaustiveCheck: never = whatsappStatus
-      throw new Error(`Unhandled status: ${exhaustiveCheck}`)
+      logger.error({
+        message: `Unhandled status: ${exhaustiveCheck}`,
+      })
+      return
     }
   }
 }

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -131,7 +131,7 @@ const parseTemplateMessageWebhook = async (
         messageId,
       },
     })
-    // returning early
+    // throwing error here to return 400
     // this is because callbacks could hit this endpoint before the messageId is updated in GovsgOp table
     // only do this for sending as this is unlikely to happen for other statuses
     // this will trigger a retry from WhatsApp, which will hit this endpoint again after messageId is updated


### PR DESCRIPTION
This PR serves as a potential fix to our webhook taking up to several minutes to receive a `delivered` message status update.

Being too easy with returning HTTP 400 can lead to a snowball of retries from Meta's end, slowing down our own resources.