### PR TITLE
fix: email attachments

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -17,7 +17,7 @@ frontend:
         - if [ "${AWS_BRANCH}" = "master" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION} &&
           export REACT_APP_ENVIRONMENT="production" &&
-          export REACT_APP_IMG_SERVER_URL="https://postman.gov.sg/v1";
+          export REACT_APP_IMG_SERVER_URL="https://legacy.postman.gov.sg/v1";
           elif [ "${AWS_BRANCH}" = "momgovsg" ]; then
           export REACT_APP_BACKEND_URL=${BACKEND_URL_PRODUCTION_MOM} &&
           export REACT_APP_ENVIRONMENT="production-02";


### PR DESCRIPTION
## Problem

Attachments broke when I performed the DNS migration to the legacy site. I think this is because we are injecting an ENV var at build time in amplify. This PR should fix it 🙏 
