### PR TITLE
feat: disable tracking in transactional email

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,9 @@ RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-
 
 RUN apk add jq
 
+# There was a breaking change in the base image used that prevents us from installing via pip
+# Instead of activating a virtual env, this is a simpler workaround
+# https://github.com/python/cpython/issues/102134
 RUN apk add --no-cache aws-cli
 
 RUN aws configure set default.region ap-southeast-1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-
 
 RUN apk add jq
 
-RUN python3 -m pip install awscli
+RUN apk add --no-cache aws-cli
 
 RUN aws configure set default.region ap-southeast-1
 

--- a/backend/src/core/config.ts
+++ b/backend/src/core/config.ts
@@ -83,6 +83,7 @@ interface ConfigSchema {
   }
   mailFrom: string
   mailConfigurationSet: string
+  noTrackingMailConfigurationSet: string
   mailVia: string
   mailDefaultRate: number
   transactionalEmail: {
@@ -467,6 +468,11 @@ const config: Config<ConfigSchema> = convict({
     doc: 'The configuration set specified when sending an email',
     default: 'postman-email-open',
     env: 'BACKEND_SES_CONFIGURATION_SET',
+  },
+  noTrackingMailConfigurationSet: {
+    doc: 'AWS SES Configuration set that does not include open and read tracking',
+    default: 'postman-email-no-tracking',
+    env: 'BACKEND_SES_NO_TRACKING_CONFIGURATION_SET',
   },
   mailVia: {
     doc: 'Text to appended to custom sender name',

--- a/backend/src/core/services/mail.service.ts
+++ b/backend/src/core/services/mail.service.ts
@@ -5,7 +5,8 @@ const mailClient = new MailClient(
   config.get('mailOptions'),
   config.get('emailCallback.hashSecret'),
   config.get('emailFallback.activate') ? config.get('mailFrom') : undefined,
-  config.get('mailConfigurationSet')
+  config.get('mailConfigurationSet'),
+  config.get('noTrackingMailConfigurationSet')
 )
 
 export const MailService = {

--- a/backend/src/email/middlewares/email-transactional.middleware.ts
+++ b/backend/src/email/middlewares/email-transactional.middleware.ts
@@ -67,6 +67,7 @@ export const InitEmailTransactionalMiddleware = (
     tag?: string
     cc?: string[]
     bcc?: string[]
+    disable_tracking?: boolean
   }
   type ReqBodyWithId = ReqBody & { emailMessageTransactionalId: string }
 
@@ -210,6 +211,7 @@ export const InitEmailTransactionalMiddleware = (
       cc,
       bcc,
       emailMessageTransactionalId, // added by saveMessage middleware
+      disable_tracking: disableTracking,
     } = req.body
 
     try {
@@ -275,6 +277,7 @@ export const InitEmailTransactionalMiddleware = (
             ? bcc.filter((c) => !blacklistedRecipients.includes(c))
             : undefined,
         emailMessageTransactionalId,
+        disableTracking,
       })
       emailMessageTransactional.set(
         'status',

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -62,7 +62,7 @@ export const InitEmailTransactionalRoute = (
         .items(
           Joi.string().trim().email().options({ convert: true }).lowercase()
         ),
-      disable_tracking: Joi.boolean().optional(),
+      disable_tracking: Joi.boolean().default(false),
     }),
   }
   const getByIdValidator = {

--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -62,6 +62,7 @@ export const InitEmailTransactionalRoute = (
         .items(
           Joi.string().trim().email().options({ convert: true }).lowercase()
         ),
+      disable_tracking: Joi.boolean().optional(),
     }),
   }
   const getByIdValidator = {

--- a/backend/src/email/routes/tests/email-transactional.routes.test.ts
+++ b/backend/src/email/routes/tests/email-transactional.routes.test.ts
@@ -368,7 +368,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
         ).id.toString(),
         attachments: undefined,
       },
-      { extraSmtpHeaders: { isTransactional: true } }
+      { disableTracking: false, extraSmtpHeaders: { isTransactional: true } }
     )
   })
   test('Should throw a 400 error if the body size is too large (JSON payload)', async () => {
@@ -616,6 +616,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
         ],
       },
       {
+        disableTracking: false,
         extraSmtpHeaders: { isTransactional: true },
       }
     )
