### PR TITLE
(PR 2) fix: create passcode only if using precall template

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -70,18 +70,10 @@ export const listMessages = async (
       officer: officer_name,
     }
   })
-  if (count > 0) {
-    const row = rows[0]
-    return res.json({
-      messages,
-      total_count: count,
-      has_passcode: !!row.govsgVerification?.passcode,
-    })
-  }
   return res.json({
     messages,
     total_count: count,
-    has_passcode: false,
+    has_passcode: !!rows[0]?.govsgVerification?.passcode,
   })
 }
 

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -65,7 +65,7 @@ export const listMessages = async (
       name: recipient_name,
       mobile: recipient,
       data: JSON.stringify(remainingParams),
-      passcode: row.govsgVerification.passcode,
+      passcode: row.govsgVerification?.passcode,
       sent: row.sentAt,
       officer: officer_name,
     }

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -70,9 +70,18 @@ export const listMessages = async (
       officer: officer_name,
     }
   })
+  if (count > 0) {
+    const row = rows[0]
+    return res.json({
+      messages,
+      total_count: count,
+      has_passcode: !!row.govsgVerification?.passcode,
+    })
+  }
   return res.json({
     messages,
     total_count: count,
+    has_passcode: false,
   })
 }
 

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -140,7 +140,7 @@ const getLanguageCode = (language: string | undefined) => {
   return WhatsAppLanguages[key as keyof typeof WhatsAppLanguages]
 }
 
