### PR TITLE
feat: reject invalid language

### DIFF
--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -134,7 +134,9 @@ export function uploadCompleteOnPreview({
 
 const getLanguageCode = (language: string | undefined) => {
   if (!language) {
-    return WhatsAppLanguages.english
+    throw new Error(
+      `Invalid language: ${language}. The supported languages are: english, chinese, malay, and tamil.`
+    )
   }
   const languageInLowerCase = language.toLowerCase()
   const whatsAppLanguages = Object.keys(WhatsAppLanguages)
@@ -142,7 +144,9 @@ const getLanguageCode = (language: string | undefined) => {
     (whatsAppLanguage) => whatsAppLanguage.toLowerCase() === languageInLowerCase
   )
   if (!key) {
-    return WhatsAppLanguages.english
+    throw new Error(
+      `Invalid language: ${language}. The supported languages are: english, chinese, malay, and tamil.`
+    )
   }
   return WhatsAppLanguages[key as keyof typeof WhatsAppLanguages]
 }

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -135,7 +135,7 @@ export function uploadCompleteOnPreview({
 const getLanguageCode = (language: string | undefined) => {
   if (!language) {
     throw new Error(
-      `Invalid language: ${language}. The supported languages are: english, chinese, malay, and tamil.`
+      `Invalid language: ${language}. The supported languages are: English, Chinese, Malay, and Tamil.`
     )
   }
   const languageInLowerCase = language.toLowerCase()
@@ -145,7 +145,7 @@ const getLanguageCode = (language: string | undefined) => {
   )
   if (!key) {
     throw new Error(
-      `Invalid language: ${language}. The supported languages are: english, chinese, malay, and tamil.`
+      `Invalid language: ${language}. The supported languages are: English, Chinese, Malay, and Tamil.`
     )
   }
   return WhatsAppLanguages[key as keyof typeof WhatsAppLanguages]

--- a/backend/src/govsg/services/govsg.service.ts
+++ b/backend/src/govsg/services/govsg.service.ts
@@ -134,9 +134,7 @@ export function uploadCompleteOnPreview({
 
 const getLanguageCode = (language: string | undefined) => {
   if (!language) {
-    throw new Error(
-      `Invalid language: ${language}. The supported languages are: English, Chinese, Malay, and Tamil.`
-    )
+    return WhatsAppLanguages.english // So that we remain backward compatible with current users who don't have access to multi-lingual support
   }
   const languageInLowerCase = language.toLowerCase()
   const whatsAppLanguages = Object.keys(WhatsAppLanguages)


### PR DESCRIPTION
## Problem

We want to reject invalid language values, instead of falling back to English.

Closes [SGC-221](https://linear.app/ogp/issue/SGC-221/reject-misspelt-language)

## Notes

This PR is backward-compatible.

If the language column is entirely absent (like how it is supposed to be right now), we fall back to English.

On the other hand, if a language is specified, then it has to be valid.