### PR TITLE
feat(sst): add cron monitor for SGC whatsapp webhook

### DIFF
--- a/sst/package-lock.json
+++ b/sst/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "dependencies": {
         "aws-cdk": "^2.87.0",
+        "axios": "^1.4.0",
         "cronitor": "^2.3.3"
       },
       "devDependencies": {

--- a/sst/package.json
+++ b/sst/package.json
@@ -32,6 +32,7 @@
   ],
   "dependencies": {
     "aws-cdk": "^2.87.0",
+    "axios": "^1.4.0",
     "cronitor": "^2.3.3"
   },
   "lint-staged": {

--- a/sst/packages/core/src/models/govsg-message.ts
+++ b/sst/packages/core/src/models/govsg-message.ts
@@ -1,0 +1,15 @@
+import { date, pgEnum, pgTable } from 'drizzle-orm/pg-core'
+
+export const govsgMessages = pgTable('govsg_messages', {
+  status: pgEnum('enum_govsg_messages_status', [
+    'UNSENT',
+    'ACCEPTED',
+    'SENT',
+    'DELIVERED',
+    'READ',
+    'ERROR',
+    'INVALID_RECIPIENT',
+    'DELETED',
+  ])('status').notNull(),
+  updatedAt: date('updated_at').notNull(),
+})

--- a/sst/packages/core/src/models/index.ts
+++ b/sst/packages/core/src/models/index.ts
@@ -1,1 +1,2 @@
 export * from './api-key'
+export * from './govsg-message'

--- a/sst/packages/functions/src/cron-jobs/govsg-webhook-monitor/cron.ts
+++ b/sst/packages/functions/src/cron-jobs/govsg-webhook-monitor/cron.ts
@@ -1,0 +1,56 @@
+import axios from 'axios'
+import { sql } from 'drizzle-orm'
+import { Config } from 'sst/node/config'
+
+import PostmanDbClient from '@/core/database/client'
+import { govsgMessages } from '@/core/models'
+
+export async function handler() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cronitor = require('cronitor')(Config.CRONITOR_URL_SUFFIX) // common to all jobs on our shared Cronitor account
+    const invokeFunction =
+      process.env.IS_LOCAL === 'true'
+        ? async function () {
+            console.log('Running cron locally')
+            await checkMessagesNotGettingWebhooks()
+          }
+        : cronitor.wrap(
+            Config.CRONITOR_CODE_GOVSG_WEBHOOK_MONITOR,
+            async function () {
+              await checkMessagesNotGettingWebhooks()
+            },
+          )
+    await invokeFunction()
+  } catch (error) {
+    console.log(error)
+    throw error
+  }
+}
+
+async function checkMessagesNotGettingWebhooks() {
+  const db = new PostmanDbClient(Config.POSTMAN_DB_URI).getClient()
+  const noWebhookMessages = await db
+    .select({})
+    .from(govsgMessages)
+    .where(
+      // the reason we want to query for the previous 10-minute block instead of
+      // the immediate one is to prevent messages from campaigns currently being sent
+      // out from being flagged (This is assuming a campaign won't take more than
+      // 10 minutes to receive all the `SENT` webhooks)
+      sql`status = 'ACCEPTED' AND updated_at < NOW() - INTERVAL '10 minutes' AND updated_at >= NOW() - INTERVAL '20 minutes'`,
+    )
+  if (noWebhookMessages.length === 0) {
+    return
+  }
+  try {
+    await axios.post(Config.SGC_ALERT_WEBHOOK, {
+      text: `<!subteam^S03JWLMTBTK|postmangineers>\n***NEW ALERT***\nThere're ${noWebhookMessages.length} messages that didn't get a webhook.\n******`,
+    })
+  } catch (e) {
+    console.log({
+      message: 'Error in govsg-webhook-monitor slack posting',
+      error: e,
+    })
+  }
+}

--- a/sst/stacks/MyStack.ts
+++ b/sst/stacks/MyStack.ts
@@ -89,6 +89,30 @@ export function MyStack({ app, stack }: StackContext) {
     new Config.Secret(stack, 'CRONITOR_CODE_UNSUB_DIGEST'),
   ]
   unsubDigestCron.bind(unsubDigestCronResources)
+
+  // Cron job #4: monitor for govsg messages not getting any webhooks
+  const govsgWebhookMonitorCron = new Cron(stack, 'govsg-webhook-monitor', {
+    schedule: 'cron(*/10 * ? * * *)',
+    job: {
+      function: {
+        handler:
+          'packages/functions/src/cron-jobs/govsg-webhook-monitor/cron.handler',
+        timeout: '10 minutes',
+        vpc: existingVpc,
+        securityGroups: [existingSg],
+        vpcSubnets: {
+          subnets: existingVpc.privateSubnets,
+        },
+      },
+    },
+  })
+  const govsgWebhookMonitorCronResources = [
+    postmanDbUri,
+    cronitorUrlSuffix,
+    new Config.Secret(stack, 'CRONITOR_CODE_GOVSG_WEBHOOK_MONITOR'),
+    new Config.Secret(stack, 'SGC_ALERT_WEBHOOK'),
+  ]
+  govsgWebhookMonitorCron.bind(govsgWebhookMonitorCronResources)
 }
 
 function getResourceIdentifiers(stage: string) {


### PR DESCRIPTION
## Problem

We want to monitor if there're webhooks coming back for all of our Gov.sg messages. No messages should stay in the `ACCEPTED` state for too long as there will always be `SENT` status webhooks.

## Solution

Implement a cron to check for the 2nd-immediate previous 10-minute window to see if there're any `ACCEPTED` messages.

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [x] create cronitor monitor and set `CRONITOR_CODE_GOVSG_WEBHOOK_MONITOR` for SST parameter store
- [x] set `SGC_ALERT_WEBHOOK` for SST parameter store