### PR TITLE
feat: Dedupe recipients for Gov.sg campaigns

### DIFF
--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -115,6 +115,7 @@ export function uploadCompleteOnChunk({
   campaignId: number
 }): (data: CSVParams[]) => Promise<void> {
   return async function (data: CSVParams[]): Promise<void> {
+    const recipients = new Set<string>([])
     const records: Array<MessageBulkInsertInterface> = data.map((entry) => {
       const keysWithMissingValues = Object.keys(entry).filter((k) => !entry[k])
       if (keysWithMissingValues.length > 0) {
@@ -124,9 +125,16 @@ export function uploadCompleteOnChunk({
           )}`
         )
       }
+      const recipient = entry.recipient.trim()
+      if (recipients.has(recipient)) {
+        throw new Error(
+          `Duplicate recipient: ${recipient}. Duplicate recipients are not acceptable in Gov.sg campaigns.`
+        )
+      }
+      recipients.add(recipient)
       return {
         campaignId,
-        recipient: entry.recipient.trim(),
+        recipient: recipient,
         params: entry,
       }
     })

--- a/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
@@ -1,4 +1,3 @@
-import { i18n } from '@lingui/core'
 import {
   Dispatch,
   SetStateAction,
@@ -6,7 +5,6 @@ import {
   useEffect,
   useState,
 } from 'react'
-import { OutboundLink } from 'react-ga'
 
 import { useParams } from 'react-router-dom'
 
@@ -30,7 +28,6 @@ import {
   WarningBlock,
 } from 'components/common'
 import useIsMounted from 'components/custom-hooks/use-is-mounted'
-import { LINKS } from 'config'
 
 import { CampaignContext } from 'contexts/campaign.context'
 import { ModalContext } from 'contexts/modal.context'
@@ -174,19 +171,8 @@ const GovsgRecipients = ({
           </p>
         </StepHeader>
         {!csvFilename && (
-          <WarningBlock title={'We do not remove duplicate recipients'}>
-            This is because some use cases intend to send multiple messages to
-            the same recipient. If this is not intended, please remove the
-            duplicates. Learn how{' '}
-            <OutboundLink
-              className={styles.warningHelpLink}
-              eventLabel={i18n._(LINKS.guideRemoveDuplicatesUrl)}
-              to={i18n._(LINKS.guideRemoveDuplicatesUrl)}
-              target="_blank"
-            >
-              from our guide
-            </OutboundLink>
-            .
+          <WarningBlock title="We do not allow duplicate recipients in Gov.sg campaigns">
+            Each recipient may only receive one message per campaign.
           </WarningBlock>
         )}
 


### PR DESCRIPTION
## Problem

If we allow each recipient in a campaign to receive multiple messages as a result of multi-lingual capabilities, there will be increased complexity in ensuring all such messages have the same OTP.

As such, we want to ensure each campaign contains unique recipients only. Each recipient can only receive 1 message in whichever language specified for the recipient.

Closes [SGC-181](https://linear.app/ogp/issue/SGC-181/de-dupe-recipient-column-in-postman-for-govsg-channel-only)

## Solution

- Update `GovsgService.uploadCompleteOnChunk` to additionally check for duplicate recipients and throw an error if so.
- Update the warning message in the frontend so that users are informed that `We do not allow duplicate recipients in Gov.sg campaigns`.

## Screenshots

### Before
<img width="1510" alt="image" src="https://github.com/opengovsg/postmangovsg/assets/14961285/bf143bbb-526d-459e-9bbf-0aab820b957a">

### After
<img width="1510" alt="Screenshot 2023-08-07 at 10 21 47 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/c291ea0f-7d0e-4f20-bb65-07f49a91a78b">
