### PR TITLE
fix: add key attribute to details element

### DIFF
--- a/frontend/src/components/common/StyledText/PasscodeBadge.tsx
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.tsx
@@ -3,18 +3,20 @@ import cx from 'classnames'
 import styles from './PasscodeBadge.module.scss'
 
 interface PasscodeBadgeProps {
+  key: string
   label: string
   placeholder: string
   onClick: () => void
 }
 
 export const PasscodeBadge = ({
+  key,
   label,
   placeholder,
   onClick,
 }: PasscodeBadgeProps) => {
   return (
-    <details>
+    <details key={key}>
       <summary onClick={onClick}>Click to reveal</summary>
       <span className={label ? cx(styles.positive) : cx(styles.negative)}>
         {label ? label : placeholder}

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -136,6 +136,7 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
           render: (govsgMessage: GovsgMessage) => {
             return (
               <PasscodeBadge
+                key={govsgMessage.id}
                 label={govsgMessage.passcode}
                 placeholder="N/A"
                 onClick={async () => await trackPasscodeReveal(govsgMessage)}


### PR DESCRIPTION
## Problem

- (BUG) The passcode badge component is being reused i.e. reveal first row = first rows in subsequent pages are also revealed already.

## Solution

Add `key` attribute to the `details` element in `PasscodeBadge` ([docs](https://legacy.reactjs.org/docs/lists-and-keys.html#keys)).
