### PR TITLE
feat: add whitelisting scripts

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -63,6 +63,7 @@
         "yamljs": "0.3.0"
       },
       "devDependencies": {
+        "@json2csv/plainjs": "^7.0.1",
         "@types/async-retry": "1.4.4",
         "@types/bcrypt": "3.0.0",
         "@types/bluebird": "3.5.30",
@@ -2505,6 +2506,23 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.1.tgz",
+      "integrity": "sha512-eCmYKIIoFDXUB0Fotet2RmcoFTtNLXLmSV7j6aEQH/D2GiO749Uan3ts03PtAhXpE11QghxBjS0toXom8VQNBw==",
+      "dev": true
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.1.tgz",
+      "integrity": "sha512-UAdaZwahrUeYhMYYilJwDsRfE7wDRsmGMsszYH67j8FLD5gZitqG38RXpUgHEH0s6YjsY8iKYWeEQ19WILncFA==",
+      "dev": true,
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.1",
+        "@streamparser/json": "^0.0.15",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.10.tgz",
@@ -3313,6 +3331,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.15.tgz",
+      "integrity": "sha512-6oikjkMTYAHGqKmcC9leE4+kY4Ch4eiTImXUN/N4d2bNGBYs0LJ/tfxmpvF5eExSU7iiPlV9jYlADqvj3NWA3Q==",
+      "dev": true
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
@@ -9081,6 +9105,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -83,6 +83,7 @@
     "yamljs": "0.3.0"
   },
   "devDependencies": {
+    "@json2csv/plainjs": "^7.0.1",
     "@types/async-retry": "1.4.4",
     "@types/bcrypt": "3.0.0",
     "@types/bluebird": "3.5.30",

--- a/backend/src/govsg/models/govsg-template-access.ts
+++ b/backend/src/govsg/models/govsg-template-access.ts
@@ -23,8 +23,8 @@ export class GovsgTemplatesAccess extends Model<GovsgTemplatesAccess> {
   govsgTemplate: GovsgTemplate
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.STRING, primaryKey: true, allowNull: false })
-  userId: string
+  @Column({ type: DataType.BIGINT, primaryKey: true, allowNull: false })
+  userId: number
 
   @BelongsTo(() => User)
   user: User

--- a/backend/src/govsg/models/govsg-template-access.ts
+++ b/backend/src/govsg/models/govsg-template-access.ts
@@ -25,4 +25,7 @@ export class GovsgTemplatesAccess extends Model<GovsgTemplatesAccess> {
   @ForeignKey(() => User)
   @Column({ type: DataType.STRING, primaryKey: true, allowNull: false })
   userId: string
+
+  @BelongsTo(() => User)
+  user: User
 }

--- a/backend/src/scripts/whitelisting/constants.ts
+++ b/backend/src/scripts/whitelisting/constants.ts
@@ -1,0 +1,8 @@
+export const SECTION_DIVIDER =
+  '\n=============================================================\n'
+
+export const OGP_TEMPLATE_ACCESS = []
+
+export const MCI_TEMPLATE_ACCESS = []
+
+export const ALL_TEMPLATE_ACCESS = []

--- a/backend/src/scripts/whitelisting/get_all_templates.ts
+++ b/backend/src/scripts/whitelisting/get_all_templates.ts
@@ -34,7 +34,7 @@ void (async function main() {
       templateId: t.id,
       templateLabel: t.whatsappTemplateLabel,
       templateName: t.name,
-      multilingualSupport: t.multilingualSupport,
+      multilingualSupport: t.multilingualSupport.map((mts) => mts.languageCode),
     }))
     console.log(csvData)
     const parser = new Parser(opts)

--- a/backend/src/scripts/whitelisting/get_all_templates.ts
+++ b/backend/src/scripts/whitelisting/get_all_templates.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config()
+require('module-alias/register')
+
+import sequelizeLoader from '@core/loaders/sequelize.loader'
+import { GovsgTemplate } from '@govsg/models'
+import { Parser } from '@json2csv/plainjs'
+import { string as stringFormatter } from '@json2csv/formatters'
+import * as fs from 'fs'
+
+/**
+ * Returns a csv file of all templates in the database.
+ * The fields of the csv file returned are as follows:
+ * templateId, templateLabel, templateName, multilingualSupport
+ */
+void (async function main() {
+  try {
+    await sequelizeLoader()
+    const templates = await GovsgTemplate.findAll()
+
+    const opts = {
+      fields: [
+        'templateId',
+        'templateLabel',
+        'templateName',
+        'multilingualSupport',
+      ],
+      formatters: {
+        string: stringFormatter({ quote: '' }),
+      },
+    }
+    const csvData = templates.map((t) => ({
+      templateId: t.id,
+      templateLabel: t.whatsappTemplateLabel,
+      templateName: t.name,
+      multilingualSupport: t.multilingualSupport,
+    }))
+    console.log(csvData)
+    const parser = new Parser(opts)
+    const csv = parser.parse(csvData)
+    fs.writeFileSync('temp/output/templates.csv', csv)
+    console.log('Done ✅')
+  } catch (err) {
+    console.log(err)
+  }
+
+  process.exit(0)
+})()

