### PR TITLE
fix: get waid from messages instead of contacts

### DIFF
--- a/backend/src/govsg/services/govsg-callback.service.ts
+++ b/backend/src/govsg/services/govsg-callback.service.ts
@@ -316,8 +316,7 @@ const parseUserMessageWebhook = async (
   body: UserMessageWebhook,
   clientId: WhatsAppApiClient
 ): Promise<void> => {
-  const { wa_id: whatsappId } = body.contacts[0]
-  const { id: messageId, type } = body.messages[0]
+  const { id: messageId, from: whatsappId, type } = body.messages[0]
   if (type !== WhatsappWebhookMessageType.text) {
     // not text message, log and ignore
     logger.info({


### PR DESCRIPTION
## Problem

We've been throwing type errors due to `contacts` being `undefined`.

This observation contradicts [Meta's docs](https://developers.facebook.com/docs/whatsapp/on-premises/reference/contacts/) but this is not the first observed contradiction.

Also, the same information that we want is available in the form of `body.messages[0].from` already.

## Solution

As such, we simply read `body.messages[0].from` instead of `contacts`.
