### PR TITLE
fix: reject utf8 emails in transactional endpoint

### DIFF
--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -24,7 +24,9 @@ export const InitEmailTransactionalRoute = (
   const sendValidator = {
     [Segments.BODY]: Joi.object({
       recipient: Joi.string()
-        .email()
+        .email({
+          allowUnicode: false,
+        })
         .options({ convert: true })
         .lowercase()
         .required(),


### PR DESCRIPTION
## Problem

In this PR, I modify the validation for the transactional email endpoint such that it rejects emails that contain UTF8 characters with a HTTP 400. In the current implementation, we allow for emails with UTF8 characters. However, these email addresses are ultimately rejected by AWS SES which result in a HTTP 500 being thrown from the transactional email endpoint. Since AWS SES currently does not support UTF8 characters in the local part of emails and there are no workarounds, the only option we have is to gracefully reject these email addresses. 

