### PR TITLE
refactor: add userClickedAt column to govsg_verification

### DIFF
--- a/backend/src/database/migrations/20230803032719-add-user-clicked-at-to-govsg-verification.js
+++ b/backend/src/database/migrations/20230803032719-add-user-clicked-at-to-govsg-verification.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('govsg_verification', 'user_clicked_at', {
+      type: Sequelize.DataTypes.DATE,
+      allowNull: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('govsg_verification', 'user_clicked_at')
+  }
+};

--- a/backend/src/govsg/models/govsg-verification.ts
+++ b/backend/src/govsg/models/govsg-verification.ts
@@ -30,4 +30,7 @@ export class GovsgVerification extends Model<GovsgVerification> {
 
   @Column({ type: DataType.STRING, allowNull: false })
   passcode: string
+
+  @Column({ type: DataType.DATE, allowNull: true })
+  userClickedAt: Date | null
 }

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -338,11 +338,16 @@ const parseUserMessageWebhook = async (
   clientId: WhatsAppApiClient
 ): Promise<void> => {
   const { wa_id: whatsappId } = body.contacts[0]
-  const { id: messageId, type } = body.messages[0]
+  const { id: messageId, type, timestamp } = body.messages[0]
+  const timestampAsDate = new Date(parseInt(timestamp, 10) * 1000) // convert to milliseconds
   if (type === WhatsappWebhookMessageType.button) {
     const message = body.messages[0] as WhatsAppWebhookButtonMessage
     if (message.button.text === 'Create passcode') {
       const passcodeCreationWamid = message.context.id
+      await GovsgVerification.update(
+        { userClickedAt: timestampAsDate },
+        { where: { passcodeCreationWamid } }
+      )
       const govsgVerification = await GovsgVerification.findOne({
         where: { passcodeCreationWamid },
         include: [GovsgMessage],


### PR DESCRIPTION
## Problem

In this PR, we add a `user_clicked_at` column to the `govsg_verification` table. Doing so gives us an additional metric to track on our Grafana dashboard. 

## Solution

Each time our whatsapp webhook receives a button click event, it will update the `user_clicked_at` value for the correct entry in the `govsg_verification` table. 

## Deployment Checklist

- [ ] Run migrations
