### PR TITLE
refactor: update SGID scope and POCDEX profile field names

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -209,7 +209,7 @@
         "filename": "backend/src/core/services/auth.service.ts",
         "hashed_secret": "f114703480996b273d7e57cbd195b4ab1e70a21b",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 64
       }
     ],
     "backend/src/email/services/tests/email-template.service.test.ts": [
@@ -365,5 +365,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-25T09:48:43Z"
+  "generated_at": "2023-10-20T05:18:31Z"
 }

--- a/backend/src/core/middlewares/auth.middleware.ts
+++ b/backend/src/core/middlewares/auth.middleware.ts
@@ -292,7 +292,7 @@ export const InitAuthMiddleware = (authService: AuthService) => {
       if (
         !req.session.sgid?.profiles ||
         !req.session.sgid.profiles.some(
-          (p: SgidPublicOfficerEmployment) => p.workEmail === workEmail
+          (p: SgidPublicOfficerEmployment) => p.work_email === workEmail
         )
       ) {
         logger.error({ message: 'Selected profile is not valid', ...logMeta })

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -59,8 +59,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     redirectUri: SGID_REDIRECT_URI,
   })
 
-  const SGID_PUBLIC_OFFICER_EMPLOYMENT_SCOPE =
-    'pocdex.public_officer_employments'
+  const SGID_PUBLIC_OFFICER_DETAILS_SCOPE = 'pocdex.public_officer_details'
   const SGID_FIELD_EMPTY = 'NA'
   const otpCharset = '234567ABCDEFGHIJKLMNOPQRSTUVWXYZ'
   /**
@@ -345,7 +344,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     const { codeChallenge, codeVerifier } = generatePkcePair()
 
     const { url, nonce } = sgidClient.authorizationUrl({
-      scope: ['openid', SGID_PUBLIC_OFFICER_EMPLOYMENT_SCOPE].join(' '),
+      scope: ['openid', SGID_PUBLIC_OFFICER_DETAILS_SCOPE].join(' '),
       codeChallenge,
     })
 
@@ -415,7 +414,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
   ): Promise<SgidPublicOfficerEmployment[]> => {
     const logMeta = { action: 'getSgidUserProfiles' }
     const profiles = JSON.parse(
-      userInfo.data[SGID_PUBLIC_OFFICER_EMPLOYMENT_SCOPE]
+      userInfo.data[SGID_PUBLIC_OFFICER_DETAILS_SCOPE]
     ) as SgidPublicOfficerEmployment[]
     logger.info({
       message: 'User attempting to log in with the following profiles',
@@ -441,7 +440,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     const validProfiles = []
     for (const profile of userProfiles) {
       // We want to log the absence of workEmail to measure the data completeness from SGID.
-      if (profile.workEmail === SGID_FIELD_EMPTY) {
+      if (profile.work_email === SGID_FIELD_EMPTY) {
         logger.warn({
           message: 'Work email is missing from SGID data',
           ...logMeta,
@@ -450,7 +449,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
         continue
       }
       try {
-        const isWhitelisted = await isWhitelistedEmail(profile.workEmail)
+        const isWhitelisted = await isWhitelistedEmail(profile.work_email)
         if (isWhitelisted) {
           validProfiles.push(profile)
         } else {
@@ -481,34 +480,34 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     const logMeta = { action: 'cleanSgidUserProfiles' }
     const cleanedProfiles = userProfiles.map((profile) => {
       // DB only accepts lowercase emails
-      profile.workEmail = profile.workEmail.toLowerCase().trim()
+      profile.work_email = profile.work_email.toLowerCase().trim()
       // If SGID does not have the field, we want to log the missing value and return an empty string
-      if (profile.agencyName === SGID_FIELD_EMPTY) {
-        profile.agencyName = ''
+      if (profile.agency_name === SGID_FIELD_EMPTY) {
+        profile.agency_name = ''
         logger.warn({
           message: 'Agency name is missing from SGID data',
           ...logMeta,
           profile,
         })
       }
-      if (profile.departmentName === SGID_FIELD_EMPTY) {
-        profile.departmentName = ''
+      if (profile.department_name === SGID_FIELD_EMPTY) {
+        profile.department_name = ''
         logger.warn({
           message: 'Department name is missing from SGID data',
           ...logMeta,
           profile,
         })
       }
-      if (profile.employmentTitle === SGID_FIELD_EMPTY) {
-        profile.employmentTitle = ''
+      if (profile.employment_title === SGID_FIELD_EMPTY) {
+        profile.employment_title = ''
         logger.warn({
           message: 'Employment title is missing from SGID data',
           ...logMeta,
           profile,
         })
       }
-      if (profile.employmentType === SGID_FIELD_EMPTY) {
-        profile.employmentType = ''
+      if (profile.employment_type === SGID_FIELD_EMPTY) {
+        profile.employment_type = ''
         logger.warn({
           message: 'Employment type is missing from SGID data',
           ...logMeta,

--- a/backend/src/core/types/auth.types.ts
+++ b/backend/src/core/types/auth.types.ts
@@ -1,7 +1,7 @@
 export type SgidPublicOfficerEmployment = {
-  agencyName: string
-  departmentName: string
-  employmentTitle: string
-  employmentType: string
-  workEmail: string
+  agency_name: string
+  department_name: string
+  employment_title: string
+  employment_type: string
+  work_email: string
 }

--- a/frontend/src/components/login/login-callback/LoginCallback.tsx
+++ b/frontend/src/components/login/login-callback/LoginCallback.tsx
@@ -60,19 +60,19 @@ const LoginCallback = () => {
       {profiles.map((profile) => (
         <div
           className={styles.profileBlock}
-          key={profile.workEmail}
-          onClick={() => confirmSgidProfile(profile.workEmail)}
+          key={profile.work_email}
+          onClick={() => confirmSgidProfile(profile.work_email)}
         >
           <div>
-            <div className={styles.profileMainText}>{profile.workEmail}</div>
-            {!!profile.agencyName && (
+            <div className={styles.profileMainText}>{profile.work_email}</div>
+            {!!profile.agency_name && (
               <div className={styles.profileSubText}>
-                {profile.agencyName}
-                {!!profile.departmentName && `, ${profile.departmentName}`}
+                {profile.agency_name}
+                {!!profile.department_name && `, ${profile.department_name}`}
               </div>
             )}
             <div className={styles.profileSubText}>
-              {!!profile.employmentTitle && profile.employmentTitle}
+              {!!profile.employment_title && profile.employment_title}
             </div>
           </div>
           <img src={RightChevron} alt="Select profile" />

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -4,11 +4,11 @@ import axios from 'axios'
 import { setGAUserId } from './ga.service'
 
 export type SgidUserProfile = {
-  workEmail: string
-  agencyName: string
-  departmentName: string
-  employmentType: string
-  employmentTitle: string
+  work_email: string
+  agency_name: string
+  department_name: string
+  employment_type: string
+  employment_title: string
 }
 
 async function getOtpWithEmail(email: string): Promise<void> {


### PR DESCRIPTION
## Problem

The SGID team made some breaking changes to the POCDEX login flow, as such in this PR, I have updated our BE and FE code to adhere to the newest changes. 

## Solution

- POCDEX scope has changed from `pocdex.public_officer_employments` to `pocdex.public_officer_details`
- The structure of data from the POCDEX scope has changed as well. The fields are now snake_case instead of camelCase