@@ -692,6 +693,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
         ],
       },
       {
+        disableTracking: false,
         extraSmtpHeaders: { isTransactional: true },
       }
     )
@@ -825,6 +827,7 @@ describe(`${emailTransactionalRoute}/send`, () => {
         ],
       },
       {
+        disableTracking: false,
         extraSmtpHeaders: { isTransactional: true },
       }
     )

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -41,6 +41,7 @@ async function sendMessage({
   cc,
   bcc,
   emailMessageTransactionalId,
+  disableTracking,
 }: {
   subject: string
   body: string
@@ -51,6 +52,7 @@ async function sendMessage({
   cc?: string[]
   bcc?: string[]
   emailMessageTransactionalId: string
+  disableTracking?: boolean
 }): Promise<void> {
   // TODO: flagging this coupling for future refactoring:
   // currently, we are using EmailTemplateService to sanitize both tx emails and campaign emails
@@ -99,6 +101,7 @@ async function sendMessage({
   // receive from SES, but not saving to DB
   const isEmailSent = await EmailService.sendEmail(mailToSend, {
     extraSmtpHeaders: { isTransactional: true },
+    disableTracking,
   })
   if (!isEmailSent) {
     throw new Error('Failed to send transactional email')

--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -18,6 +18,13 @@ export default class MailClient {
   private email: string
   private hashSecret: string
   private defaultConfigSet: string | undefined
+  /*
+    The AWS SES events to be tracked are defined in configuration sets within the AWS console.
+    When an email is sent, we specify the configuration set to be used by setting "X-SES-CONFIGURATION-SET" in the API call header.
+
+    There is no option to turn off tracking via parameters in the API call, it can only be configured through a configuration set.
+    Thus, we need multiple configuration sets to toggle the tracking feature for read and open receipts.
+  */
   private noTrackingConfigSet: string | undefined
 
   constructor(

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -21,6 +21,9 @@ RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-
 
 RUN apk add jq
 
+# There was a breaking change in the base image used that prevents us from installing via pip
+# Instead of activating a virtual env, this is a simpler workaround
+# https://github.com/python/cpython/issues/102134
 RUN apk add --no-cache aws-cli
 
 RUN aws configure set default.region ap-southeast-1

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -21,7 +21,7 @@ RUN apk update && apk upgrade && apk add --no-cache --virtual builds-deps build-
 
 RUN apk add jq
 
-RUN python3 -m pip install awscli
+RUN apk add --no-cache aws-cli
 
 RUN aws configure set default.region ap-southeast-1
 


### PR DESCRIPTION
## Problem

AWS SES includes a 1x1 tracking pixel to detect whether or not a user has opened/read an email.  GSIBs block this tracking pixel which causes it to appear as a little red X at the bottom of emails. This makes the emails appear suspicious.

In this PR, I add a feature to enable transactional email users to turn off this tracking feature via a new `disable_tracking` flag. This would prevent this issue from popping up. 

## Solution

The events that are tracked by SES is determined by the configuration set that SES uses when sending out the email. This configuration set is determined by the value of the `X-SES-CONFIGURATION-SET` header. Configuration sets are defined via the AWS console. 

I've added an additional configuration set (`postman-email-no-tracking`) to `ap-southeast-2` that does not include tracking `Open` and `Read` states. This prevents the gif from being added. 

Additionally, the transactional email request body now includes an optional `disable_tracking` field that users can set to `true` if they don't want the tracking pixel to be added. When tracking is disabled, we will use the `postman-email-no-tracking` configuration set instead of the default `postman-email-open` configuration set.

## Deployment Notes

### New Env Vars
- `BACKEND_SES_NO_TRACKING_CONFIGURATION_SET` : `Name of SES configuration set that does not include tracking open/read events`
