### PR TITLE
fix: bug fixes for multi-lingual feature

### DIFF
--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -39,7 +39,14 @@ export async function getCampaignDetails(
       ? {
           ...(pivot.govsgTemplate.toJSON() as any), // any to get around the snake vs camel casing difference between TS type and actual db table field
           for_single_recipient: pivot.forSingleRecipient,
-          languages: pivot.govsgTemplate.multilingualSupport,
+          languages: pivot.govsgTemplate.multilingualSupport.map(
+            (languageSupport) => ({
+              ...languageSupport,
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              code: languageSupport.language_code,
+            })
+          ),
         }
       : undefined,
   }

--- a/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
@@ -157,7 +157,7 @@ function GovsgPickTemplate({
                     shouldHighlightVariables
                     preview
                   />
-                  {canAccessGovsgV && t.languages.length > 0 && (
+                  {canAccessGovsgV && (
                     <LanguageChipGroup
                       options={t.languages.map((languageSupport) =>
                         languageSupport.language.toLowerCase()

--- a/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
@@ -1,7 +1,5 @@
 import { WhatsAppLanguages } from '@shared/clients/whatsapp-client.class/types'
 
-import { capitalize } from 'lodash'
-
 import { Dispatch, SetStateAction, useContext, useState } from 'react'
 
 import { useParams } from 'react-router-dom'
@@ -139,12 +137,14 @@ const GovsgSingleRecipient = ({
             </p>
             {typedCampaign.languages.map((languageSupport) => {
               const language = languageSupport.language
-              const label = capitalize(language)
+              const languageInLowerCase = language.toLowerCase()
               const languageCode =
-                WhatsAppLanguages[language as keyof typeof WhatsAppLanguages]
+                WhatsAppLanguages[
+                  languageInLowerCase as keyof typeof WhatsAppLanguages
+                ]
               return (
                 <SimpleRadioButton
-                  aria-label={label}
+                  aria-label={language}
                   id={`language-${language}`}
                   value={languageCode}
                   checked={data.languageCode === languageCode}
@@ -154,7 +154,7 @@ const GovsgSingleRecipient = ({
                       languageCode,
                     })
                   }
-                  label={label}
+                  label={language}
                   key={language}
                 />
               )

--- a/frontend/src/components/dashboard/create/govsg/RadioChoice.tsx
+++ b/frontend/src/components/dashboard/create/govsg/RadioChoice.tsx
@@ -25,7 +25,7 @@ function RadioChoice({
         <input type="radio" id={id} {...rest} onChange={onChange} />
         <label htmlFor={id}>{label}</label>
       </div>
-      {rest.checked && children && (
+      {rest.checked && children && children.length > 0 && (
         <div className={styles.body}>{children[0]}</div>
       )}
       {rest.checked && children && children.length > 1 && (


### PR DESCRIPTION
### refactor: remove redundant length check

This length check was originally needed because we show either 0 or 4 lang chips. Now, we check the `languages` array to know what to render.

### fix: update capitalisation due to smart lang chips

The values passed around have changed a bit due to this refactor. This commit handles the aftermath that was previously undetected.

### fix: make getCampaignDetails return code instead of language_code

With the current set of PRs, coming back to an existing Draft campaign and selecting the language will lead to a crash because I did not make `getCampaignDetails` return `code` instead of `language_code`.

### fix: add missing length check

`rest.checked && children` alone is not enough to say there is at least 1 child in the array. This is because `[]` is truthy. Added a length check. Kudos to @KishenKumarrrrr for catching this.