--- a/backend/src/scripts/whitelisting/get_template_access.ts
+++ b/backend/src/scripts/whitelisting/get_template_access.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config()
+require('module-alias/register')
+
+import sequelizeLoader from '@core/loaders/sequelize.loader'
+import { User } from '@core/models'
+import { GovsgTemplate, GovsgTemplatesAccess } from '@govsg/models'
+import { Op } from 'sequelize'
+import { Parser } from '@json2csv/plainjs'
+import { string as stringFormatter } from '@json2csv/formatters'
+import * as fs from 'fs'
+
+/**
+ * Returns a csv file detailing user template access.
+ * The fields of the csv file returned are as follows:
+ * templateLabel, userEmail
+ *
+ * Accepts optional arguments. If arguments are passed in, the function will only
+ * return the user access for the templates specified. Otherwise, the user access
+ * for all templates will be returned.
+ */
+void (async function main() {
+  try {
+    await sequelizeLoader()
+    const templatesToFind: string[] = process.argv.slice(2)
+    let templates: GovsgTemplate[]
+    if (templatesToFind.length === 0) {
+      console.log('Fetching data for all templates')
+      templates = await GovsgTemplate.findAll({})
+    } else {
+      console.log(
+        `Fetching data for the following templates: ${templatesToFind}`
+      )
+      templates = await GovsgTemplate.findAll({
+        where: {
+          whatsappTemplateLabel: {
+            [Op.in]: templatesToFind,
+          },
+        },
+      })
+      if (templatesToFind.length !== templates.length) {
+        throw new Error(
+          `Could not find some templates. Wanted ${templatesToFind}, Got ${templates.map(
+            (t) => t.whatsappTemplateLabel
+          )}`
+        )
+      }
+    }
+    const templateIds = templates.map((t) => t.id)
+    const templateAccess = await GovsgTemplatesAccess.findAll({
+      where: {
+        templateId: {
+          [Op.in]: templateIds,
+        },
+      },
+      include: [GovsgTemplate, User],
+    })
+
+    const opts = {
+      fields: ['templateLabel', 'userEmail'],
+      formatters: {
+        string: stringFormatter({ quote: '' }),
+      },
+    }
+    const csvData = templateAccess.map((ta) => ({
+      templateLabel: ta.govsgTemplate.whatsappTemplateLabel,
+      userEmail: ta.user.email,
+    }))
+    const parser = new Parser(opts)
+    const csv = parser.parse(csvData)
+    fs.writeFileSync('temp/output/template_access.csv', csv)
+    console.log('Done ✅')
+  } catch (err) {
+    console.log(err)
+  }
+
+  process.exit(0)
+})()

