### PR TITLE
style: make Click to reveal more prominent

### DIFF
--- a/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
@@ -9,6 +9,12 @@ details[open] > summary {
   display: none;
 }
 
+summary {
+  @extend %body-2;
+  color: $primary;
+  text-decoration: underline;
+}
+
 summary:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
### Before
<img width="1510" alt="Screenshot 2023-08-29 at 9 44 31 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/d0c5c0f9-2e9c-4168-9d4f-2e9fab713539">

### After
<img width="1510" alt="Screenshot 2023-08-29 at 9 44 51 AM" src="https://github.com/opengovsg/postmangovsg/assets/14961285/48fda465-bbc6-44a3-91ae-567e2c4e7742">
