### PR TITLE
refactor: remove .env value

### DIFF
--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -183,7 +183,6 @@ interface ConfigSchema {
     clientSecret: string
     privateKey: string
     redirectUri: string
-    validDomains: string
   }
 }
 
@@ -852,13 +851,6 @@ const config: Config<ConfigSchema> = convict({
       doc: 'Redirect URI of application registered with sgID',
       default: '',
       env: 'SGID_REDIRECT_URI',
-      format: 'required-string',
-      sensitive: true,
-    },
-    validDomains: {
-      doc: 'Valid email domains that can log in with sgID',
-      default: '',
-      env: 'SGID_VALID_DOMAINS',
       format: 'required-string',
       sensitive: true,
     },


### PR DESCRIPTION
## Problem

We no longer need the `SGID_VALID_DOMAINS` env var so we can remove it. 

## Deployment Checklist

- [ ] Delete var from production
- [ ] Delete var from staging