### PR TITLE
chore: remove record log and turn on dbm propagation

### DIFF
--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -225,7 +225,6 @@ const blacklistIfNeeded = async (message: any): Promise<void> => {
 const parseRecord = async (record: SesRecord): Promise<void> => {
   logger.info({
     message: 'Parsing SES callback record',
-    record,
   })
   const message = JSON.parse(record.Message)
   const smtpApiHeader = getSmtpApiHeader(message)

--- a/shared/src/tracing.ts
+++ b/shared/src/tracing.ts
@@ -10,6 +10,7 @@ const ENABLE_PROFILING_FOR_20_PER_CENT = RANDOM_NUMBER_MAX_100 <= 20 // 20% chan
 export function init() {
   tracer.init({
     profiling: ENABLE_PROFILING_FOR_20_PER_CENT,
+    dbmPropagationMode: 'full',
   })
   tracer.use('http', {
     client: {


### PR DESCRIPTION
## Problem

This PR is a continuation of #2283. The profile from the latest callback spike indicates that the logging statement in the callback flow is introducing a significant bottleneck to our processing. This could be explained by the log statement that attempts to log out the entire record that is returned to us by SNS. 

<img width="1146" alt="Screenshot 2024-11-20 at 10 35 18 AM" src="https://github.com/user-attachments/assets/73677da2-4969-4516-9868-63741f3ba9e0">


## Solution

In this PR, I avoid logging out the entire record in an attempt to remove the above-mentioned bottleneck. Additionally, I also set `dbmPropagationMode: 'full'` in our tracers so that we can retrieve explain plans of the SQL statements we are executing in the future. Based on the traces, the DB query is the next potential bottleneck in the execution and generating data on its performance will allow us to optimise in the future. 
