### PR TITLE
feat: add migration files for index

### DIFF
--- a/backend/src/database/migrations/20241101014358-email-messages-aggregation-index.js
+++ b/backend/src/database/migrations/20241101014358-email-messages-aggregation-index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('email_messages', {
+      name: 'email_messages_campaign_id_status_error_code',
+      fields: ['campaign_id', 'status', 'error_code'],
+      concurrently: true,
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('email_messages', 'email_messages_campaign_id_status_error_code')
+  }
+};

--- a/backend/src/database/migrations/20241101015340-remove-email-messages-campaign_id_indx.js
+++ b/backend/src/database/migrations/20241101015340-remove-email-messages-campaign_id_indx.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.removeIndex('email_messages', 'email_messages_campaign_id')
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addIndex('email_messages', {
+      name: 'email_messages_campaign_id',
+      fields: ['campaign_id'],
+      concurrently: true,
+    })
+  }
+};


### PR DESCRIPTION
## Problem

This PR is part of my solution for the aggregation problem. The current explain plan hints at some inefficiencies where we are filtering through many rows in order to derive the result we need. My hypothesis is that this would perform significantly better if we add a proper index to allow efficient filtering of `status` and `error_code`. In this PR, I add the relevant index for this. 

<img width="1039" alt="Screenshot 2024-11-01 at 10 00 50 AM" src="https://github.com/user-attachments/assets/4b6041d6-8300-4863-b61e-b5675122c497">


## Deployment Checklist

- [ ] Run migration on `staging`
- [ ] Run migration on `production`
