### PR TITLE
feat: disable resend until delivered

### DIFF
--- a/frontend/src/components/common/action-button/ResendButton.tsx
+++ b/frontend/src/components/common/action-button/ResendButton.tsx
@@ -1,13 +1,35 @@
+import Tooltip from '../tooltip/Tooltip'
+
 import { ActionButton } from 'components/common'
 
 interface ResendButtonProps {
   onClick: () => void
+  disabled?: boolean
 }
 
-export const ResendButton = ({ onClick }: ResendButtonProps) => {
+const resendButtonStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+}
+
+export const ResendButton = ({ onClick, disabled }: ResendButtonProps) => {
+  const renderTooltip = () => {
+    return (
+      <div style={{ visibility: disabled ? 'visible' : 'hidden' }}>
+        <Tooltip text="Unable to resend passcode creation because the initial message has not reached the recipient's phone. Contact us if this problem persists.">
+          <i className="bx bxs-help-circle"></i>
+        </Tooltip>
+      </div>
+    )
+  }
+
   return (
-    <ActionButton onClick={onClick}>
-      <span>RESEND</span>
-    </ActionButton>
+    <div style={resendButtonStyle}>
+      {renderTooltip()}
+      <ActionButton onClick={onClick} disabled={disabled}>
+        <span>RESEND</span>
+      </ActionButton>
+    </div>
   )
 }

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -105,6 +105,11 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     await fetchGovsgMessages(newSearch, 0)
   }
 
+  const statusesWhichAllowResend = new Set(['DELIVERED', 'READ'])
+  const shouldDisableResend = (status: string) => {
+    return !statusesWhichAllowResend.has(status)
+  }
+
   const columns = [
     {
       name: 'RECIPIENT NAME',
@@ -198,7 +203,12 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     {
       name: 'ACTION',
       render: (govsgMessage: GovsgMessage) => {
-        return <ResendButton onClick={() => openModal(govsgMessage)} />
+        return (
+          <ResendButton
+            onClick={() => openModal(govsgMessage)}
+            disabled={shouldDisableResend(govsgMessage.status)}
+          />
+        )
       },
       width: 'xs',
       renderHeader: (name: string, width: string, key: number) => (


### PR DESCRIPTION
## Problem

We want to disable to Resend button when the pre-call notification message has not reached the recipient's phone. We also add a tooltip to explain why the button was disabled.

Closes [SGC-194](https://linear.app/ogp/issue/SGC-194/disable-resend-button-when-msg-not-delivered-with-tooltip-explaining)

## Screenshots

### Before
<img width="1510" alt="Screenshot 2023-08-14 at 6 37 16 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/2d0183c7-8f7c-4a84-94b5-bd69615e3663">

### After
<img width="1510" alt="Screenshot 2023-08-14 at 6 35 13 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/3ba853dc-c900-44ce-9d5c-0d30a5a0a41d">
