### PR TITLE
fix: fetch correct client

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -101,6 +101,8 @@ export const resendPasscodeCreationMessage = async (
   }
   const { recipient } = govsgMessage
   // flamingoDb has phone numbers prepended with +countrycode but phone numbers in govsgMessage don't always have that.
+  // In addition, phone numbers in govsgMessage are sometimes observed to have whitespaces inside them. Such is not observed
+  // in flamingoDb.
   const recipientWithCountryCode =
     removeWhitespacesAndPrependCountryCode(recipient)
   const apiClientIdMap = await whatsappService.flamingoDbClient.getApiClientId([

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -4,8 +4,8 @@ import { GovsgMessage } from '@govsg/models'
 import { GovsgVerification } from '@govsg/models/govsg-verification'
 import { WhatsAppApiClient } from '@shared/clients/whatsapp-client.class/types'
 import { sendPasscodeCreationMessage } from '@govsg/services/govsg-verification-service'
-import { removeWhitespacesAndPrependCountryCode } from '@govsg/utils/recipient'
 import { Op } from 'sequelize'
+import { PhoneNumberService } from '@shared/utils/phone-number.service'
 
 const generateSearchOptions = (search: string) => {
   // TODO: Use an OR operation
@@ -100,14 +100,11 @@ export const resendPasscodeCreationMessage = async (
     })
   }
   const { recipient } = govsgMessage
-  // flamingoDb has phone numbers prepended with +countrycode but phone numbers in govsgMessage don't always have that.
-  // In addition, phone numbers in govsgMessage are sometimes observed to have whitespaces inside them. Such is not observed
   // flamingoDb numbers are prepended with +countrycode and have no whitespaces.
   // recipient numbers of govsgMessage may not fulfil the above thus have to be preprocessed first.
-  const recipientWithCountryCode =
-    removeWhitespacesAndPrependCountryCode(recipient)
+  const normalisedRecipient = PhoneNumberService.normalisePhoneNumber(recipient)
   const apiClientIdMap = await whatsappService.flamingoDbClient.getApiClientId([
-    recipientWithCountryCode,
+    normalisedRecipient,
   ])
   // if recipient not in db, map.get(recipient) will return undefined
   // default to clientTwo in this case

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -102,7 +102,8 @@ export const resendPasscodeCreationMessage = async (
   const { recipient } = govsgMessage
   // flamingoDb has phone numbers prepended with +countrycode but phone numbers in govsgMessage don't always have that.
   // In addition, phone numbers in govsgMessage are sometimes observed to have whitespaces inside them. Such is not observed
-  // in flamingoDb.
+  // flamingoDb numbers are prepended with +countrycode and have no whitespaces.
+  // recipient numbers of govsgMessage may not fulfil the above thus have to be preprocessed first.
   const recipientWithCountryCode =
     removeWhitespacesAndPrependCountryCode(recipient)
   const apiClientIdMap = await whatsappService.flamingoDbClient.getApiClientId([

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -4,6 +4,7 @@ import { GovsgMessage } from '@govsg/models'
 import { GovsgVerification } from '@govsg/models/govsg-verification'
 import { WhatsAppApiClient } from '@shared/clients/whatsapp-client.class/types'
 import { sendPasscodeCreationMessage } from '@govsg/services/govsg-verification-service'
+import { removeWhitespacesAndPrependCountryCode } from '@govsg/utils/recipient'
 import { Op } from 'sequelize'
 
 const generateSearchOptions = (search: string) => {
@@ -99,8 +100,11 @@ export const resendPasscodeCreationMessage = async (
     })
   }
   const { recipient } = govsgMessage
+  // flamingoDb has phone numbers prepended with +countrycode but phone numbers in govsgMessage don't always have that.
+  const recipientWithCountryCode =
+    removeWhitespacesAndPrependCountryCode(recipient)
   const apiClientIdMap = await whatsappService.flamingoDbClient.getApiClientId([
-    recipient,
+    recipientWithCountryCode,
   ])
   // if recipient not in db, map.get(recipient) will return undefined
   // default to clientTwo in this case

--- a/backend/src/govsg/utils/recipient.ts
+++ b/backend/src/govsg/utils/recipient.ts
@@ -1,5 +1,5 @@
 export const removeWhitespacesAndPrependCountryCode = (recipient: string) => {
-  const withoutWhitespaces = recipient.replace(/ /g, '')
+  const withoutWhitespaces = recipient.replace(/\s/g, '')
   const hasCountryCode = recipient.startsWith('+')
   if (hasCountryCode) {
     return withoutWhitespaces

--- a/backend/src/govsg/utils/recipient.ts
+++ b/backend/src/govsg/utils/recipient.ts
@@ -1,0 +1,8 @@
+export const removeWhitespacesAndPrependCountryCode = (recipient: string) => {
+  const withoutWhitespaces = recipient.replace(/ /g, '')
+  const hasCountryCode = recipient.startsWith('+')
+  if (hasCountryCode) {
+    return withoutWhitespaces
+  }
+  return `+65${withoutWhitespaces}`
+}

--- a/backend/src/govsg/utils/recipient.ts
+++ b/backend/src/govsg/utils/recipient.ts
@@ -1,8 +1,0 @@
-export const removeWhitespacesAndPrependCountryCode = (recipient: string) => {
-  const withoutWhitespaces = recipient.replace(/\s/g, '')
-  const hasCountryCode = recipient.startsWith('+')
-  if (hasCountryCode) {
-    return withoutWhitespaces
-  }
-  return `+65${withoutWhitespaces}`
-}


### PR DESCRIPTION
## Problem

The Resend button uses client 2 all the time.

Closes [SGC-191](https://linear.app/ogp/issue/SGC-191/resend-causes-two-govsg-threads-in-prod)

## Solution

Remove whitespaces and prepend +countrycode to phone numbers when using the `getApiClientId` query.

Don't merge today. Merge on Friday.
