### PR TITLE
Feat/disable adding telegram credentials

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -92,6 +92,7 @@ interface ConfigSchema {
   defaultCountryCode: string
   telegramOptions: {
     webhookUrl: string
+    disableNewCredentials: boolean
   }
   maxRatePerJob: number
   apiKey: {
@@ -506,6 +507,11 @@ const config: Config<ConfigSchema> = convict({
       doc: 'Webhook URL to configure for all Telegram bots',
       default: '',
       env: 'TELEGRAM_WEBHOOK_URL',
+    },
+    disableNewCredentials: {
+      doc: 'Disables the addition of new Telegram credentials',
+      default: false,
+      env: 'TELEGRAM_DISABLE_NEW_CREDENTIALS',
     },
   },
   maxRatePerJob: {

--- a/backend/src/telegram/middlewares/telegram.middleware.ts
+++ b/backend/src/telegram/middlewares/telegram.middleware.ts
@@ -11,6 +11,7 @@ import {
   ApiInvalidTemplateError,
   ApiNotFoundError,
 } from '@core/errors/rest-api.errors'
+import config from '@core/config'
 
 export interface TelegramMiddleware {
   getCredentialsFromBody: Handler
@@ -25,6 +26,7 @@ export interface TelegramMiddleware {
   sendValidationMessage: Handler
   disabledForDemoCampaign: Handler
   duplicateCampaign: Handler
+  canValidateCredentials: Handler
 }
 
 export const InitTelegramMiddleware = (
@@ -427,6 +429,26 @@ export const InitTelegramMiddleware = (
     }
   }
 
+  /**
+   * Determine if new credentials can be validated based on whether validation is disabled.
+   * @param _req
+   * @param res
+   * @param next
+   */
+  const canValidateCredentials = async (
+    _req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<Response | void> => {
+    if (config.get('telegramOptions.disableNewCredentials')) {
+      return res.status(400).json({
+        message:
+          'Postman no longer supports the addition of new Telegram credentials.',
+      })
+    }
+    next()
+  }
+
   return {
     getCredentialsFromBody,
     getCredentialsFromLabel,
@@ -440,5 +462,6 @@ export const InitTelegramMiddleware = (
     sendValidationMessage,
     disabledForDemoCampaign,
     duplicateCampaign,
+    canValidateCredentials,
   }
 }

--- a/backend/src/telegram/routes/telegram-campaign.routes.ts
+++ b/backend/src/telegram/routes/telegram-campaign.routes.ts
@@ -118,6 +118,7 @@ export const InitTelegramCampaignMiddleware = (
     '/new-credentials',
     celebrate(storeCredentialsValidator),
     CampaignMiddleware.canEditCampaign,
+    telegramMiddleware.canValidateCredentials,
     telegramMiddleware.disabledForDemoCampaign,
     telegramMiddleware.getCredentialsFromBody,
     telegramMiddleware.validateAndStoreCredentials,

--- a/backend/src/telegram/routes/telegram-settings.routes.ts
+++ b/backend/src/telegram/routes/telegram-settings.routes.ts
@@ -65,6 +65,7 @@ export const InitTelegramSettingsRoute = (
   router.post(
     '/credentials',
     celebrate(storeCredentialValidator),
+    telegramMiddleware.canValidateCredentials,
     settingsMiddleware.checkUserCredentialLabel,
     telegramMiddleware.getCredentialsFromBody,
     telegramMiddleware.validateAndStoreCredentials,

--- a/frontend/src/components/common/banner/Banner.module.scss
+++ b/frontend/src/components/common/banner/Banner.module.scss
@@ -1,0 +1,33 @@
+@import 'styles/_variables';
+@import 'styles/base/_colours';
+@import 'styles/_mixins';
+.container {
+  height: auto;
+  padding: 4px $site-padding;
+  color: white;
+  text-align: center;
+  @include flex-horizontal;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+  z-index: 5;
+
+  .infoText {
+    max-width: $header-max-width;
+    font-size: 1rem;
+  }
+
+  @include mobile() {
+    padding: 4px $mobile-site-padding;
+    text-align: justify;
+  }
+}
+.primary {
+  background-color: $primary;
+}
+.danger {
+  background-color: $red-500;
+}
+.warning {
+  background-color: $yellow-700;
+}

--- a/frontend/src/components/common/banner/Banner.tsx
+++ b/frontend/src/components/common/banner/Banner.tsx
@@ -1,0 +1,33 @@
+import cx from 'classnames'
+import { RefObject } from 'react'
+
+import styles from './Banner.module.scss'
+export enum BannerColors {
+  Primary = 'primary',
+  Warning = 'warning',
+  Danger = 'danger',
+}
+
+const Banner = (props: {
+  innerRef?: RefObject<HTMLDivElement>
+  bannerContent: string
+  bannerColor: string
+}) => {
+  const { innerRef, bannerColor, bannerContent } = props
+
+  let colorClassname = (bannerColor as BannerColors) || BannerColors.Primary
+  if (!Object.values(BannerColors).includes(colorClassname)) {
+    colorClassname = BannerColors.Primary
+  }
+
+  return (
+    <div
+      className={cx(styles.container, styles[colorClassname])}
+      ref={innerRef}
+    >
+      <span className={styles.infoText}>{bannerContent}</span>
+    </div>
+  )
+}
+
+export default Banner

--- a/frontend/src/components/common/banner/index.ts
+++ b/frontend/src/components/common/banner/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Banner'

--- a/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
+++ b/frontend/src/components/dashboard/create/telegram/TelegramCreate.tsx
@@ -2,6 +2,8 @@ import cx from 'classnames'
 
 import { useContext, useEffect, useState } from 'react'
 
+import { TELEGRAM_CREDENTIAL_BANNER_MESSAGE } from '../../../../constants'
+
 import styles from '../Create.module.scss'
 import BodyTemplate from '../common/BodyTemplate'
 
@@ -12,6 +14,7 @@ import TelegramSend from './TelegramSend'
 
 import { Status, TelegramCampaign, TelegramProgress } from 'classes'
 import { ProgressPane } from 'components/common'
+import Banner from 'components/common/banner'
 import { CampaignContext } from 'contexts/campaign.context'
 import {
   saveTemplate,
@@ -61,24 +64,30 @@ const CreateTelegram = () => {
   }
 
   return (
-    <div className={styles.createContainer}>
-      {status !== Status.Draft ? (
-        <div className={cx(styles.stepContainer, styles.detailContainer)}>
-          <TelegramDetail></TelegramDetail>
-        </div>
-      ) : (
-        <>
-          <ProgressPane
-            steps={TELEGRAM_PROGRESS_STEPS}
-            activeStep={activeStep}
-            setActiveStep={setActiveStep}
-            progress={progress}
-            disabled={isCsvProcessing}
-          />
-          <div className={styles.stepContainer}>{renderStep()}</div>
-        </>
-      )}
-    </div>
+    <>
+      <Banner
+        bannerContent={TELEGRAM_CREDENTIAL_BANNER_MESSAGE}
+        bannerColor="warning"
+      />
+      <div className={styles.createContainer}>
+        {status !== Status.Draft ? (
+          <div className={cx(styles.stepContainer, styles.detailContainer)}>
+            <TelegramDetail></TelegramDetail>
+          </div>
+        ) : (
+          <>
+            <ProgressPane
+              steps={TELEGRAM_PROGRESS_STEPS}
+              activeStep={activeStep}
+              setActiveStep={setActiveStep}
+              progress={progress}
+              disabled={isCsvProcessing}
+            />
+            <div className={styles.stepContainer}>{renderStep()}</div>
+          </>
+        )}
+      </div>
+    </>
   )
 }
 

--- a/frontend/src/components/dashboard/settings/Settings.tsx
+++ b/frontend/src/components/dashboard/settings/Settings.tsx
@@ -3,6 +3,8 @@ import cx from 'classnames'
 import { useContext, useState, useEffect } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 
+import { TELEGRAM_CREDENTIAL_BANNER_MESSAGE } from '../../../constants'
+
 import styles from './Settings.module.scss'
 import AddApiKeyModal from './add-api-key-modal'
 import AddCredentialModal from './add-credential-modal'
@@ -13,6 +15,7 @@ import CustomFromAddress from './custom-from-address'
 import CredentialsImage from 'assets/img/credentials.svg'
 import { ChannelType, channelIcons } from 'classes'
 import { SideNav, TitleBar } from 'components/common'
+import Banner from 'components/common/banner'
 import { ModalContext } from 'contexts/modal.context'
 import type { UserCredential } from 'services/settings.service'
 import {
@@ -175,6 +178,10 @@ const Settings = () => {
   return (
     <>
       <TitleBar title="Settings"> </TitleBar>
+      <Banner
+        bannerContent={TELEGRAM_CREDENTIAL_BANNER_MESSAGE}
+        bannerColor="warning"
+      />
       {isLoading ? (
         <i className={cx(styles.spinner, 'bx bx-loader-alt bx-spin')} />
       ) : !hasApiKey && creds.length < 1 && !hasCustomFromAddresses ? (

--- a/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
+++ b/frontend/src/components/dashboard/settings/credentials/Credentials.tsx
@@ -9,7 +9,7 @@ import VerifyCredentialModal from '../verify-credential-modal'
 import styles from './Credentials.module.scss'
 
 import EmptyCredentialsImage from 'assets/img/credentials.svg'
-import type { ChannelType } from 'classes'
+import { ChannelType } from 'classes'
 
 import { PrimaryButton, ConfirmModal } from 'components/common'
 import { ModalContext } from 'contexts/modal.context'

--- a/frontend/src/constants.tsx
+++ b/frontend/src/constants.tsx
@@ -1,0 +1,2 @@
+export const TELEGRAM_CREDENTIAL_BANNER_MESSAGE =
+  'Postman no longer supports the addition of new Telegram credentials as of 12-09-2023'


### PR DESCRIPTION
## Problem

Telegram credentials added after this [PR was merged](https://github.com/opengovsg/postmangovsg/pull/1414) cannot be used to send out campaigns due to the implementation of the `enqueue_messages_telegram` DB function. Since we have a low number of telegram users, we have decided to stop accepting new telegram credentials instead of trying to rectify the issue. 

## Solution

I added a `canValidateCredentials` function to the `telegram.middleware.ts` to throw an error whenever users try to add a new set of telegram credentials. In addition to this guard, I have also added a banner to inform users that we no longer support the addition of new telegram credentials in the FE. This banner is displayed on the telegram campaign and settings pages. 

## Deployment Checklist

**New Env Vars**
- `TELEGRAM_DISABLE_NEW_CREDENTIALS` : `boolean`

- [x] Add env var to staging environment
- [x] Add env var to production environment