### PR TITLE
feat: add user_id indx to email_messages_transactional

### DIFF
--- a/backend/src/database/migrations/20240812063204-add-user-id-index-to-email-messages-transactional.js
+++ b/backend/src/database/migrations/20240812063204-add-user-id-index-to-email-messages-transactional.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('email_messages_transactional', {
+      name: 'email_messages_transactional_user_id_idx',
+      fields: ['user_id']
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('email_messages_transactional', 'email_messages_transactional_user_id_idx')
+  }
+};

--- a/backend/src/database/migrations/20240812063204-add-user-id-index-to-email-messages-transactional.js
+++ b/backend/src/database/migrations/20240812063204-add-user-id-index-to-email-messages-transactional.js
@@ -3,12 +3,12 @@
 module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.addIndex('email_messages_transactional', {
-      name: 'email_messages_transactional_user_id_idx',
-      fields: ['user_id']
+      name: 'email_messages_transactional_user_id_tag_idx',
+      fields: ['user_id', 'tag']
     })
   },
 
   down: async (queryInterface, Sequelize) => {
-    await queryInterface.removeIndex('email_messages_transactional', 'email_messages_transactional_user_id_idx')
+    await queryInterface.removeIndex('email_messages_transactional', 'email_messages_transactional_user_id_tag_idx')
   }
 };


### PR DESCRIPTION
## Problem

In this PR, I add a `user_id` indx to `email_messages_transactional`. Currently, the list messages endpoint is performing a sequential scan that regularly takes > 30s. This is causing client calls to timeout. Thus, by adding this index, we hope to improve the performance of this endpoint. 

## Deployment Checklist

- [x] Run migration on `staging`
- [x] Run migration on `production`