-const isUsingPrecallTemplate = async (govsgMessage: GovsgMessage) => {
+const isTemplateWithPasscode = async (govsgMessage: GovsgMessage) => {
   const campaignId = govsgMessage.campaignId
   const campaignGovsgTemplate = await CampaignGovsgTemplate.findOne({
     where: {
@@ -210,7 +210,7 @@ export function uploadCompleteOnChunk({
     }
     // All govsg messages grouped in bulk-send use the same message template, so it is enough to check isUsingPrecallTemplate on any one message.
     const govsgMessage = govsgMessages[0]
-    const shouldHavePasscode = await isUsingPrecallTemplate(govsgMessage)
+    const shouldHavePasscode = await isTemplateWithPasscode(govsgMessage)
     if (shouldHavePasscode) {
       await GovsgVerification.bulkCreate(
         govsgMessages.map(
@@ -260,7 +260,7 @@ export async function processSingleRecipientCampaign(
       } as GovsgMessage,
       { transaction, returning: true }
     )
-    const shouldHavePasscode = await isUsingPrecallTemplate(govsgMessage)
+    const shouldHavePasscode = await isTemplateWithPasscode(govsgMessage)
     if (shouldHavePasscode) {
       await GovsgVerification.create(
         {

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -208,7 +208,7 @@ export function uploadCompleteOnChunk({
     if (!govsgMessages.length) {
       return
     }
-    // All govsg messages grouped in bulk-send use the same message template, so it is enough to check isUsingPrecallTemplate on any one message.
+    // All govsg messages grouped in bulk-send use the same message template, so it is enough to check isTemplateWithPasscode on any one message.
     const govsgMessage = govsgMessages[0]
     const shouldHavePasscode = await isTemplateWithPasscode(govsgMessage)
     if (shouldHavePasscode) {

--- a/frontend/src/components/common/action-button/ResendButton.tsx
+++ b/frontend/src/components/common/action-button/ResendButton.tsx
@@ -17,7 +17,7 @@ export const ResendButton = ({ onClick, disabled }: ResendButtonProps) => {
   const renderTooltip = () => {
     return (
       <div style={{ visibility: disabled ? 'visible' : 'hidden' }}>
-        <Tooltip text="Unable to resend passcode creation because the initial message has not reached the recipient's phone. Contact us if this problem persists.">
+        <Tooltip text="Resend is not applicable to this message template.">
           <i className="bx bxs-help-circle"></i>
         </Tooltip>
       </div>

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -53,6 +53,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   const [search, setSearch] = useState('')
   const [selectedPage, setSelectedPage] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [shouldHavePasscode, setShouldHavePasscode] = useState(false)
   const modalContext = useContext(ModalContext)
 
   const fetchGovsgMessages = async (search: string, selectedPage: number) => {
@@ -67,10 +68,15 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         ...options,
       },
     })
-    const { messages: govsgMessages, total_count: totalCount } = response.data
+    const {
+      messages: govsgMessages,
+      total_count: totalCount,
+      has_passcode: hasPasscode,
+    } = response.data
     setGovsgMessageCount(totalCount)
     setGovsgMessagesDisplayed(govsgMessages)
     setSelectedPage(selectedPage)
+    setShouldHavePasscode(hasPasscode)
   }
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -118,6 +124,25 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     return !govsgMessage.passcode
   }
 
+  const passcodeColumn = shouldHavePasscode
+    ? [
+        {
+          name: 'PASSCODE',
+          render: (govsgMessage: GovsgMessage) => {
+            return (
+              <PasscodeBadge label={govsgMessage.passcode} placeholder="N/A" />
+            )
+          },
+          width: 'xs',
+          renderHeader: (name: string, width: string, key: number) => (
+            <th className={width} key={key}>
+              {name}
+            </th>
+          ),
+        },
+      ]
+    : []
+
   const columns = [
     {
       name: 'RECIPIENT NAME',
@@ -152,18 +177,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         </th>
       ),
     },
-    {
-      name: 'PASSCODE',
-      render: (govsgMessage: GovsgMessage) => {
-        return <PasscodeBadge label={govsgMessage.passcode} placeholder="N/A" />
-      },
-      width: 'xs',
-      renderHeader: (name: string, width: string, key: number) => (
-        <th className={width} key={key}>
-          {name}
-        </th>
-      ),
-    },
+    ...passcodeColumn,
     {
       name: 'STATUS',
       render: (govsgMessage: GovsgMessage) => {

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -170,7 +170,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         const json = JSON.parse(govsgMessage.data)
         return <PrettyJson json={json} />
       },
-      width: 'md',
+      width: 'sm',
       renderHeader: (name: string, width: string, key: number) => (
         <th className={width} key={key}>
           {name}
@@ -200,7 +200,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         ) : (
           <span></span>
         ),
-      width: 'sm',
+      width: 'xs',
       renderHeader: (name: string, width: string, key: number) => (
         <th className={width} key={key}>
           {name}

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -114,9 +114,8 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     await searchGovsgMessages(newSearch, 0)
   }
 
-  const statusesWhichAllowResend = new Set(['DELIVERED', 'READ'])
-  const shouldDisableResend = (status: string) => {
-    return !statusesWhichAllowResend.has(status)
+  const shouldDisableResend = (govsgMessage: GovsgMessage) => {
+    return !govsgMessage.passcode
   }
 
   const columns = [
@@ -156,12 +155,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     {
       name: 'PASSCODE',
       render: (govsgMessage: GovsgMessage) => {
-        return (
-          <PasscodeBadge
-            label={govsgMessage.passcode}
-            placeholder="Not created yet"
-          />
-        )
+        return <PasscodeBadge label={govsgMessage.passcode} placeholder="N/A" />
       },
       width: 'xs',
       renderHeader: (name: string, width: string, key: number) => (
@@ -215,7 +209,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
         return (
           <ResendButton
             onClick={() => openModal(govsgMessage)}
-            disabled={shouldDisableResend(govsgMessage.status)}
+            disabled={shouldDisableResend(govsgMessage)}
           />
         )
       },

--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -114,7 +114,7 @@ table {
   tr {
     @include flex-horizontal;
     border-bottom: 1px solid adjust-color($primary-light, $alpha: -0.5);
-    height: $height-3;
+    min-height: $height-3;
 
     td,
     th {


### PR DESCRIPTION
## Problem

We should run passcode functionality and show passcode only if the message template is a pre-call template.

Closes [SGC-213](https://linear.app/ogp/issue/SGC-213/add-missed-call-and-house-visit-templates)

## Solution

- [x] Add if-condition before every creation of `GovsgVerification`
- [x] Change absent passcode text to `N/A`
- [x] Hide passcode column if the message template used is not a pre-call template
- [x] Temporarily disable Resend button for non-pre-call template messages

### Other improvements

- [x] Change `tr height` to `tr min-height` so that the message data column can expand vertically and we don't break other existing tables relying on `tr height`. Out-of-scope for this PR: Handling horizontal overflow

## Screenshots
<img width="1510" alt="Screenshot 2023-08-18 at 10 17 14 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/2b9a112d-a3e4-4546-a203-0a2c96624aa7">
