### PR TITLE
feat: add partial index to user credentials table

### DIFF
--- a/backend/src/database/migrations/20230906063204-add-partial-index-to-user-credentials.js
+++ b/backend/src/database/migrations/20230906063204-add-partial-index-to-user-credentials.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('user_credentials', {
+      unique: true,
+      name: 'uuid_unique_after_06-09-2023',
+      fields: ['cred_name','created_at'],
+      where: {
+          created_at: {
+            [Sequelize.Op.gte]: new Date('2023-09-06')
+          } 
+      },
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('user_credentials', 'uuid_unique_after_06-09-2023')
+  }
+};

--- a/backend/src/sms/middlewares/sms.middleware.ts
+++ b/backend/src/sms/middlewares/sms.middleware.ts
@@ -261,7 +261,7 @@ export const InitSmsMiddleware = (
         error: err,
         ...logMeta,
       })
-      return res.status(400).json({ message: `${(err as Error).message}` })
+      return res.status(500).json({ message: `${(err as Error).message}` })
     }
   }
 


### PR DESCRIPTION
## Problem

This PR is a follow up to https://github.com/opengovsg/postmangovsg/pull/2212

This PR addresses two problems:

1. The DB allows duplicate values for the `cred_name` column in the `user_credentials` table. Even though we don't expect the `uuid` values to collide, in the event that they do, we will run into the "hash collision" problem again. 

2. When new credentials are added, we perform an `upsert` to AWS Secrets Manager. The original purpose of this was to save space in Secrets Manager but the implementation is incorrect. In the event that a set of credentials already exist, we do not want to update the existing value. 

## Solution

The following solutions are provided for the 2 problems above:

1. We add a partial index that ensures that all values of `cred_name` are unique if the value of `created_at` >= `2023-09-06` to block the addition of duplicate credentials at the DB level. 

2. We remove the `upsert` to AWS Secrets Manager and replace it with a `create`. This prevents existing credentials from ever being updated. 

## Deployment Checklist

- [x] Run DB Migration on `staging`
- [x] Run DB Migration on `production`
