### PR TITLE
feat(worker): implement alert for campaign with errors

### DIFF
--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -93,6 +93,7 @@ export interface ConfigSchema {
     authTokenTwo: string
     authTokenTwoExpiry: string
   }
+  sgcCampaignAlertChannelWebhookUrl: string
 
   phonebook: {
     enabled: boolean
@@ -418,6 +419,11 @@ const config: Config<ConfigSchema> = convict({
       env: 'WA_AUTH_TOKEN_2_EXPIRY',
       default: '',
     },
+  },
+  sgcCampaignAlertChannelWebhookUrl: {
+    doc: 'Slack webhook URL to post Gov.sg campaign alerts',
+    env: 'SGC_CAMPAIGN_ALERT_WEBHOOK',
+    default: '',
   },
   phonebook: {
     enabled: {


### PR DESCRIPTION
## Problem

Alert on GovSG campaign with errored messages

## Solution

Check if there're errored messages for a campaign at the finalize step in logger worker

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [ ] Add `SGC_CAMPAIGN_ALERT_WEBHOOK` env var