### PR TITLE
feat: smart lang chips

### DIFF
--- a/frontend/src/components/common/ChipGroup/LanguageChipGroup.tsx
+++ b/frontend/src/components/common/ChipGroup/LanguageChipGroup.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction } from 'react'
 import { Chip } from './Chip'
 
 interface LanguageChipGroupProps {
+  options: string[]
   selected: WhatsAppLanguages
   setSelection: Dispatch<SetStateAction<WhatsAppLanguages>>
 }
@@ -15,12 +16,13 @@ const languageChipGroupStyle = {
 }
 
 export const LanguageChipGroup = ({
+  options,
   selected,
   setSelection,
 }: LanguageChipGroupProps) => {
   return (
     <div style={languageChipGroupStyle}>
-      {Object.keys(WhatsAppLanguages).map((language) => {
+      {options.map((language) => {
         const value =
           WhatsAppLanguages[language as keyof typeof WhatsAppLanguages]
         return (

--- a/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
@@ -159,6 +159,9 @@ function GovsgPickTemplate({
                   />
                   {canAccessGovsgV && t.languages.length > 0 && (
                     <LanguageChipGroup
+                      options={t.languages.map((languageSupport) =>
+                        languageSupport.language.toLowerCase()
+                      )}
                       selected={selectedLanguage}
                       setSelection={setSelectedLanguage}
                     />

--- a/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
@@ -137,7 +137,8 @@ const GovsgSingleRecipient = ({
             <p>
               <label htmlFor="language">Language</label>{' '}
             </p>
-            {Object.keys(WhatsAppLanguages).map((language) => {
+            {typedCampaign.languages.map((languageSupport) => {
+              const language = languageSupport.language
               const label = capitalize(language)
               const languageCode =
                 WhatsAppLanguages[language as keyof typeof WhatsAppLanguages]


### PR DESCRIPTION
## Problem

Before this PR, we either show 0 or 4 language chips and radio options.

We should show them based on the actual languages supported by the template.

Closes [SGC-188](https://linear.app/ogp/issue/SGC-188/show-only-language-chips-which-the-template-has)