### PR TITLE
(PR 4) feat: replace passcode button with passcode in first message

### DIFF
--- a/backend/src/govsg/routes/govsg-campaign.routes.ts
+++ b/backend/src/govsg/routes/govsg-campaign.routes.ts
@@ -143,13 +143,13 @@ router.get(
 )
 
 router.post(
-  '/resend-passcode-creation',
+  '/resend',
   celebrate({
     [Segments.BODY]: {
       govsg_message_id: Joi.string().required(),
     },
   }),
-  GovsgVerificationMiddleware.resendPasscodeCreationMessage
+  GovsgVerificationMiddleware.resendMessage
 )
 
 router.post(

--- a/backend/src/govsg/services/govsg-verification-service.ts
+++ b/backend/src/govsg/services/govsg-verification-service.ts
@@ -1,13 +1,8 @@
 import config from '@core/config'
 import { whatsappService } from '@core/services'
-import { GovsgMessage, GovsgVerification } from '@govsg/models'
-import { createPasscode } from '@govsg/utils/passcode'
 import {
-  WhatsAppId,
-  WhatsAppApiClient,
   MessageId,
   WhatsAppTemplateMessageToSend,
-  WhatsAppLanguages,
 } from '@shared/clients/whatsapp-client.class/types'
 
 export const sendMessage = async (
@@ -19,82 +14,4 @@ export const sendMessage = async (
     isLocal
   )
   return wamid
-}
-
-// TODO: Remove
-export const sendPasscodeCreationMessage = async (
-  whatsappId: WhatsAppId,
-  clientId: WhatsAppApiClient
-): Promise<MessageId> => {
-  const templateMessageToSend: WhatsAppTemplateMessageToSend = {
-    recipient: whatsappId,
-    apiClient: clientId,
-    templateName: 'sgc_passcode_generation', // TODO: Un-hardcode this
-    params: [],
-    language: WhatsAppLanguages.english,
-  }
-  const isLocal = config.get('env') === 'development'
-  const passcodeCreationWamid =
-    await whatsappService.whatsappClient.sendTemplateMessage(
-      templateMessageToSend,
-      isLocal
-    )
-  return passcodeCreationWamid
-}
-
-// TODO: Remove
-export const storePrecreatedPasscode = async (
-  govsgMessageId: GovsgMessage['id'],
-  passcodeCreationWamid: MessageId
-): Promise<GovsgVerification> => {
-  const govsgVerification = await GovsgVerification.findOne({
-    where: { govsgMessageId },
-  })
-  if (!govsgVerification) {
-    return await GovsgVerification.create({
-      govsgMessageId,
-      passcodeCreationWamid,
-      passcode: createPasscode(),
-    } as GovsgVerification)
-  }
-  return await govsgVerification.update({
-    passcodeCreationWamid,
-  })
-}
-
-// TODO: Remove
-export const sendPasscodeMessage = async (
-  whatsappId: WhatsAppId,
-  clientId: WhatsAppApiClient,
-  officerName: string,
-  officerAgency: string,
-  passcode: string
-): Promise<MessageId> => {
-  const templateMessageToSend: WhatsAppTemplateMessageToSend = {
-    recipient: whatsappId,
-    apiClient: clientId,
-    templateName: 'sgc_send_passcode', // TODO: Un-hardcode this
-    params: [
-      {
-        type: 'text',
-        text: officerName,
-      },
-      {
-        type: 'text',
-        text: officerAgency,
-      },
-      {
-        type: 'text',
-        text: passcode,
-      },
-    ],
-    language: WhatsAppLanguages.english,
-  }
-  const isLocal = config.get('env') === 'development'
-  const passcodeCreationWamid =
-    await whatsappService.whatsappClient.sendTemplateMessage(
-      templateMessageToSend,
-      isLocal
-    )
-  return passcodeCreationWamid
 }

--- a/backend/src/govsg/services/govsg-verification-service.ts
+++ b/backend/src/govsg/services/govsg-verification-service.ts
@@ -10,6 +10,18 @@ import {
   WhatsAppLanguages,
 } from '@shared/clients/whatsapp-client.class/types'
 
+export const sendMessage = async (
+  templateMessageToSend: WhatsAppTemplateMessageToSend
+): Promise<MessageId> => {
+  const isLocal = config.get('env') === 'development'
+  const wamid = await whatsappService.whatsappClient.sendTemplateMessage(
+    templateMessageToSend,
+    isLocal
+  )
+  return wamid
+}
+
+// TODO: Remove
 export const sendPasscodeCreationMessage = async (
   whatsappId: WhatsAppId,
   clientId: WhatsAppApiClient
@@ -30,6 +42,7 @@ export const sendPasscodeCreationMessage = async (
   return passcodeCreationWamid
 }
 
+// TODO: Remove
 export const storePrecreatedPasscode = async (
   govsgMessageId: GovsgMessage['id'],
   passcodeCreationWamid: MessageId
@@ -49,6 +62,7 @@ export const storePrecreatedPasscode = async (
   })
 }
 
+// TODO: Remove
 export const sendPasscodeMessage = async (
   whatsappId: WhatsAppId,
   clientId: WhatsAppApiClient,

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -111,11 +111,18 @@ export function uploadCompleteOnPreview({
   campaignId: number
 }): (data: CSVParams[]) => Promise<void> {
   return async function (data: CSVParams[]): Promise<void> {
+    const paramsWithoutPasscode = template.params!.filter(
+      (param) => param !== 'passcode'
+    ) // TODO: Un-hardcode this
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    UploadService.checkTemplateKeysMatch(data, template.params!)
+    UploadService.checkTemplateKeysMatch(data, paramsWithoutPasscode)
 
+    const testDataWithPasscodePlaceholder = {
+      ...data[0],
+      ['passcode' as string]: '(random 4-digit passcode)',
+    }
     GovsgTemplateService.testHydration(
-      [{ params: data[0] }],
+      [{ params: testDataWithPasscodePlaceholder }],
       template.body as string
     )
     await GovsgMessage.destroy({
@@ -178,10 +185,14 @@ export function uploadCompleteOnChunk({
         )
       }
       recipients.add(recipient)
+      const paramsWithPasscode = {
+        ...entry,
+        passcode: createPasscode(),
+      }
       return {
         campaignId,
         recipient: recipient,
-        params: entry,
+        params: paramsWithPasscode,
         languageCode: getLanguageCode(entry.language),
       }
     })
@@ -218,7 +229,9 @@ export function uploadCompleteOnChunk({
           (message) =>
             ({
               govsgMessageId: message.id,
-              passcode: createPasscode(),
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore
+              passcode: message.params.passcode,
             } as GovsgVerification)
         ),
         { transaction }

--- a/frontend/src/components/common/action-button/ResendButton.tsx
+++ b/frontend/src/components/common/action-button/ResendButton.tsx
@@ -1,5 +1,3 @@
-import Tooltip from '../tooltip/Tooltip'
-
 import { ActionButton } from 'components/common'
 
 interface ResendButtonProps {
@@ -14,19 +12,8 @@ const resendButtonStyle = {
 }
 
 export const ResendButton = ({ onClick, disabled }: ResendButtonProps) => {
-  const renderTooltip = () => {
-    return (
-      <div style={{ visibility: disabled ? 'visible' : 'hidden' }}>
-        <Tooltip text="Resend is not applicable to this message template.">
-          <i className="bx bxs-help-circle"></i>
-        </Tooltip>
-      </div>
-    )
-  }
-
   return (
     <div style={resendButtonStyle}>
-      {renderTooltip()}
       <ActionButton onClick={onClick} disabled={disabled}>
         <span>RESEND</span>
       </ActionButton>

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -88,7 +88,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
   )
 
   const onModalConfirm = async (govsgMessage: GovsgMessage) => {
-    await axios.post(`/campaign/${campaignId}/govsg/resend-passcode-creation`, {
+    await axios.post(`/campaign/${campaignId}/govsg/resend`, {
       govsg_message_id: govsgMessage.id,
     })
   }
@@ -128,10 +128,6 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     },
     []
   )
-
-  const shouldDisableResend = (govsgMessage: GovsgMessage) => {
-    return !govsgMessage.passcode
-  }
 
   const passcodeColumn = shouldHavePasscode
     ? [
@@ -233,12 +229,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     {
       name: 'ACTION',
       render: (govsgMessage: GovsgMessage) => {
-        return (
-          <ResendButton
-            onClick={() => openModal(govsgMessage)}
-            disabled={shouldDisableResend(govsgMessage)}
-          />
-        )
+        return <ResendButton onClick={() => openModal(govsgMessage)} />
       },
       width: 'xs',
       renderHeader: (name: string, width: string, key: number) => (

--- a/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
@@ -52,6 +52,7 @@ const GovsgRecipients = ({
     csvFilename: initialCsvFilename,
     params,
   } = campaign
+  const paramsWithoutPasscode = params.filter((value) => value !== 'passcode')
   const [csvInfo, setCsvInfo] = useState<
     Omit<CsvStatusResponse, 'isCsvProcessing' | 'preview'>
   >({ numRecipients: initialNumRecipients, csvFilename: initialCsvFilename })
@@ -186,7 +187,11 @@ const GovsgRecipients = ({
           <FileInput isProcessing={isUploading} onFileSelected={uploadFile} />
           <p>or</p>
           <SampleCsv
-            params={canAccessGovsgV ? ['language', ...params] : params}
+            params={
+              canAccessGovsgV
+                ? ['language', ...paramsWithoutPasscode]
+                : paramsWithoutPasscode
+            }
             defaultParams={{ language: 'English' }}
             defaultRecipient="81234567"
             setErrorMsg={console.error}

--- a/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
@@ -52,6 +52,7 @@ const GovsgSingleRecipient = ({
     fieldsToRender.reduce((cul, f) => ({ [f.id]: '', ...cul }), {
       recipient: '',
       language: WhatsAppLanguages.english,
+      passcode: '(random 4-digit passcode)',
     })
   )
   const { id: campaignId } = useParams<{ id: string }>()
@@ -86,8 +87,13 @@ const GovsgSingleRecipient = ({
 
   const onModalConfirm = async () => {
     if (!campaignId) return
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { passcode, ...dataWithoutPasscodePlaceholder } = data
     try {
-      await sendSingleRecipientCampaign(+campaignId, data)
+      await sendSingleRecipientCampaign(
+        +campaignId,
+        dataWithoutPasscodePlaceholder
+      )
       updateCampaign({ status: Status.Sending, numRecipients: 1 })
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
## Problem

Closes [SGC-215](https://linear.app/ogp/issue/SGC-215/remove-officer-verification-button)

## Checklist

- [x] Single send
- [x] Bulk send

## Screen recordings

https://drive.google.com/drive/folders/1JkFGh_SSYBMIm9F_YtXxdCCBxiCDl7xp?usp=sharing

## Notes

- cursor not set to pointer when hovering over Click to reveal passcode. Will address this in a separate PR.
- The template name should not mention `OTP` at all. Should be something along the lines of "with officer verification". Will rename when populating templates to production.