### PR TITLE
feat: enable multi-lingual support for bulk send

### DIFF
--- a/backend/src/govsg/middlewares/govsg-template.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-template.middleware.ts
@@ -33,7 +33,7 @@ const convertMultilingualSupportToResponse = (
     language: languageSupport.language,
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    code: languageSupport.languageCode ?? languageSupport['language_code'],
+    code: languageSupport.language_code,
   }))
 }
 

--- a/backend/src/govsg/services/govsg-template.service.ts
+++ b/backend/src/govsg/services/govsg-template.service.ts
@@ -29,12 +29,17 @@ export async function getFilledTemplate(
 
 const getLocalisedTemplateBody = (
   template: GovsgTemplate | null,
-  languageCode: string
+  language: string
 ) => {
+  console.log(
+    'getLocalisedTemplateBody',
+    language,
+    template?.multilingualSupport
+  )
+  const languageInLowerCase = language.toLowerCase()
   return (template?.multilingualSupport.find(
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    (languageSupport) => languageSupport.language_code === languageCode
+    (languageSupport) =>
+      languageSupport.language.toLowerCase() === languageInLowerCase
   )?.body ?? template?.body) as string
 }
 
@@ -55,8 +60,10 @@ export async function getHydratedMessage(
     return null
   }
 
-  const languageCode = params.language
-  const localisedTemplateBody = getLocalisedTemplateBody(template, languageCode)
+  const localisedTemplateBody = getLocalisedTemplateBody(
+    template,
+    params.language
+  )
   return { body: templateCli.template(localisedTemplateBody, params) }
 }
 

--- a/backend/src/govsg/services/govsg-template.service.ts
+++ b/backend/src/govsg/services/govsg-template.service.ts
@@ -29,13 +29,11 @@ export async function getFilledTemplate(
 
 const getLocalisedTemplateBody = (
   template: GovsgTemplate | null,
-  language: string
+  language: string | undefined
 ) => {
-  console.log(
-    'getLocalisedTemplateBody',
-    language,
-    template?.multilingualSupport
-  )
+  if (!language) {
+    return template?.body as string
+  }
   const languageInLowerCase = language.toLowerCase()
   return (template?.multilingualSupport.find(
     (languageSupport) =>

--- a/backend/src/govsg/services/govsg-template.service.ts
+++ b/backend/src/govsg/services/govsg-template.service.ts
@@ -27,6 +27,17 @@ export async function getFilledTemplate(
   return pivot.govsgTemplate
 }
 
+const getLocalisedTemplateBody = (
+  template: GovsgTemplate | null,
+  languageCode: string
+) => {
+  return (template?.multilingualSupport.find(
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    (languageSupport) => languageSupport.language_code === languageCode
+  )?.body ?? template?.body) as string
+}
+
 export async function getHydratedMessage(
   campaignId: number
 ): Promise<{ body: string } | null> {
@@ -44,7 +55,9 @@ export async function getHydratedMessage(
     return null
   }
 
-  return { body: templateCli.template(template?.body as string, params) }
+  const languageCode = params.language
+  const localisedTemplateBody = getLocalisedTemplateBody(template, languageCode)
+  return { body: templateCli.template(localisedTemplateBody, params) }
 }
 
 export function testHydration(

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -115,7 +115,10 @@ export function uploadCompleteOnPreview({
   }
 }
 
-const getLanguageCode = (language: string) => {
+const getLanguageCode = (language: string | undefined) => {
+  if (!language) {
+    return WhatsAppLanguages.english
+  }
   const languageInLowerCase = language.toLowerCase()
   const whatsAppLanguages = Object.keys(WhatsAppLanguages)
   const key = whatsAppLanguages.find(

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -10,6 +10,7 @@ import { GovsgTemplateService } from '.'
 import { GovsgMessage } from '@govsg/models/govsg-message'
 import { MessageBulkInsertInterface } from '@core/interfaces/message.interface'
 import { loggerWithLabel } from '@core/logger'
+import { WhatsAppLanguages } from '@shared/clients/whatsapp-client.class/types'
 
 const logger = loggerWithLabel(module)
 
@@ -114,6 +115,18 @@ export function uploadCompleteOnPreview({
   }
 }
 
+const getLanguageCode = (language: string) => {
+  const languageInLowerCase = language.toLowerCase()
+  const whatsAppLanguages = Object.keys(WhatsAppLanguages)
+  const key = whatsAppLanguages.find(
+    (whatsAppLanguage) => whatsAppLanguage.toLowerCase() === languageInLowerCase
+  )
+  if (!key) {
+    return WhatsAppLanguages.english
+  }
+  return WhatsAppLanguages[key as keyof typeof WhatsAppLanguages]
+}
+
 export function uploadCompleteOnChunk({
   transaction,
   campaignId,
@@ -143,7 +156,7 @@ export function uploadCompleteOnChunk({
         campaignId,
         recipient: recipient,
         params: entry,
-        languageCode: entry.language,
+        languageCode: getLanguageCode(entry.language),
       }
     })
 

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -143,6 +143,7 @@ export function uploadCompleteOnChunk({
         campaignId,
         recipient: recipient,
         params: entry,
+        languageCode: entry.language,
       }
     })
 

--- a/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
@@ -28,6 +28,7 @@ import {
   WarningBlock,
 } from 'components/common'
 import useIsMounted from 'components/custom-hooks/use-is-mounted'
+import { useGovsgV } from 'components/custom-hooks/useGovsgV'
 
 import { CampaignContext } from 'contexts/campaign.context'
 import { ModalContext } from 'contexts/modal.context'
@@ -43,6 +44,7 @@ const GovsgRecipients = ({
 }: {
   setActiveStep: Dispatch<SetStateAction<GovsgProgress>>
 }) => {
+  const { canAccessGovsgV } = useGovsgV()
   const { campaign, updateCampaign } = useContext(CampaignContext)
   const {
     isCsvProcessing: initialIsProcessing,
@@ -184,7 +186,7 @@ const GovsgRecipients = ({
           <FileInput isProcessing={isUploading} onFileSelected={uploadFile} />
           <p>or</p>
           <SampleCsv
-            params={params}
+            params={canAccessGovsgV ? ['language', ...params] : params}
             defaultRecipient="81234567"
             setErrorMsg={console.error}
           />


### PR DESCRIPTION
## Notes

- Merge #2155 first. Remember to switch base to `master`.
- Only users with access to the GOVSGV feature can enjoy this feature.

## Summary of changes

Enable multi-lingual templates for bulk send too.

Closes [SGC-189](https://linear.app/ogp/issue/SGC-189/support-multi-lingual-messages-in-bulk-send)

## Checklist

- [x] Add `language` column to sample CSV
- [x] Inject language into `GovsgMessage`
- [x] Localise message preview
- [x] Transform language into language code for upstream processing

## Screenshots

<img width="1512" alt="Screenshot 2023-08-10 at 4 54 59 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/9aaef624-5af2-48a7-9665-2f9e8a4aa9ba">
