### PR TITLE
feat(worker): thread sgc error alert messages

### DIFF
--- a/worker/src/core/config.ts
+++ b/worker/src/core/config.ts
@@ -93,7 +93,10 @@ export interface ConfigSchema {
     authTokenTwo: string
     authTokenTwoExpiry: string
   }
-  sgcCampaignAlertChannelWebhookUrl: string
+  sgcAlert: {
+    apiToken: string
+    channel: string
+  }
 
   phonebook: {
     enabled: boolean
@@ -420,10 +423,19 @@ const config: Config<ConfigSchema> = convict({
       default: '',
     },
   },
-  sgcCampaignAlertChannelWebhookUrl: {
-    doc: 'Slack webhook URL to post Gov.sg campaign alerts',
-    env: 'SGC_CAMPAIGN_ALERT_WEBHOOK',
-    default: '',
+  sgcAlert: {
+    apiToken: {
+      doc: 'API Token for Bob the Post Office Builder',
+      env: 'SGC_ALERT_API_TOKEN',
+      format: 'required-string',
+      default: '',
+    },
+    channel: {
+      doc: 'Slack alert channel for SGC',
+      env: 'SGC_ALERT_CHANNEL',
+      format: 'required-string',
+      default: '',
+    },
   },
   phonebook: {
     enabled: {

--- a/worker/src/core/loaders/message-worker/index.ts
+++ b/worker/src/core/loaders/message-worker/index.ts
@@ -191,7 +191,6 @@ const finalize = tracer.wrap(
         const subsequentMessages = messagesWithErr.map(
           (m) => `| ${m.id} | ${m.error_code} | ${m.error_description} |`
         )
-        console.log(firstText, subsequentMessages, config.get('sgcAlert'))
         await axios
           .post(
             'https://slack.com/api/chat.postMessage',
@@ -205,10 +204,6 @@ const finalize = tracer.wrap(
               },
             }
           )
-          .then(({ data }) => {
-            console.log(data)
-            return { data }
-          })
           .then(({ data }) =>
             Promise.all(
               subsequentMessages.map((m) =>


### PR DESCRIPTION
## Problem

Campaign with a lot of errors and long error messages are hard to be compiled in a single message

## Solution

Thread the error messages one to each reply

## Deployment Checklist

_Any tasks that need to be done on the environment before releasing of this PR (e.g. Setting environment variables, running migrations, etc). If there's no task to be done, put "N/A"_

- [x] Set `SGC_ALERT_API_TOKEN` env var
- [x] Set `SGC_ALERT_CHANNEL` env var
- [x] Remove `SGC_ALERT_WEBHOOK` env var