### PR TITLE
style: set cursor to pointer when hovering over tabs in CampaignHeaderTabs

### DIFF
--- a/frontend/src/components/common/CampaignHeaderTabs/CampaignHeaderTabs.module.scss
+++ b/frontend/src/components/common/CampaignHeaderTabs/CampaignHeaderTabs.module.scss
@@ -1,0 +1,15 @@
+@import 'styles/_mixins';
+@import 'styles/_variables';
+
+.tab {
+  margin-right: 1rem;
+}
+
+.tab:hover {
+  cursor: pointer;
+}
+
+.active {
+  font-weight: bold;
+  color: $blue-500;
+}

--- a/frontend/src/components/common/CampaignHeaderTabs/CampaignHeaderTabs.tsx
+++ b/frontend/src/components/common/CampaignHeaderTabs/CampaignHeaderTabs.tsx
@@ -1,4 +1,8 @@
+import cx from 'classnames'
+
 import { useContext } from 'react'
+
+import styles from './CampaignHeaderTabs.module.scss'
 
 import { GovsgDetailContext } from 'contexts/govsg-detail.context'
 
@@ -11,11 +15,9 @@ export const CampaignHeaderTabs = () => {
         <span
           key={tabLabel}
           onClick={() => setActiveTab(tabIndex)}
-          style={
-            activeTab === tabIndex
-              ? { marginRight: '1rem', fontWeight: 'bold', color: '#2C2CDC' }
-              : { marginRight: '1rem' }
-          }
+          className={cx(styles.tab, {
+            [styles.active]: activeTab === tabIndex,
+          })}
         >
           {tabLabel}
         </span>


### PR DESCRIPTION
## Problem

When hovering over tabs in CampaignHeaderTabs, the cursor was not set, so it becomes unclear if the tabs are clickable.

Closes [SGC-187](https://linear.app/ogp/issue/SGC-187/use-cursor-pointer-for-report-messages-tabs)

## Solution

CSS
