### PR TITLE
chore: update github actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,7 +54,7 @@ jobs:
           SMS_NUMBER: "+6582410222"
           MAILBOX: internal-testing@open.gov.sg
         working-directory: e2e
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
## Problem

Github actions is deprecating `actions/upload-artifact@v3`. In this PR I ensure that we use `v4`.
