### PR TITLE
fix: use normalised recipient in templateMessageToSend

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -155,7 +155,7 @@ export const resendMessage = async (
   )
   const language = getWhatsAppLanguageFromLanguageCode(govsgMessage)
   const templateMessageToSend: WhatsAppTemplateMessageToSend = {
-    recipient,
+    recipient: normalisedRecipient,
     apiClient,
     templateName: campaignGovsgTemplate.govsgTemplate.whatsappTemplateLabel,
     params: normalisedParams,


### PR DESCRIPTION
We previously fixed normalising recipient before querying flamingo for which WA client id to use.

But, resend failed because recipient in templateMessageToSend is not normalised.