### PR TITLE
Revert "fix: TypeError: Cannot read properties of undefined (reading 'userId')"

### DIFF
--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -259,7 +259,7 @@ const parseTemplateMessageWebhook = async (
       }
       const message = (govsgMessage ?? govsgOp) as GovsgMessage
       const experimentalData = await experimentService.getUserExperimentalData(
-        message.campaign?.userId ?? -1
+        message.campaign.userId
       )
       const canAccessGovsgV = `${ChannelType.Govsg}V` in experimentalData
       if (!canAccessGovsgV) {


### PR DESCRIPTION
Reverts opengovsg/postmangovsg#2144

The "delivered" status update webhook requests have been "missing" since last Thursday/Friday, leading to absence of officer verification message(s).

This commit was found to have caused the issue. It is currently unknown why but I propose to revert this first.

Impact of reverting: We'll see Sentry errors on this type error, but it's acceptable for now.