### PR TITLE
fix: bugs in whitelisting script

### DIFF
--- a/backend/src/scripts/insert_experimental_govsg_user.ts
+++ b/backend/src/scripts/insert_experimental_govsg_user.ts
@@ -29,7 +29,7 @@ void (async function main() {
       'temp/Agency Whitelist - Whitelist.csv'
     )
   )
-    .filter((r) => r[4] === 'N')
+    .filter((r) => r[4] === 'N' && r[5] !== 'Y')
     .map(
       (r) =>
         ({

--- a/backend/src/scripts/whitelisting/constants.ts
+++ b/backend/src/scripts/whitelisting/constants.ts
@@ -1,8 +1,12 @@
 export const SECTION_DIVIDER =
   '\n=============================================================\n'
 
-export const OGP_TEMPLATE_ACCESS = []
+export const OGP_TEMPLATE_ACCESS = ['sgc_trial1_feedback_message']
 
 export const MCI_TEMPLATE_ACCESS = []
 
-export const ALL_TEMPLATE_ACCESS = []
+export const ALL_TEMPLATE_ACCESS = [
+  'sgc_notify_upcoming_house_visit_1',
+  'sgc_notify_missed_call_1',
+  'sgc_notify_upcoming_call_2',
+]


### PR DESCRIPTION
## Problem

- `update_whitelist.ts` : The previous script added all users regardless of whether or not they are part of the experimental feature.
- `insert_experimental_govsg_user.ts` : The previous script did not check to see whether or not the user should be deleted from the DB. 

## Solution

- `update_whitelist.ts` : When querying users, we do so from the `GovsgTemplatesAccess` table instead of `Users` table.
- `insert_experimental_govsg_user.ts` : Perform an extra check on the `to remove` column of the CSV file (5th column). If this value is `'Y'`, we do not add the user to the DB.

## Deployment Checklist

NA
