### PR TITLE
fix: do not reorder after passcode reveal

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -52,6 +52,7 @@ export const listMessages = async (
     },
     offset: +(offset as string),
     limit: +(limit as string),
+    order: [['createdAt', 'ASC']],
     include: [
       {
         model: GovsgVerification,


### PR DESCRIPTION
Because the first click to passcode reveal updates the db, the order of records might change.

I've observed instances where I revealed the passcode of one record in page 1, and it got moved to page 2.