### PR TITLE
fix: remove initial flicker when showing Gov.sg messages

### DIFF
--- a/frontend/src/components/common/LoadingSpinner/LoadingSpinner.module.scss
+++ b/frontend/src/components/common/LoadingSpinner/LoadingSpinner.module.scss
@@ -1,0 +1,6 @@
+@import 'styles/_variables';
+@import 'styles/_mixins';
+
+.spinner {
+  @include spinner;
+}

--- a/frontend/src/components/common/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+import styles from './LoadingSpinner.module.scss'
+
+export const LoadingSpinner = () => {
+  return (
+    <div className={styles.spinner}>
+      <i className="bx bx-loader-alt bx-spin"></i>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -19,6 +19,7 @@ import {
   TextInput,
   TitleBar,
 } from 'components/common'
+import { LoadingSpinner } from 'components/common/LoadingSpinner/LoadingSpinner'
 import { StatusIconText } from 'components/common/StatusIconText/StatusIconText'
 
 import { PasscodeBadge } from 'components/common/StyledText/PasscodeBadge'
@@ -50,6 +51,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   >([])
   const [search, setSearch] = useState('')
   const [selectedPage, setSelectedPage] = useState(0)
+  const [loading, setLoading] = useState(true)
   const modalContext = useContext(ModalContext)
 
   const fetchGovsgMessages = async (search: string, selectedPage: number) => {
@@ -89,7 +91,9 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   }
 
   useEffect(() => {
-    void fetchGovsgMessages(search, selectedPage)
+    void fetchGovsgMessages(search, selectedPage).finally(() => {
+      setLoading(false)
+    })
   }, [])
 
   const handlePageChange = (index: number) => {
@@ -282,5 +286,5 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     )
   }
 
-  return renderGovsgMessage()
+  return loading ? <LoadingSpinner /> : renderGovsgMessage()
 }


### PR DESCRIPTION
## Problem

Before this PR, there would be an initial flicker from `renderNoMatch()` -> `renderGovsgMessage()` because we had no loading spinner for this component.

Now, we have it.

Closes [SGC-184](https://linear.app/ogp/issue/SGC-184/fix-flicker-between-empty-dashboard-and-list-of-messages)

Note: For now, it is ok to rapidly switch from `renderNoMatch()` -> `renderGovsgMessage()` during search. This is because we don't want the search bar to become a `LoadingSpinner` on key down.
