### PR TITLE
feat: scroll to top on recipient step for better UX

### DIFF
--- a/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgRecipients.tsx
@@ -69,6 +69,11 @@ const GovsgRecipients = ({
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const modalContext = useContext(ModalContext)
 
+  // Scroll window to top when component mounts
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
   // Poll csv status
   useEffect(() => {
     if (!campaignId) return

--- a/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgSingleRecipient.tsx
@@ -1,6 +1,12 @@
 import { WhatsAppLanguages } from '@shared/clients/whatsapp-client.class/types'
 
-import { Dispatch, SetStateAction, useContext, useState } from 'react'
+import {
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useState,
+  useEffect,
+} from 'react'
 
 import { useParams } from 'react-router-dom'
 
@@ -58,6 +64,11 @@ const GovsgSingleRecipient = ({
   const { id: campaignId } = useParams<{ id: string }>()
   const modalContext = useContext(ModalContext)
   const [errMessage, setErrMessage] = useState<string>('')
+
+  // Scroll window to top when component mounts
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
 
   const getUpdateData = (field: string) => (value: string) => {
     setData(Object.assign({}, data, { [field]: value }))


### PR DESCRIPTION
## Problem
When user moves from the "Pick a template" to "Upload recipients tab", the window scroll is preserved.

This is especially bad UX when "Pick a template" and "One recipient" is selected, because the "One recipient" tab is long, so it starts at the very bottom, and hence the user has to scroll all the way to the top to start the form. 

## Screenshots
1. View after completing "Pick a template" tab, then user will click "Next"
 ![Screenshot 2023-08-29 at 9 35 47 AM](https://github.com/opengovsg/postmangovsg/assets/39242294/8b28cbbe-2420-4575-b192-558af4d0347e)

2. View after user clicks "Next" - he looks at the bottom of the page since window scroll is preserved. Intuitively, the tab should start at the top.
![Screenshot 2023-08-29 at 9 35 38 AM](https://github.com/opengovsg/postmangovsg/assets/39242294/dd93cc58-8f84-408e-a70b-511064f03c4d)

