### PR TITLE
Fix/form data cc bcc single recipient

### DIFF
--- a/backend/src/email/routes/email-transactional.routes.ts
+++ b/backend/src/email/routes/email-transactional.routes.ts
@@ -21,6 +21,45 @@ export const InitEmailTransactionalRoute = (
   const router = Router({ mergeParams: true })
 
   // Validators
+  const emailArrayValidation = (fieldName: 'cc' | 'bcc') => {
+    return Joi.alternatives().try(
+      // array
+      Joi.array()
+        .unique()
+        .items(
+          Joi.string().trim().email().options({ convert: true }).lowercase()
+        ),
+
+      // stringified array (form-data)
+      Joi.string().custom((value: string) => {
+        let parsed
+        try {
+          parsed = JSON.parse(value)
+        } catch {
+          throw new Error(
+            `${fieldName} must be a valid array or stringified array.`
+          )
+        }
+
+        if (!Array.isArray(parsed)) {
+          throw new Error(`${fieldName} must be a valid stringified array`)
+        }
+        const { value: validatedEmails, error } = Joi.array()
+          .unique()
+          .items(
+            Joi.string().email().trim().lowercase().options({ convert: true })
+          )
+          .validate(parsed)
+
+        if (error) {
+          throw new Error(`${fieldName} ${error.message}`)
+        }
+
+        return validatedEmails
+      })
+    )
+  }
+
   const sendValidator = {
     [Segments.BODY]: Joi.object({
       recipient: Joi.string()
@@ -54,16 +93,8 @@ export const InitEmailTransactionalRoute = (
         .valid(...Object.values(TransactionalEmailClassification))
         .optional(),
       tag: Joi.string().max(255).optional(),
-      cc: Joi.array()
-        .unique()
-        .items(
-          Joi.string().trim().email().options({ convert: true }).lowercase()
-        ),
-      bcc: Joi.array()
-        .unique()
-        .items(
-          Joi.string().trim().email().options({ convert: true }).lowercase()
-        ),
+      cc: emailArrayValidation('cc'),
+      bcc: emailArrayValidation('bcc'),
       disable_tracking: Joi.boolean().default(false),
     }),
   }


### PR DESCRIPTION
## Problem
Unable to send a single CC/BCC recipient when calling the transactional email API with form-data. This appears to be an edge case, as there are no issues when sending multiple CC/BCC recipients using form-data.

```
// how we normally append CC/BCC with more than 1 recipient
// this is accepted
formData.append('cc', 'user@agency.gov.sg')
formData.append('cc', 'admin@agency.gov.sg')

// BUT fails when only 1 recipient, api validation interprets this as a string
// returning error message 'cc must be an array'
formData.append('cc', 'user@agency.gov.sg')


// other alternatives that were tested but not allowed by api
formData.append('cc[]', 'user@agency.gov.sg')
formData.append('cc', ['user@agency.gov.sg'])  // form-data does not accept arrays
formData.append('cc', JSON.stringify(['user@agency.gov.sg']))  // api does not accept stringified arrays
```
Note: Postman requires attachments to be sent via form-data

Related issue highlighted by another user: https://github.com/opengovsg/postmangovsg/issues/2140 

## Solution
Enhance current CC/BCC validation to accept stringified arrays.
This change ensures:
- Compatibility with direct array submissions (existing implementation).
- Compatibility with form-data, where cc can be sent as a stringified JSON array.
