### PR TITLE
Fix/statistics table bug

### DIFF
--- a/backend/src/core/services/campaign.service.ts
+++ b/backend/src/core/services/campaign.service.ts
@@ -353,7 +353,10 @@ const getCampaignDetails = async (
       ],
       [
         literal(
-          'Statistic.unsent + Statistic.sent + Statistic.errored + Statistic.invalid'
+          // 'Statistic.unsent + Statistic.sent + Statistic.errored + Statistic.invalid'
+          `CASE WHEN Statistic.delivered IS NOT NULL ` +
+            `THEN Statistic.unsent + Statistic.sent + Statistic.errored + Statistic.invalid + Statistic.delivered ` +
+            `ELSE Statistic.unsent + Statistic.sent + Statistic.errored + Statistic.invalid END`
         ),
         'num_recipients',
       ],


### PR DESCRIPTION
## Problem

When a `Gov.sg` whatsapp campaign is sent, the total messages displayed on the `Report` tab will always be 0. 

Closes [SGC-172](https://linear.app/ogp/issue/SGC-172/fix-0-instead-of-1-messages-sent)

## Solution

WhatsApp messages make use of a `delivered` column in the DB that was excluded from the `getNumRecipients` function. I have ensured that the `delivered` variable gets used in the calculation.

Additionally, I've updated the `getCampaignDetails` in `campaign.service.ts` to reflect the correct `num_recipients` calculation for campaigns

## Before & After Screenshots

**BEFORE**:
<img width="746" alt="Screenshot 2023-08-15 at 11 18 40 AM" src="https://github.com/opengovsg/postmangovsg/assets/53511604/f36bc81b-3297-4b68-b04b-18148abbcfe7">

**AFTER**:
<img width="727" alt="Screenshot 2023-08-15 at 11 18 11 AM" src="https://github.com/opengovsg/postmangovsg/assets/53511604/62a02029-b517-47c5-b340-4090864f2b8a">

## Deployment Checklist

N/A