### PR TITLE
feat: hide passcode until MOP clicks

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -45,7 +45,7 @@ export const listMessages = async (
     include: [
       {
         model: GovsgVerification,
-        attributes: ['passcode'],
+        attributes: ['passcode', 'userClickedAt'],
       },
     ],
   })
@@ -65,7 +65,9 @@ export const listMessages = async (
       name: recipient_name,
       mobile: recipient,
       data: JSON.stringify(remainingParams),
-      passcode: row.govsgVerification?.passcode ?? '',
+      passcode: row.govsgVerification?.userClickedAt
+        ? row.govsgVerification.passcode
+        : '',
       sent: row.sentAt,
       officer: officer_name,
     }


### PR DESCRIPTION
## Problem

We want to hide the passcode from the govt officer until the MOP clicks/taps the `Create passcode` button.

Closes [SGC-192](https://linear.app/ogp/issue/SGC-192/hide-passcode-from-officer-until-user-clicks-create-passcode)

## Screenshots

### Before
<img width="1510" alt="Screenshot 2023-08-14 at 5 50 48 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/fae0dbba-01b6-4a7a-9853-a57d326849ff">

### After 
<img width="1510" alt="Screenshot 2023-08-14 at 5 49 51 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/84250ea7-3087-423e-bfe1-ffc2e3ac70d3">
