### PR TITLE
Fix/telegram credential reuse bug

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -259,7 +259,7 @@
         "filename": "backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts",
         "hashed_secret": "f165653aec311836bf8bd77ad0fd8ff5480f03eb",
         "is_verified": false,
-        "line_number": 202
+        "line_number": 210
       }
     ],
     "backend/src/telegram/routes/tests/telegram-settings.routes.test.ts": [
@@ -383,5 +383,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-11T04:10:56Z"
+  "generated_at": "2023-09-11T04:25:14Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,6 +253,24 @@
         "line_number": 44
       }
     ],
+    "backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts",
+        "hashed_secret": "f165653aec311836bf8bd77ad0fd8ff5480f03eb",
+        "is_verified": false,
+        "line_number": 202
+      }
+    ],
+    "backend/src/telegram/routes/tests/telegram-settings.routes.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/src/telegram/routes/tests/telegram-settings.routes.test.ts",
+        "hashed_secret": "f165653aec311836bf8bd77ad0fd8ff5480f03eb",
+        "is_verified": false,
+        "line_number": 78
+      }
+    ],
     "backend/src/test-utils/global-setup.ts": [
       {
         "type": "Secret Keyword",
@@ -348,22 +366,6 @@
         "line_number": 46
       }
     ],
-    "serverless/database-backup/src/config.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "serverless/database-backup/src/config.ts",
-        "hashed_secret": "c6594ed82c75623781bbb4bfabe4afcb129e1c39",
-        "is_verified": false,
-        "line_number": 139
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "serverless/database-backup/src/config.ts",
-        "hashed_secret": "7ae7d51087af32cf059509eecb652a5ee9f88fd6",
-        "is_verified": false,
-        "line_number": 146
-      }
-    ],
     "worker/.env-example": [
       {
         "type": "Secret Keyword",
@@ -381,5 +383,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-14T06:54:52Z"
+  "generated_at": "2023-09-11T04:10:56Z"
 }

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -130,7 +130,7 @@ export const InitTelegramCampaignMiddleware = (
     celebrate(useCredentialsValidator),
     CampaignMiddleware.canEditCampaign,
     telegramMiddleware.getCredentialsFromLabel,
-    telegramMiddleware.validateAndStoreCredentials,
+    telegramMiddleware.validateCredentials,
     telegramMiddleware.setCampaignCredential
   )
 

--- a/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-campaign.routes.test.ts
@@ -4,7 +4,6 @@ import initialiseServer from '@test-utils/server'
 import { Campaign, User, Credential } from '@core/models'
 import sequelizeLoader from '@test-utils/sequelize-loader'
 import { DefaultCredentialName } from '@core/constants'
-import { formatDefaultCredentialName } from '@core/utils'
 import { UploadService } from '@core/services'
 import { TelegramMessage } from '@telegram/models'
 import { ChannelType } from '@core/constants'
@@ -108,9 +107,6 @@ describe('POST /campaign/{campaignId}/telegram/credentials', () => {
     const demoCampaign = await createCampaign({ isDemo: true })
 
     const DEFAULT_TELEGRAM_CREDENTIAL = '12345'
-    mockSecretsManager.getSecretValue.mockResolvedValue({
-      SecretString: DEFAULT_TELEGRAM_CREDENTIAL,
-    })
 
     const res = await request(app)
       .post(`/campaign/${demoCampaign.id}/telegram/credentials`)
@@ -119,10 +115,6 @@ describe('POST /campaign/{campaignId}/telegram/credentials', () => {
       })
 
     expect(res.status).toBe(200)
-
-    expect(mockSecretsManager.getSecretValue).toHaveBeenCalledWith({
-      SecretId: formatDefaultCredentialName(DefaultCredentialName.Telegram),
-    })
     expect(Telegram).toHaveBeenCalledWith(DEFAULT_TELEGRAM_CREDENTIAL)
 
     mockSecretsManager.getSecretValue.mockReset()
@@ -207,7 +199,7 @@ describe('POST /campaign/{campaignId}/telegram/new-credentials', () => {
 
     expect(res.status).toBe(200)
 
-    const secretName = `${process.env.APP_ENV}-12345`
+    const secretName = 'MOCKED_UUID'
     expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
       expect.objectContaining({
         Name: secretName,

--- a/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
+++ b/backend/src/telegram/routes/tests/telegram-settings.routes.test.ts
@@ -75,7 +75,7 @@ describe('POST /settings/telegram/credentials', () => {
 
     expect(res.status).toBe(200)
 
-    const secretName = `${process.env.APP_ENV}-12345`
+    const secretName = 'MOCKED_UUID'
     expect(mockSecretsManager.createSecret).toHaveBeenCalledWith(
       expect.objectContaining({
         Name: secretName,

--- a/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
+++ b/frontend/src/components/dashboard/create/sms/SMSCredentials.tsx
@@ -25,7 +25,6 @@ import {
   StepHeader,
   StepSection,
   CredLabelInput,
-  Checkbox,
   InfoBlock,
 } from 'components/common'
 import { LINKS } from 'config'
@@ -55,7 +54,6 @@ const SMSCredentials = ({
   const [selectedCredential, setSelectedCredential] = useState('')
   const [creds, setCreds] = useState(null as TwilioCredentials | null)
   const [label, setLabel] = useState('')
-  const [saveCredentialWithLabel, setSaveCredentialWithLabel] = useState(false)
   const [showCredentialFields, setShowCredentialFields] = useState(
     !hasCredential
   )
@@ -86,7 +84,6 @@ const SMSCredentials = ({
     setIsManual((m) => !m)
     setCreds(null)
     setLabel('')
-    setSaveCredentialWithLabel(false)
     setSelectedCredential('')
   }
 
@@ -101,7 +98,7 @@ const SMSCredentials = ({
           campaignId: +campaignId,
           ...creds,
           recipient,
-          ...(saveCredentialWithLabel && { label }),
+          ...{ label },
         })
       } else if (!isManual && selectedCredential) {
         await validateStoredCredentials({
@@ -134,25 +131,17 @@ const SMSCredentials = ({
               <div>
                 <CredLabelInput
                   className={{
-                    [styles.credentialLabelInputError]:
-                      saveCredentialWithLabel && !label,
+                    [styles.credentialLabelInputError]: !label,
                   }}
                   value={label}
                   onChange={setLabel}
                   labels={credLabels}
                 />
-                {saveCredentialWithLabel && !label && (
+                {!label && (
                   <span className={styles.credentialLabelError}>
                     Please enter a credential name
                   </span>
                 )}
-                <Checkbox
-                  checked={saveCredentialWithLabel}
-                  onChange={setSaveCredentialWithLabel}
-                >
-                  Save this credential for future use. If unchecked, nothing is
-                  saved.
-                </Checkbox>
               </div>
               <div>
                 <TwilioCredentialsInput onFilled={setCreds} />
@@ -220,11 +209,7 @@ const SMSCredentials = ({
           </StepHeader>
           <SMSValidationInput
             onClick={handleValidateCredentials}
-            buttonDisabled={
-              isManual
-                ? !creds || (saveCredentialWithLabel && !label)
-                : !selectedCredential
-            }
+            buttonDisabled={isManual ? !creds || !label : !selectedCredential}
           />
           <ErrorBlock>{errorMessage}</ErrorBlock>
         </StepSection>

--- a/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCredentials.tsx
@@ -24,7 +24,6 @@ import {
   StepHeader,
   StepSection,
   CredLabelInput,
-  Checkbox,
   InfoBlock,
 } from 'components/common'
 import { LINKS } from 'config'
@@ -55,7 +54,6 @@ const TelegramCredentials = ({
   const [selectedCredential, setSelectedCredential] = useState('')
   const [creds, setCreds] = useState(null as any)
   const [label, setLabel] = useState('')
-  const [saveCredentialWithLabel, setSaveCredentialWithLabel] = useState(false)
   const [showCredentialFields, setShowCredentialFields] = useState(
     !hasCredential
   )
@@ -88,7 +86,6 @@ const TelegramCredentials = ({
     setIsManual((m) => !m)
     setCreds(null)
     setLabel('')
-    setSaveCredentialWithLabel(false)
     setSelectedCredential('')
   }
 
@@ -111,7 +108,7 @@ const TelegramCredentials = ({
         await validateNewCredentials({
           campaignId: +campaignId,
           ...creds,
-          ...(saveCredentialWithLabel && { label }),
+          ...{ label },
         })
       } else if (!isManual && selectedCredential) {
         await validateStoredCredentials({
@@ -195,25 +192,17 @@ const TelegramCredentials = ({
               <div>
                 <CredLabelInput
                   className={{
-                    [styles.credentialLabelInputError]:
-                      saveCredentialWithLabel && !label,
+                    [styles.credentialLabelInputError]: !label,
                   }}
                   value={label}
                   onChange={setLabel}
                   labels={credLabels}
                 />
-                {saveCredentialWithLabel && !label && (
+                {!label && (
                   <span className={styles.credentialLabelError}>
                     Please enter a credential name
                   </span>
                 )}
-                <Checkbox
-                  checked={saveCredentialWithLabel}
-                  onChange={setSaveCredentialWithLabel}
-                >
-                  Save this credential for future use. If unchecked, nothing is
-                  saved.
-                </Checkbox>
               </div>
               <div className={styles.validateCredentialsInfo}>
                 <TelegramCredentialsInput onFilled={setCreds} />


### PR DESCRIPTION
## Problem

After merging https://github.com/opengovsg/postmangovsg/pull/2213, users were no longer able to use existing telegram credentials to create a campaign because the `/credentials` endpoint attempted to recreate already existing credentials, resulting in an error being thrown. 

⚠️ New telegram credentials can no longer be used on Postman. This feature has been broken for almost a year and we are no longer supporting it. I will be making a separate PR to disable the adding of new credentials. 

## Solution

I have split the `validateAndStoreCredentials` function into a `validateCredentials` function and have used that for the `/credentials` endpoint. 

This allows users to reuse already existing credentials in the system. 

## Deployment Checklist

N/A
