### PR TITLE
feat: allow user-specified default params in sample csv

### DIFF
--- a/frontend/src/components/common/sample-csv/SampleCsv.tsx
+++ b/frontend/src/components/common/sample-csv/SampleCsv.tsx
@@ -1,5 +1,5 @@
 import download from 'downloadjs'
-import { without, times, constant } from 'lodash'
+import { without } from 'lodash'
 
 import TextButton from '../text-button'
 
@@ -14,12 +14,14 @@ import {
 const SampleCsv = ({
   defaultRecipient,
   params,
+  defaultParams,
   template,
   protect = false,
   setErrorMsg,
 }: {
   defaultRecipient: string
   params?: Array<string>
+  defaultParams?: Record<string, string>
   template?: string
   protect?: boolean
   setErrorMsg?: (message: string | null) => void
@@ -39,11 +41,19 @@ const SampleCsv = ({
         ...without(variableHeaders, ...fixedHeaders),
       ]
 
+      const variableRow = Array(headers.length - 1).fill('abc')
+      if (params && defaultParams) {
+        for (const key in defaultParams) {
+          const indexInVariableRow = params.findIndex((param) => param === key)
+          if (indexInVariableRow < 0) {
+            continue
+          }
+          variableRow[indexInVariableRow] = defaultParams[key]
+        }
+      }
+
       // Set default recipient as first value and pad with placeholder
-      const body = [
-        defaultRecipient,
-        ...times(headers.length - 1, constant('abc')),
-      ]
+      const body = [defaultRecipient, ...variableRow]
 
       const content = [`${headers.join(',')}`, `${body.join(',')}`].join('\r\n')
 

--- a/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
@@ -187,6 +187,7 @@ const GovsgRecipients = ({
           <p>or</p>
           <SampleCsv
             params={canAccessGovsgV ? ['language', ...params] : params}
+            defaultParams={{ language: 'English' }}
             defaultRecipient="81234567"
             setErrorMsg={console.error}
           />


### PR DESCRIPTION
## Problem

Closes [SGC-197](https://linear.app/ogp/issue/SGC-197/set-default-language-in-bulk-send-csv-to-english)

## Solution

Create an optional `defaultParams` prop for `SampleCsv`.
