### PR TITLE
feat: remove click to reveal

### DIFF
--- a/backend/src/govsg/middlewares/govsg-verification.middleware.ts
+++ b/backend/src/govsg/middlewares/govsg-verification.middleware.ts
@@ -167,25 +167,3 @@ export const resendMessage = async (
     wamid: serviceProviderMessageId,
   })
 }
-
-export const trackPasscodeReveal = async (
-  req: Request,
-  res: Response
-): Promise<Response | void> => {
-  const { govsg_message_id: govsgMessageId } = req.body
-  const userClickedAt = new Date()
-  await GovsgVerification.update(
-    { userClickedAt },
-    {
-      where: {
-        govsgMessageId,
-        userClickedAt: {
-          [Op.eq]: null,
-        },
-      },
-    }
-  )
-  return res.json({
-    govsg_message_id: govsgMessageId,
-  })
-}

--- a/backend/src/govsg/routes/govsg-campaign.routes.ts
+++ b/backend/src/govsg/routes/govsg-campaign.routes.ts
@@ -152,14 +152,4 @@ router.post(
   GovsgVerificationMiddleware.resendMessage
 )
 
-router.post(
-  '/track-passcode-reveal',
-  celebrate({
-    [Segments.BODY]: {
-      govsg_message_id: Joi.string().required(),
-    },
-  }),
-  GovsgVerificationMiddleware.trackPasscodeReveal
-)
-
 export default router

--- a/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.module.scss
@@ -1,24 +1,6 @@
 @import 'styles/_variables';
 @import 'styles/_mixins';
 
-details > summary {
-  list-style: none;
-}
-
-details[open] > summary {
-  display: none;
-}
-
-summary {
-  @extend %body-2;
-  color: $primary;
-  text-decoration: underline;
-}
-
-summary:hover {
-  cursor: pointer;
-}
-
 .positive {
   background-color: $grey-300;
   border-radius: 8px;

--- a/frontend/src/components/common/StyledText/PasscodeBadge.tsx
+++ b/frontend/src/components/common/StyledText/PasscodeBadge.tsx
@@ -6,21 +6,19 @@ interface PasscodeBadgeProps {
   key: string
   label: string
   placeholder: string
-  onClick: () => void
 }
 
 export const PasscodeBadge = ({
   key,
   label,
   placeholder,
-  onClick,
 }: PasscodeBadgeProps) => {
   return (
-    <details key={key}>
-      <summary onClick={onClick}>Click to reveal</summary>
-      <span className={label ? cx(styles.positive) : cx(styles.negative)}>
-        {label ? label : placeholder}
-      </span>
-    </details>
+    <span
+      key={key}
+      className={label ? cx(styles.positive) : cx(styles.negative)}
+    >
+      {label ? label : placeholder}
+    </span>
   )
 }

--- a/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
+++ b/frontend/src/components/dashboard/create/govsg/GovsgMessages.tsx
@@ -120,15 +120,6 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
     await searchGovsgMessages(newSearch, 0)
   }
 
-  const trackPasscodeReveal = useCallback(
-    async (govsgMessage: GovsgMessage) => {
-      await axios.post(`/campaign/${campaignId}/govsg/track-passcode-reveal`, {
-        govsg_message_id: govsgMessage.id,
-      })
-    },
-    []
-  )
-
   const passcodeColumn = shouldHavePasscode
     ? [
         {
@@ -139,7 +130,6 @@ export const GovsgMessages = ({ campaignId }: GovsgMessagesProps) => {
                 key={govsgMessage.id}
                 label={govsgMessage.passcode}
                 placeholder="N/A"
-                onClick={async () => await trackPasscodeReveal(govsgMessage)}
               />
             )
           },


### PR DESCRIPTION
As requested by Paul and users

## Before
<img width="1512" alt="click-to-reveal-before" src="https://github.com/opengovsg/postmangovsg/assets/14961285/cae95fc5-0911-4a6b-9b3e-18d085beb4a8">

## After
<img width="1512" alt="click-to-reveal-after" src="https://github.com/opengovsg/postmangovsg/assets/14961285/bf40561a-28af-4689-b060-897c8e859552">

## Won't do

- Removing the `user_clicked_at` column
