### PR TITLE
(PR 3) feat: implement click to reveal passcode

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -128,3 +128,18 @@ export const resendPasscodeCreationMessage = async (
     passcode_creation_wamid: passcodeCreationWamid,
   })
 }
+
+export const trackPasscodeReveal = async (
+  req: Request,
+  res: Response
+): Promise<Response | void> => {
+  const { govsg_message_id: govsgMessageId } = req.body
+  const userClickedAt = new Date()
+  await GovsgVerification.update(
+    { userClickedAt },
+    { where: { govsgMessageId } }
+  )
+  return res.json({
+    user_clicked_at: userClickedAt,
+  })
+}

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -70,6 +70,14 @@ export const listMessages = async (
       officer: officer_name,
     }
   })
+  if (count > 0) {
+    const row = rows[0]
+    return res.json({
+      messages,
+      total_count: count,
+      has_passcode: !!row.govsgVerification?.passcode,
+    })
+  }
   return res.json({
     messages,
     total_count: count,

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -137,7 +137,14 @@ export const trackPasscodeReveal = async (
   const userClickedAt = new Date()
   await GovsgVerification.update(
     { userClickedAt },
-    { where: { govsgMessageId } }
+    {
+      where: {
+        govsgMessageId,
+        userClickedAt: {
+          [Op.eq]: null,
+        },
+      },
+    }
   )
   return res.json({
     user_clicked_at: userClickedAt,

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -147,6 +147,6 @@ export const trackPasscodeReveal = async (
     }
   )
   return res.json({
-    user_clicked_at: userClickedAt,
+    govsg_message_id: govsgMessageId,
   })
 }

--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -70,14 +70,6 @@ export const listMessages = async (
       officer: officer_name,
     }
   })
-  if (count > 0) {
-    const row = rows[0]
-    return res.json({
-      messages,
-      total_count: count,
-      has_passcode: !!row.govsgVerification?.passcode,
-    })
-  }
   return res.json({
     messages,
     total_count: count,

--- a/backend/src/govsg/routes/govsg-campaign.routes.ts
+++ b/backend/src/govsg/routes/govsg-campaign.routes.ts
@@ -152,4 +152,14 @@ router.post(
   GovsgVerificationMiddleware.resendPasscodeCreationMessage
 )
 
+router.post(
+  '/track-passcode-reveal',
+  celebrate({
+    [Segments.BODY]: {
+      govsg_message_id: Joi.string().required(),
+    },
+  }),
+  GovsgVerificationMiddleware.trackPasscodeReveal
+)
+
 export default router

--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -385,16 +385,11 @@ const parseUserMessageWebhook = async (
   clientId: WhatsAppApiClient
 ): Promise<void> => {
   const { wa_id: whatsappId } = body.contacts[0]
-  const { id: messageId, type, timestamp } = body.messages[0]
-  const timestampAsDate = new Date(parseInt(timestamp, 10) * 1000) // convert to milliseconds
+  const { id: messageId, type } = body.messages[0]
   if (type === WhatsappWebhookMessageType.button) {
     const message = body.messages[0] as WhatsAppWebhookButtonMessage
     if (message.button.text === 'Create passcode') {
       const passcodeCreationWamid = message.context.id
-      await GovsgVerification.update(
-        { userClickedAt: timestampAsDate },
-        { where: { passcodeCreationWamid } }
-      )
       const govsgVerification = await GovsgVerification.findOne({
         where: { passcodeCreationWamid },
         include: [GovsgMessage],

--- a/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
@@ -1,6 +1,14 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
 
+details > summary {
+  list-style: none;
+}
+
+details[open] > summary {
+  display: none;
+}
+
 .positive {
   background-color: $grey-300;
   border-radius: 8px;

--- a/frontend/src/components/common/StyledText/PasscodeBadge.tsx
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.tsx
@@ -5,16 +5,17 @@ import styles from './PasscodeBadge.module.scss'
 interface PasscodeBadgeProps {
   label: string
   placeholder: string
+  onClick: () => void
 }
 
-export const PasscodeBadge = ({ label, placeholder }: PasscodeBadgeProps) => {
-  const logOnClick = () => {
-    // TODO: Log click
-  }
-
+export const PasscodeBadge = ({
+  label,
+  placeholder,
+  onClick,
+}: PasscodeBadgeProps) => {
   return (
     <details>
-      <summary onClick={logOnClick}>Click to reveal</summary>
+      <summary onClick={onClick}>Click to reveal</summary>
       <span className={label ? cx(styles.positive) : cx(styles.negative)}>
         {label ? label : placeholder}
       </span>

--- a/frontend/src/components/common/StyledText/PasscodeBadge.tsx
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.tsx
@@ -8,9 +8,16 @@ interface PasscodeBadgeProps {
 }
 
 export const PasscodeBadge = ({ label, placeholder }: PasscodeBadgeProps) => {
+  const logOnClick = () => {
+    // TODO: Log click
+  }
+
   return (
-    <span className={label ? cx(styles.positive) : cx(styles.negative)}>
-      {label ? label : placeholder}
-    </span>
+    <details>
+      <summary onClick={logOnClick}>Click to reveal</summary>
+      <span className={label ? cx(styles.positive) : cx(styles.negative)}>
+        {label ? label : placeholder}
+      </span>
+    </details>
   )
 }

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -120,6 +120,15 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     await searchGovsgMessages(newSearch, 0)
   }
 
+  const trackPasscodeReveal = useCallback(
+    async (govsgMessage: GovsgMessage) => {
+      await axios.post(`/campaign/${campaignId}/govsg/track-passcode-reveal`, {
+        govsg_message_id: govsgMessage.id,
+      })
+    },
+    []
+  )
+
   const shouldDisableResend = (govsgMessage: GovsgMessage) => {
     return !govsgMessage.passcode
   }
@@ -130,7 +139,11 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
           name: 'PASSCODE',
           render: (govsgMessage: GovsgMessage) => {
             return (
-              <PasscodeBadge label={govsgMessage.passcode} placeholder="N/A" />
+              <PasscodeBadge
+                label={govsgMessage.passcode}
+                placeholder="N/A"
+                onClick={async () => await trackPasscodeReveal(govsgMessage)}
+              />
             )
           },
           width: 'xs',


### PR DESCRIPTION
## Problem

We want to track officer's usage of passcode. We do this by prompting them to Click to reveal passcode.

Closes [SGC-214](https://linear.app/ogp/issue/SGC-214/make-passcode-click-to-reveal-and-log-click-events)

And [SGC-215](https://linear.app/ogp/issue/SGC-215/remove-officer-verification-button) (see #2189)

## Solution

- Leveraging the `details` HTML element ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details))

## Notes

cursor not set to pointer when hovering over Click to reveal. This will be done in a separate PR.