### PR TITLE
refactor: bad sgid session returns 400 instead of 500

### DIFF
--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -362,7 +362,8 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
   }
 
   /**
-   * Checks the user's sgID code and returns their singpass info if valid
+   * Checks the user's sgID code and returns their singpass info if valid.
+   * This function assumes that req.session.sgid has already been validated by the calling function.
    * @param req
    * @param code
    */
@@ -373,10 +374,7 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
     | { authenticated: true; data: UserInfoReturn }
     | { authenticated: false; reason: string }
   > => {
-    if (!req.session || !req.session.sgid) {
-      throw new Error('Unable to find user session')
-    }
-    const { codeVerifier, nonce } = req.session.sgid
+    const { codeVerifier, nonce } = req.session!.sgid
 
     if (typeof codeVerifier !== 'string' || typeof nonce !== 'string') {
       throw new Error('Invalid parameter types')


### PR DESCRIPTION
## Problem

Since Feb 8 2024, the `POST /login/sgid` endpoint is called twice whenever a user attempts to log in via a GSIB device. One of the API calls is made without `req.session.sgid` set and thus fails in the BE and results in a HTTP 500 being returned. 

However, this HTTP 500 does not affect the user's ability to log in and is not reflected in the network tab of the developer console as well. Thus, the impact of this issue is low. Instead of returning a HTTP 500, we are choosing to downgrade the error to a HTTP 400 instead to reflect the seriousness of the issue. 

Our current hypothesis is that this second call is made by SIS instead of our FE due to `*.postman.gov.sg` being whitelisted on SGProxy but the SGID URL having to go through SIS. The emergence of this issue also nicely corresponds to the date we whitelisted `*.postman.gov.sg` which lends credence to the hypothesis.
