### PR TITLE
fix: statistics table bug for govsg

### DIFF
--- a/backend/src/core/services/stats.service.ts
+++ b/backend/src/core/services/stats.service.ts
@@ -54,8 +54,10 @@ const getStatsFromArchive = async (
  * @param campaignId
  */
 const getNumRecipients = async (campaignId: number): Promise<number> => {
-  const { error, unsent, sent, invalid } = await getStatsFromArchive(campaignId)
-  return error + unsent + sent + invalid
+  const { error, unsent, sent, invalid, delivered } = await getStatsFromArchive(
+    campaignId
+  )
+  return error + unsent + sent + invalid + (delivered ?? 0)
 }
 
 /**


### PR DESCRIPTION
## Problem

When a `Gov.sg` whatsapp campaign is sent, the total messages displayed on the `Report` tab will always be 0. 

Closes [SGC-172](https://linear.app/ogp/issue/SGC-172/fix-0-instead-of-1-messages-sent)

## Solution

WhatsApp messages make use of a `delivered` column in the DB that was excluded from the `getNumRecipients` function. I have ensured that the `delivered` variable gets used in the calculation.

## Before & After Screenshots

**BEFORE**:
<img width="746" alt="Screenshot 2023-08-15 at 11 18 40 AM" src="https://github.com/opengovsg/postmangovsg/assets/53511604/f36bc81b-3297-4b68-b04b-18148abbcfe7">

**AFTER**:
<img width="727" alt="Screenshot 2023-08-15 at 11 18 11 AM" src="https://github.com/opengovsg/postmangovsg/assets/53511604/62a02029-b517-47c5-b340-4090864f2b8a">

## Deployment Checklist

N/A