### PR TITLE
fix(backend): account message.eventType for blacklisting emails

### DIFF
--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -199,7 +199,7 @@ const validateRecord = async (
   }
 }
 const blacklistIfNeeded = async (message: any): Promise<void> => {
-  const notificationType = message?.notificationType // should this be message?.notificationType || message?.eventType?
+  const notificationType = message?.notificationType || message?.eventType
   const bounceType = message?.bounce?.bounceType
   const complaintType = message?.complaint?.complaintFeedbackType
 


### PR DESCRIPTION
## Problem

We switched to using only events from SNS instead of native events from SES. There's a discrepancy which is the prior one uses `eventType` field name while the latter uses `notiticationType`

## Solution

Use both fields to determine the notification type in blacklisting

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- N/A