### PR TITLE
refactor: sort template order in frontend

### DIFF
--- a/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgPickTemplate.tsx
@@ -1,4 +1,5 @@
 import { WhatsAppLanguages } from '@shared/clients/whatsapp-client.class/types'
+import { sortBy } from 'lodash'
 import {
   Dispatch,
   ReactNode,
@@ -136,7 +137,7 @@ function GovsgPickTemplate({
               <i className="bx bx-loader-alt bx-spin" />
             </div>
           ) : (
-            availableTemplates.map((t: GovsgTemplate) => (
+            sortBy(availableTemplates, 'name').map((t: GovsgTemplate) => (
               <>
                 <RadioChoice
                   key={t.id}


### PR DESCRIPTION
This is all my idea. But please let me know if this isn't the way.

## Before

<img width="760" alt="Screenshot 2023-08-21 at 5 24 10 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/8c43d0b7-59e8-4c46-b6a0-6edd7bceb969">

## After

<img width="775" alt="Screenshot 2023-08-21 at 5 24 35 PM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/0ff2f4fa-c2de-400a-aac3-7ee33ec90435">