--- a/backend/src/scripts/whitelisting/update_whitelist.ts
+++ b/backend/src/scripts/whitelisting/update_whitelist.ts
@@ -1,0 +1,113 @@
+/* eslint-disable no-console */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config()
+require('module-alias/register')
+
+import sequelizeLoader from '@core/loaders/sequelize.loader'
+import { User } from '@core/models'
+import { Op } from 'sequelize'
+import { GovsgTemplate, GovsgTemplatesAccess } from '@govsg/models'
+import {
+  ALL_TEMPLATE_ACCESS,
+  MCI_TEMPLATE_ACCESS,
+  OGP_TEMPLATE_ACCESS,
+  SECTION_DIVIDER,
+} from './constants'
+
+/**
+ * Updates the user template access for the following default groups:
+ * 1. OGP accessible templates
+ * 2. MCI accessible templates
+ * 3. Templates accessible to all users
+ */
+void (async function main() {
+  await sequelizeLoader()
+
+  const templates = await GovsgTemplate.findAll({})
+  const templateLabelToId = new Map<string | null, number>()
+  templates.forEach((t) => {
+    templateLabelToId.set(t.whatsappTemplateLabel, t.id)
+  })
+
+  const usersToUpdate = await User.findAll({
+    where: {
+      email: {
+        [Op.or]: [
+          {
+            [Op.endsWith]: '@open.gov.sg',
+          },
+          {
+            [Op.endsWith]: '@mci.gov.sg',
+          },
+        ],
+      },
+    },
+  })
+  console.log(SECTION_DIVIDER)
+  console.log(`Number of users to update: ${usersToUpdate.length}`)
+  const ogpOfficers = usersToUpdate.filter(
+    (u) => u.email.split('@')[1] === 'open.gov.sg'
+  )
+  const ogpAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    ogpOfficers.flatMap((u) =>
+      OGP_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  const mciOfficers = usersToUpdate.filter(
+    (u) => u.email.split('@')[1] === 'mci.gov.sg'
+  )
+  const mciAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    mciOfficers.flatMap((u) =>
+      MCI_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+
+  const allAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    usersToUpdate.flatMap((u) =>
+      ALL_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  const insertedAccess = [...ogpAccessRule, ...mciAccessRule, ...allAccessRule]
+  console.log(SECTION_DIVIDER)
+  console.log(
+    `Number of rows inserted into Govsg Template Access table: ${insertedAccess.length}`
+  )
+  console.log('Info inserted into Govsg Template Access table:')
+  console.log(
+    JSON.stringify(
+      insertedAccess.map((i) => i.toJSON()),
+      null,
+      2
+    )
+  )
+  console.log(SECTION_DIVIDER)
+  console.log('Done ✅')
+  process.exit(0)
+})()

--- a/backend/src/scripts/whitelisting/whitelist_users.ts
+++ b/backend/src/scripts/whitelisting/whitelist_users.ts
@@ -26,6 +26,12 @@ type RawOfficerData = {
   id?: number
 }
 
+/**
+ * Receives a csv and whitelists users to use the govsg feature.
+ * In addition to giving users default access for the different template groups (OGP, MCI, ALL),
+ * The user can be given adhoc access by passing in a list of template labels separated by ';' in the 5th column of the csv.
+ * Example: template1;template2;template3
+ */
 void (async function main() {
   await sequelizeLoader()
   const rawDataToInsert = (

--- a/backend/src/scripts/whitelisting/whitelist_users.ts
+++ b/backend/src/scripts/whitelisting/whitelist_users.ts
@@ -1,0 +1,240 @@
+/* eslint-disable no-console */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('dotenv').config()
+require('module-alias/register')
+
+import sequelizeLoader from '@core/loaders/sequelize.loader'
+import { Domain, User } from '@core/models'
+import { Op } from 'sequelize'
+import csv from 'csvtojson'
+import { UserExperimental } from '@core/models/user/user-experimental'
+import { ChannelType } from '@core/constants'
+import { GovsgTemplate, GovsgTemplatesAccess } from '@govsg/models'
+import {
+  ALL_TEMPLATE_ACCESS,
+  MCI_TEMPLATE_ACCESS,
+  OGP_TEMPLATE_ACCESS,
+  SECTION_DIVIDER,
+} from './constants'
+
+type RawOfficerData = {
+  name: string
+  email: string
+  designation: string
+  agency: string
+  templates: string[]
+  id?: number
+}
+
+void (async function main() {
+  await sequelizeLoader()
+  const rawDataToInsert = (
+    await csv({ output: 'csv' }).fromFile(
+      'temp/Agency Whitelist - Whitelist.csv'
+    )
+  )
+    .filter((r) => r[5] === 'N')
+    .map(
+      (r) =>
+        ({
+          name: r[0],
+          email: r[1].toLowerCase(),
+          designation: r[2],
+          agency: r[3],
+          templates: r[4] ? r[4].split(';') : [],
+        } as RawOfficerData)
+    )
+  const rawUniqueDomains = Array.from(
+    new Set(rawDataToInsert.map((r) => `@${r.email.split('@')[1]}`))
+  )
+  const domains = await Domain.findAll({
+    where: {
+      domain: {
+        [Op.in]: rawUniqueDomains,
+      },
+    },
+  })
+  console.log(`Number of users in raw data: ${rawDataToInsert.length}`)
+  if (domains.length !== rawUniqueDomains.length) {
+    throw new Error(
+      `There are missing domains in DB. Needed ${rawUniqueDomains}, Got ${domains.map(
+        (d) => d.domain
+      )}`
+    )
+  }
+  const templatesToAccess = Array.from(
+    new Set(rawDataToInsert.flatMap((r) => r.templates))
+  )
+  console.log(templatesToAccess)
+  const templates = await GovsgTemplate.findAll({})
+  const templateLabelToId = new Map<string | null, number>()
+  templates.forEach((t) => {
+    templateLabelToId.set(t.whatsappTemplateLabel, t.id)
+  })
+  if (templatesToAccess.some((ta) => !templateLabelToId.has(ta))) {
+    throw new Error(
+      `There are templates that do not exist. Needed ${templatesToAccess}, Have ${templates.map(
+        (t) => t.whatsappTemplateLabel
+      )}`
+    )
+  }
+
+  const existingUsers = await User.findAll({
+    where: {
+      email: {
+        [Op.in]: rawDataToInsert.map((r) => r.email),
+      },
+    },
+  })
+  console.log(SECTION_DIVIDER)
+  console.log(`Number of existing users: ${existingUsers.length}`)
+  const existingEmails = existingUsers.map((u) => u.email)
+  console.log(JSON.stringify(existingEmails, null, 2))
+  const newUsers = await User.bulkCreate(
+    rawDataToInsert
+      .filter((r) => !existingEmails.includes(r.email))
+      .map(
+        (r) =>
+          ({
+            email: r.email,
+            emailDomain: `@${r.email.split('@')[1]}`,
+          } as User)
+      ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  console.log(SECTION_DIVIDER)
+  console.log(`Number of new users: ${newUsers.length}`)
+  console.log(
+    JSON.stringify(
+      newUsers.map((i) => i.toJSON()),
+      null,
+      2
+    )
+  )
+  const allUsers = [...existingUsers, ...newUsers]
+  const officersWithIds = rawDataToInsert.map(
+    (r) =>
+      ({
+        ...r,
+        id: allUsers.find((u) => u.email === r.email)?.id,
+      } as RawOfficerData)
+  )
+  const inserted = await UserExperimental.bulkCreate(
+    officersWithIds.map(
+      (o) =>
+        ({
+          feature: ChannelType.Govsg,
+          userId: o.id,
+          metadata: {
+            officer_name: o.name,
+            agency: o.agency,
+            officer_designation: o.designation,
+          },
+        } as UserExperimental)
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  console.log(SECTION_DIVIDER)
+  console.log(
+    `Number of rows inserted into User Experimental table: ${inserted.length}`
+  )
+  console.log('Info inserted into User Experimental table:')
+  console.log(
+    JSON.stringify(
+      inserted.map((i) => i.toJSON()),
+      null,
+      2
+    )
+  )
+  // Gives user access to templates according to the csv input
+  const csvAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    officersWithIds.flatMap((u) =>
+      u.templates.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  const ogpOfficers = officersWithIds.filter(
+    (u) => u.email.split('@')[1] === 'open.gov.sg'
+  )
+  // Gives OGP officers access to OGP default templates
+  const ogpAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    ogpOfficers.flatMap((u) =>
+      OGP_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  const mciOfficers = officersWithIds.filter(
+    (u) => u.email.split('@')[1] === 'mci.gov.sg'
+  )
+  // Gives MCI officers access to MCI default templates
+  const mciAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    mciOfficers.flatMap((u) =>
+      MCI_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  // Gives access to all default templates
+  const allAccessRule = await GovsgTemplatesAccess.bulkCreate(
+    officersWithIds.flatMap((u) =>
+      ALL_TEMPLATE_ACCESS.map(
+        (t) =>
+          ({
+            userId: u.id,
+            templateId: templateLabelToId.get(t),
+          } as unknown as GovsgTemplatesAccess)
+      )
+    ),
+    {
+      ignoreDuplicates: true,
+    }
+  )
+  const insertedAccess = [
+    ...csvAccessRule,
+    ...ogpAccessRule,
+    ...mciAccessRule,
+    ...allAccessRule,
+  ]
+  console.log(SECTION_DIVIDER)
+  console.log(
+    `Number of rows inserted into Govsg Template Access table: ${insertedAccess.length}`
+  )
+  console.log('Info inserted into Govsg Template Access table:')
+  console.log(
+    JSON.stringify(
+      insertedAccess.map((i) => i.toJSON()),
+      null,
+      2
+    )
+  )
+  console.log(SECTION_DIVIDER)
+  console.log('Done ✅')
+  process.exit(0)
+})()


### PR DESCRIPTION
## Problem

In this PR, I add new whitelisting scripts to facilitate having different groups for WhatsApp templates. 

Closes [SGC-180](https://linear.app/ogp/issue/SGC-180/wa-templates-will-be-grouped-into-3-categories)

## Solution

Instead of handling the implementation for grouping templates at the DB level, we've decided that we can do it from the whitelisting scripts. Doing this gives us the added benefit of not having to change any of the query parameters/data model in the system. 

I've added 4 new whitelisting scripts. A detailed description of each script can be found in their respective files. 

1. `get_template_access.ts`
2. `get_all_templates.ts`
3. `update_whitelist.ts`
4. `whitelist_users.ts`



## Deployment Checklist

**New dev dependencies**:

- `@json2csv/plainjs` : used to create csv files

**No further deployment steps need to be taken**

