### PR TITLE
refactor: rename and hide language param

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -58,6 +58,8 @@ export const listMessages = async (
       recipient_name,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       officer_designation,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      language,
       ...remainingParams
     } = row.params as Record<string, string>
     return {

--- a/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
@@ -51,7 +51,7 @@ const GovsgSingleRecipient = ({
   const [data, setData] = useState<Record<string, string>>(
     fieldsToRender.reduce((cul, f) => ({ [f.id]: '', ...cul }), {
       recipient: '',
-      languageCode: WhatsAppLanguages.english,
+      language: WhatsAppLanguages.english,
     })
   )
   const { id: campaignId } = useParams<{ id: string }>()
@@ -66,7 +66,7 @@ const GovsgSingleRecipient = ({
     return hydrateTemplate(
       getLocalisedTemplateBody(
         typedCampaign.languages,
-        data.languageCode,
+        data.language,
         typedCampaign.body
       ),
       Object.assign(
@@ -147,11 +147,11 @@ const GovsgSingleRecipient = ({
                   aria-label={language}
                   id={`language-${language}`}
                   value={languageCode}
-                  checked={data.languageCode === languageCode}
+                  checked={data.language === languageCode}
                   onChange={() =>
                     setData({
                       ...data,
-                      languageCode,
+                      language: languageCode,
                     })
                   }
                   label={language}

--- a/frontend/src/services/govsg.service.ts
+++ b/frontend/src/services/govsg.service.ts
@@ -58,7 +58,7 @@ export async function sendSingleRecipientCampaign(
 ): Promise<void> {
   await axios.post(`/campaign/${campaignId}/govsg/send-single`, {
     recipient: params.recipient,
-    language_code: params.languageCode,
+    language_code: params.language,
     params,
   })
 }


### PR DESCRIPTION
## Problem

Two problems:

### Inconsistency in the param field name for language code

In bulk send, the param field name for language code is `language`. Refer to the sample csv file. But in single send, the param field name for language code is `languageCode`.

Not ideal because the govsg messages frontend table will show `language` for bulk send and `languageCode` for single send. Plus, in the db, `params` has both snake case (e.g. `officer_name` ) and camel case (e.g. `languageCode`) field names.

This PR standardises the param field name for language code to just `language`.

### Should hide the language from params in the govsg messages table 

Why:

- Leaving the code as-is would give a poor UX. I put in a small amount of time to see if I could expand the height of the table row but I have not been successful yet.
    - Poor UX: Table row is too squeezy for showing the language, see screenshot
- Original screen does not have this. We may want to render this in a column of its own. But given there are other more important tasks at hand, we hide this param first.
    - Poor UX: For single send, the language value is pre-populated by the radio button but for bulk, the language value is the raw value provided by the user.

## Screenshots

### Before

#### Single send
![Screenshot 2023-08-14 at 9 54 10 AM](https://github.com/opengovsg/postmangovsg/assets/14961285/c1b0f99f-a31e-48a7-9c32-1c00545c97e3)

#### Bulk send
![Screenshot 2023-08-14 at 9 54 30 AM](https://github.com/opengovsg/postmangovsg/assets/14961285/a841e9af-867d-415e-a357-c0db5312fea1)

### After

#### Both
![Screenshot 2023-08-14 at 9 54 44 AM](https://github.com/opengovsg/postmangovsg/assets/14961285/cde61d45-bb57-4d72-957b-3a378279110f)
