### PR TITLE
chore: remove unused UnexpectedWebhookError and disable webhook retry for errors that don't need it

### DIFF
--- a/backend/src/govsg/middlewares/govsg-callback.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-callback.middleware.ts
@@ -1,10 +1,7 @@
 import { loggerWithLabel } from '@core/logger'
 import { Request, Response, NextFunction } from 'express'
 import { GovsgCallbackService } from '@govsg/services/govsg-callback.service'
-import {
-  MessageIdNotFoundWebhookError,
-  UnexpectedWebhookError,
-} from '@shared/clients/whatsapp-client.class/errors'
+import { MessageIdNotFoundWebhookError } from '@shared/clients/whatsapp-client.class/errors'
 import { WhatsAppApiClient } from '@shared/clients/whatsapp-client.class/types'
 
 const logger = loggerWithLabel(module)
@@ -67,10 +64,6 @@ const parseWebhook = async (
     await GovsgCallbackService.parseWebhook(req.body, id)
     res.sendStatus(200)
   } catch (err) {
-    if (err instanceof UnexpectedWebhookError) {
-      res.sendStatus(500)
-      return
-    }
     if (err instanceof MessageIdNotFoundWebhookError) {
       res.sendStatus(400)
       return

--- a/backend/src/govsg/middlewares/govsg-callback.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-callback.middleware.ts
@@ -15,7 +15,7 @@ const isAuthenticated = (req: Request, res: Response, next: NextFunction) => {
         query: req.query,
       },
     })
-    res.sendStatus(400)
+    res.sendStatus(200)
     return
   }
   if (!GovsgCallbackService.isAuthenticated(auth)) {
@@ -25,7 +25,7 @@ const isAuthenticated = (req: Request, res: Response, next: NextFunction) => {
         query: req.query,
       },
     })
-    res.sendStatus(400)
+    res.sendStatus(200)
     return
   }
   next()
@@ -45,7 +45,7 @@ const parseWebhook = async (
           query: req.query,
         },
       })
-      res.sendStatus(400)
+      res.sendStatus(200)
       return
     }
     if (
@@ -58,7 +58,7 @@ const parseWebhook = async (
           query: req.query,
         },
       })
-      res.sendStatus(400)
+      res.sendStatus(200)
       return
     }
     await GovsgCallbackService.parseWebhook(req.body, id)

--- a/shared/src/clients/whatsapp-client.class/errors.ts
+++ b/shared/src/clients/whatsapp-client.class/errors.ts
@@ -16,12 +16,6 @@ export class RateLimitError extends Error {
   }
 }
 
-export class UnexpectedWebhookError extends Error {
-  constructor(message: string) {
-    super(message)
-  }
-}
-
 export class MessageIdNotFoundWebhookError extends Error {
   constructor(message: string) {
     super(message)


### PR DESCRIPTION
### Summary of changes

- remove unused UnexpectedWebhookError
- make `isAuthenticated` middleware function in `GovsgCallbackMiddleware` return HTTP 200