### PR TITLE
feat: custom spans

### DIFF
--- a/backend/src/email/middlewares/email-callback.middleware.ts
+++ b/backend/src/email/middlewares/email-callback.middleware.ts
@@ -48,25 +48,28 @@ const printConfirmSubscription = (
   res: Response,
   next: NextFunction
 ): Response | void => {
-  tracer.wrap('printConfirmSubscription', () => {
-    const { Type: type, SubscribeURL: subscribeUrl } = JSON.parse(req.body)
-    if (type === 'SubscriptionConfirmation') {
-      const parsed = new URL(subscribeUrl)
-      if (
-        parsed.protocol === 'https:' &&
-        /^sns\.[a-zA-Z0-9-]{3,}\.amazonaws\.com(\.cn)?$/.test(parsed.host)
-      ) {
-        logger.info({
-          message: 'Confirm the subscription',
-          type,
-          subscribeUrl,
-          action: 'printConfirmSubscription',
-        })
-        return res.sendStatus(202)
-      }
+  const printConfirmSubscriptionSpan = tracer.startSpan(
+    'printConfirmSubscription'
+  )
+  const { Type: type, SubscribeURL: subscribeUrl } = JSON.parse(req.body)
+  if (type === 'SubscriptionConfirmation') {
+    const parsed = new URL(subscribeUrl)
+    if (
+      parsed.protocol === 'https:' &&
+      /^sns\.[a-zA-Z0-9-]{3,}\.amazonaws\.com(\.cn)?$/.test(parsed.host)
+    ) {
+      logger.info({
+        message: 'Confirm the subscription',
+        type,
+        subscribeUrl,
+        action: 'printConfirmSubscription',
+      })
+
+      return res.sendStatus(202)
     }
-    return next()
-  })
+  }
+  printConfirmSubscriptionSpan.finish()
+  return next()
 }
 export const EmailCallbackMiddleware = {
   isAuthenticated,

--- a/backend/src/email/middlewares/email-callback.middleware.ts
+++ b/backend/src/email/middlewares/email-callback.middleware.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { EmailCallbackService } from '@email/services'
 import { loggerWithLabel } from '@core/logger'
+import { tracer } from 'dd-trace'
 
 const logger = loggerWithLabel(module)
 
@@ -9,22 +10,24 @@ const isAuthenticated = (
   res: Response,
   next: NextFunction
 ): Response | void => {
-  const authHeader = req.get('authorization')
-  if (!authHeader) {
-    // SNS will send 2 request:
-    // - first one without the basic authorization first and require the callback
-    //   server to respond with 401 WWW-Authenticate Basic realm="Email"
-    // - second one with the basic authorization
-    // The above mechanism is based on RFC-2671 https://www.rfc-editor.org/rfc/rfc2617.html#page-8
-    // Of course, this middleare is to reject all requests without the
-    // Authorization header as well
-    res.set('WWW-Authenticate', 'Basic realm="Email"')
-    return res.sendStatus(401)
-  }
-  if (EmailCallbackService.isAuthenticated(authHeader)) {
-    return next()
-  }
-  return res.sendStatus(403)
+  tracer.wrap('isAuthenticated', () => {
+    const authHeader = req.get('authorization')
+    if (!authHeader) {
+      // SNS will send 2 request:
+      // - first one without the basic authorization first and require the callback
+      //   server to respond with 401 WWW-Authenticate Basic realm="Email"
+      // - second one with the basic authorization
+      // The above mechanism is based on RFC-2671 https://www.rfc-editor.org/rfc/rfc2617.html#page-8
+      // Of course, this middleare is to reject all requests without the
+      // Authorization header as well
+      res.set('WWW-Authenticate', 'Basic realm="Email"')
+      return res.sendStatus(401)
+    }
+    if (EmailCallbackService.isAuthenticated(authHeader)) {
+      return next()
+    }
+    return res.sendStatus(403)
+  })
 }
 
 const parseEvent = async (
@@ -45,23 +48,25 @@ const printConfirmSubscription = (
   res: Response,
   next: NextFunction
 ): Response | void => {
-  const { Type: type, SubscribeURL: subscribeUrl } = JSON.parse(req.body)
-  if (type === 'SubscriptionConfirmation') {
-    const parsed = new URL(subscribeUrl)
-    if (
-      parsed.protocol === 'https:' &&
-      /^sns\.[a-zA-Z0-9-]{3,}\.amazonaws\.com(\.cn)?$/.test(parsed.host)
-    ) {
-      logger.info({
-        message: 'Confirm the subscription',
-        type,
-        subscribeUrl,
-        action: 'printConfirmSubscription',
-      })
-      return res.sendStatus(202)
+  tracer.wrap('printConfirmSubscription', () => {
+    const { Type: type, SubscribeURL: subscribeUrl } = JSON.parse(req.body)
+    if (type === 'SubscriptionConfirmation') {
+      const parsed = new URL(subscribeUrl)
+      if (
+        parsed.protocol === 'https:' &&
+        /^sns\.[a-zA-Z0-9-]{3,}\.amazonaws\.com(\.cn)?$/.test(parsed.host)
+      ) {
+        logger.info({
+          message: 'Confirm the subscription',
+          type,
+          subscribeUrl,
+          action: 'printConfirmSubscription',
+        })
+        return res.sendStatus(202)
+      }
     }
-  }
-  return next()
+    return next()
+  })
 }
 export const EmailCallbackMiddleware = {
   isAuthenticated,

--- a/backend/src/email/middlewares/email-callback.middleware.ts
+++ b/backend/src/email/middlewares/email-callback.middleware.ts
@@ -1,8 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import { EmailCallbackService } from '@email/services'
 import { loggerWithLabel } from '@core/logger'
-import { tracer } from 'dd-trace'
-
 const logger = loggerWithLabel(module)
 
 const isAuthenticated = (
@@ -10,24 +8,22 @@ const isAuthenticated = (
   res: Response,
   next: NextFunction
 ): Response | void => {
-  tracer.wrap('isAuthenticated', () => {
-    const authHeader = req.get('authorization')
-    if (!authHeader) {
-      // SNS will send 2 request:
-      // - first one without the basic authorization first and require the callback
-      //   server to respond with 401 WWW-Authenticate Basic realm="Email"
-      // - second one with the basic authorization
-      // The above mechanism is based on RFC-2671 https://www.rfc-editor.org/rfc/rfc2617.html#page-8
-      // Of course, this middleare is to reject all requests without the
-      // Authorization header as well
-      res.set('WWW-Authenticate', 'Basic realm="Email"')
-      return res.sendStatus(401)
-    }
-    if (EmailCallbackService.isAuthenticated(authHeader)) {
-      return next()
-    }
-    return res.sendStatus(403)
-  })
+  const authHeader = req.get('authorization')
+  if (!authHeader) {
+    // SNS will send 2 request:
+    // - first one without the basic authorization first and require the callback
+    //   server to respond with 401 WWW-Authenticate Basic realm="Email"
+    // - second one with the basic authorization
+    // The above mechanism is based on RFC-2671 https://www.rfc-editor.org/rfc/rfc2617.html#page-8
+    // Of course, this middleare is to reject all requests without the
+    // Authorization header as well
+    res.set('WWW-Authenticate', 'Basic realm="Email"')
+    return res.sendStatus(401)
+  }
+  if (EmailCallbackService.isAuthenticated(authHeader)) {
+    return next()
+  }
+  return res.sendStatus(403)
 }
 
 const parseEvent = async (
@@ -48,9 +44,6 @@ const printConfirmSubscription = (
   res: Response,
   next: NextFunction
 ): Response | void => {
-  const printConfirmSubscriptionSpan = tracer.startSpan(
-    'printConfirmSubscription'
-  )
   const { Type: type, SubscribeURL: subscribeUrl } = JSON.parse(req.body)
   if (type === 'SubscriptionConfirmation') {
     const parsed = new URL(subscribeUrl)
@@ -68,7 +61,6 @@ const printConfirmSubscription = (
       return res.sendStatus(202)
     }
   }
-  printConfirmSubscriptionSpan.finish()
   return next()
 }
 export const EmailCallbackMiddleware = {

--- a/backend/src/email/routes/email-callback.routes.ts
+++ b/backend/src/email/routes/email-callback.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { EmailCallbackMiddleware } from '@email/middlewares'
+import tracer from 'dd-trace'
 const router = Router()
 /**
  * paths:
@@ -16,9 +17,12 @@ const router = Router()
  */
 router.post(
   '/',
-  EmailCallbackMiddleware.printConfirmSubscription,
-  EmailCallbackMiddleware.isAuthenticated,
-  EmailCallbackMiddleware.parseEvent
+  tracer.wrap(
+    'printConfirmSubscription',
+    () => EmailCallbackMiddleware.printConfirmSubscription
+  ),
+  tracer.wrap('isAuthenticated', () => EmailCallbackMiddleware.isAuthenticated),
+  tracer.wrap('parseEvent', () => EmailCallbackMiddleware.parseEvent)
 )
 
 export default router

--- a/backend/src/email/routes/email-callback.routes.ts
+++ b/backend/src/email/routes/email-callback.routes.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import { EmailCallbackMiddleware } from '@email/middlewares'
-import tracer from 'dd-trace'
 const router = Router()
 /**
  * paths:
@@ -17,10 +16,7 @@ const router = Router()
  */
 router.post(
   '/',
-  tracer.wrap(
-    'printConfirmSubscription',
-    () => EmailCallbackMiddleware.printConfirmSubscription
-  ),
+  EmailCallbackMiddleware.printConfirmSubscription,
   EmailCallbackMiddleware.isAuthenticated,
   EmailCallbackMiddleware.parseEvent
 )

--- a/backend/src/email/routes/email-callback.routes.ts
+++ b/backend/src/email/routes/email-callback.routes.ts
@@ -21,8 +21,8 @@ router.post(
     'printConfirmSubscription',
     () => EmailCallbackMiddleware.printConfirmSubscription
   ),
-  tracer.wrap('isAuthenticated', () => EmailCallbackMiddleware.isAuthenticated),
-  tracer.wrap('parseEvent', () => EmailCallbackMiddleware.parseEvent)
+  EmailCallbackMiddleware.isAuthenticated,
+  EmailCallbackMiddleware.parseEvent
 )
 
 export default router

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -2,6 +2,7 @@ import { Request } from 'express'
 import { ses, sendgrid } from '@email/utils/callback/parsers'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
+import { tracer } from 'dd-trace'
 
 const logger = loggerWithLabel(module)
 
@@ -24,7 +25,9 @@ const isAuthenticated = (authHeader?: string): boolean => {
 }
 
 const parseEvent = async (req: Request): Promise<void> => {
+  const parseJsonSpan = tracer.startSpan('parseJson')
   const parsed = JSON.parse(req.body)
+  parseJsonSpan.finish()
   let records: Promise<void>[] = []
   if (ses.isEvent(req)) {
     // body could be one record or an array of records, hence we concat

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -45,7 +45,7 @@ const parseEvent = async (req: Request): Promise<void> => {
   }
   const parseNotificationAndEventSpan = tracer.startSpan(
     'parseNotificationAndEvent',
-    { childOf: parseJsonSpan }
+    { childOf: tracer.scope().active() || undefined }
   )
   await Promise.all(records)
   parseNotificationAndEventSpan.finish()

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -25,8 +25,9 @@ const isAuthenticated = (authHeader?: string): boolean => {
 }
 
 const parseEvent = async (req: Request): Promise<void> => {
-  const parentSpan = tracer.scope().active() || undefined
-  const parseJsonSpan = tracer.startSpan('parseJson', { childOf: parentSpan })
+  const parseJsonSpan = tracer.startSpan('parseJson', {
+    childOf: tracer.scope().active() || undefined,
+  })
   const parsed = JSON.parse(req.body)
   parseJsonSpan.finish()
   let records: Promise<void>[] = []

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -35,7 +35,11 @@ const parseEvent = async (req: Request): Promise<void> => {
     // body could be one record or an array of records, hence we concat
     const body: ses.SesRecord[] = []
     const sesHttpEvent = body.concat(parsed)
+    const parseAllRecordsSpan = tracer.startSpan('parseAllRecords', {
+      childOf: tracer.scope().active() || undefined,
+    })
     records = sesHttpEvent.map(ses.parseRecord)
+    parseAllRecordsSpan.finish()
   } else if (sendgrid.isEvent(req)) {
     // body is always an array
     const sgEvent = parsed
@@ -44,7 +48,7 @@ const parseEvent = async (req: Request): Promise<void> => {
     throw new Error('Unable to handle this event')
   }
   const parseNotificationAndEventSpan = tracer.startSpan(
-    'parseNotificationAndEvent',
+    'parseAllNotificationAndEvents',
     { childOf: tracer.scope().active() || undefined }
   )
   await Promise.all(records)

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -43,6 +43,11 @@ const parseEvent = async (req: Request): Promise<void> => {
   } else {
     throw new Error('Unable to handle this event')
   }
+  const parseNotificationAndEventSpan = tracer.startSpan(
+    'parseNotificationAndEvent',
+    { childOf: parseJsonSpan }
+  )
   await Promise.all(records)
+  parseNotificationAndEventSpan.finish()
 }
 export const EmailCallbackService = { isAuthenticated, parseEvent }

--- a/backend/src/email/services/email-callback.service.ts
+++ b/backend/src/email/services/email-callback.service.ts
@@ -25,7 +25,8 @@ const isAuthenticated = (authHeader?: string): boolean => {
 }
 
 const parseEvent = async (req: Request): Promise<void> => {
-  const parseJsonSpan = tracer.startSpan('parseJson')
+  const parentSpan = tracer.scope().active() || undefined
+  const parseJsonSpan = tracer.startSpan('parseJson', { childOf: parentSpan })
   const parsed = JSON.parse(req.body)
   parseJsonSpan.finish()
   let records: Promise<void>[] = []

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -129,10 +129,11 @@ type CallbackMetaData = {
 async function handleStatusCallbacks(
   type: SesEventType,
   id: string,
-  metadata: CallbackMetaData
+  metadata: CallbackMetaData,
+  parentSpan?: tracer.Span
 ): Promise<void> {
   const handleStatusCallbacksSpan = tracer.startSpan('handleStatusCallbacks', {
-    childOf: tracer.scope().active() || undefined,
+    childOf: parentSpan,
   })
   const emailMessageTransactional = await EmailMessageTransactional.findByPk(id)
   if (!emailMessageTransactional) {

--- a/backend/src/email/services/email-transactional.service.ts
+++ b/backend/src/email/services/email-transactional.service.ts
@@ -16,6 +16,7 @@ import {
 } from '@core/constants'
 import { Order } from 'sequelize/types/model'
 import { Op, WhereOptions } from 'sequelize'
+import tracer from 'dd-trace'
 
 const logger = loggerWithLabel(module)
 
@@ -130,103 +131,107 @@ async function handleStatusCallbacks(
   id: string,
   metadata: CallbackMetaData
 ): Promise<void> {
-  const emailMessageTransactional = await EmailMessageTransactional.findByPk(id)
-  if (!emailMessageTransactional) {
-    throw new Error(`Failed to find emailMessageTransactional for id: ${id}`)
-  }
+  tracer.wrap('handleStatusCallbacks', async () => {
+    const emailMessageTransactional = await EmailMessageTransactional.findByPk(
+      id
+    )
+    if (!emailMessageTransactional) {
+      throw new Error(`Failed to find emailMessageTransactional for id: ${id}`)
+    }
 
-  const mainRecipientDelivered = metadata.delivery?.recipients?.find(
-    (e) => e === emailMessageTransactional.recipient
-  )
-  const mainRecipientBounced = metadata.bounce?.bouncedRecipients?.find(
-    (e) => e.emailAddress === emailMessageTransactional.recipient
-  )
-  const mainRecipientComplained =
-    metadata.complaint?.complainedRecipients?.find(
+    const mainRecipientDelivered = metadata.delivery?.recipients?.find(
+      (e) => e === emailMessageTransactional.recipient
+    )
+    const mainRecipientBounced = metadata.bounce?.bouncedRecipients?.find(
       (e) => e.emailAddress === emailMessageTransactional.recipient
     )
+    const mainRecipientComplained =
+      metadata.complaint?.complainedRecipients?.find(
+        (e) => e.emailAddress === emailMessageTransactional.recipient
+      )
 
-  switch (type) {
-    case SesEventType.Delivery:
-      if (mainRecipientDelivered) {
-        await EmailMessageTransactional.update(
-          {
-            status: TransactionalEmailMessageStatus.Delivered,
-            deliveredAt: metadata.timestamp,
-          },
-          {
-            where: { id },
-          }
-        )
-      }
-      break
-    case SesEventType.Bounce:
-      // check that bounce applies to the main recipient
-      if (mainRecipientBounced) {
-        await EmailMessageTransactional.update(
-          {
-            status: TransactionalEmailMessageStatus.Bounced,
-            errorCode:
-              metadata.bounce?.bounceType === 'Permanent'
-                ? 'Hard bounce'
-                : 'Soft bounce',
-            errorSubType: metadata.bounce?.bounceSubType,
-          },
-          {
-            where: { id },
-          }
-        )
-      }
-      break
-    case SesEventType.Complaint:
-      // check that complaint applies to the main recipient
-      if (mainRecipientComplained) {
-        await EmailMessageTransactional.update(
-          {
-            status: TransactionalEmailMessageStatus.Complaint,
-            errorCode: metadata.complaint?.complaintFeedbackType,
-            errorSubType: metadata.complaint?.complaintSubType,
-          },
-          {
-            where: { id },
-          }
-        )
-      }
-      break
-    case SesEventType.Open:
-      // Cannot check that open applies to the main recipient
-      // we only update the DB if there was no previous error
-      await EmailMessageTransactional.update(
-        {
-          status: TransactionalEmailMessageStatus.Opened,
-          openedAt: metadata.timestamp,
-        },
-        {
-          where: { id, errorCode: null },
+    switch (type) {
+      case SesEventType.Delivery:
+        if (mainRecipientDelivered) {
+          await EmailMessageTransactional.update(
+            {
+              status: TransactionalEmailMessageStatus.Delivered,
+              deliveredAt: metadata.timestamp,
+            },
+            {
+              where: { id },
+            }
+          )
         }
-      )
-      break
-    case SesEventType.Send:
-      // Cannot check that send applies to the main recipient
-      // we only update the DB if there was no previous error
-      await EmailMessageTransactional.update(
-        {
-          status: TransactionalEmailMessageStatus.Sent,
-          sentAt: metadata.timestamp,
-        },
-        {
-          where: { id, errorCode: null },
+        break
+      case SesEventType.Bounce:
+        // check that bounce applies to the main recipient
+        if (mainRecipientBounced) {
+          await EmailMessageTransactional.update(
+            {
+              status: TransactionalEmailMessageStatus.Bounced,
+              errorCode:
+                metadata.bounce?.bounceType === 'Permanent'
+                  ? 'Hard bounce'
+                  : 'Soft bounce',
+              errorSubType: metadata.bounce?.bounceSubType,
+            },
+            {
+              where: { id },
+            }
+          )
         }
-      )
-      break
-    default:
-      logger.warn({
-        message: 'Unable to handle messages with this type',
-        type,
-        id,
-        metadata,
-      })
-  }
+        break
+      case SesEventType.Complaint:
+        // check that complaint applies to the main recipient
+        if (mainRecipientComplained) {
+          await EmailMessageTransactional.update(
+            {
+              status: TransactionalEmailMessageStatus.Complaint,
+              errorCode: metadata.complaint?.complaintFeedbackType,
+              errorSubType: metadata.complaint?.complaintSubType,
+            },
+            {
+              where: { id },
+            }
+          )
+        }
+        break
+      case SesEventType.Open:
+        // Cannot check that open applies to the main recipient
+        // we only update the DB if there was no previous error
+        await EmailMessageTransactional.update(
+          {
+            status: TransactionalEmailMessageStatus.Opened,
+            openedAt: metadata.timestamp,
+          },
+          {
+            where: { id, errorCode: null },
+          }
+        )
+        break
+      case SesEventType.Send:
+        // Cannot check that send applies to the main recipient
+        // we only update the DB if there was no previous error
+        await EmailMessageTransactional.update(
+          {
+            status: TransactionalEmailMessageStatus.Sent,
+            sentAt: metadata.timestamp,
+          },
+          {
+            where: { id, errorCode: null },
+          }
+        )
+        break
+      default:
+        logger.warn({
+          message: 'Unable to handle messages with this type',
+          type,
+          id,
+          metadata,
+        })
+    }
+  })
 }
 
 async function listMessages({

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -136,13 +136,8 @@ const shouldBlacklist = ({
 const parseNotificationAndEvent = async (
   type: SesEventType,
   message: any,
-  metadata: Metadata,
-  parentSpan?: tracer.Span
+  metadata: Metadata
 ): Promise<void> => {
-  const parseNotificationAndEventSpan = tracer.startSpan(
-    'parseNotificationAndEvent',
-    { childOf: parentSpan }
-  )
   if (!isNotificationAndEventForMainRecipient(message, type)) {
     logger.info({
       message: 'SES notification or event is not for the main recipient',
@@ -182,7 +177,6 @@ const parseNotificationAndEvent = async (
       })
       return
   }
-  parseNotificationAndEventSpan.finish()
 }
 
 // Validate SES record hash, returns message ID if valid, otherwise throw errors
@@ -281,7 +275,7 @@ const parseRecord = async (record: SesRecord): Promise<void> => {
         parseRecordSpan
       )
     }
-    return parseNotificationAndEvent(type, message, metadata, parseRecordSpan)
+    return parseNotificationAndEvent(type, message, metadata)
   }
   parseRecordSpan.finish()
 }

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -136,8 +136,13 @@ const shouldBlacklist = ({
 const parseNotificationAndEvent = async (
   type: SesEventType,
   message: any,
-  metadata: Metadata
+  metadata: Metadata,
+  parentSpan?: tracer.Span
 ): Promise<void> => {
+  const parseNotificationAndEventSpan = tracer.startSpan(
+    'parseNotificationAndEvent',
+    { childOf: parentSpan }
+  )
   if (!isNotificationAndEventForMainRecipient(message, type)) {
     logger.info({
       message: 'SES notification or event is not for the main recipient',
@@ -177,6 +182,7 @@ const parseNotificationAndEvent = async (
       })
       return
   }
+  parseNotificationAndEventSpan.finish()
 }
 
 // Validate SES record hash, returns message ID if valid, otherwise throw errors
@@ -275,7 +281,7 @@ const parseRecord = async (record: SesRecord): Promise<void> => {
         parseRecordSpan
       )
     }
-    return parseNotificationAndEvent(type, message, metadata)
+    return parseNotificationAndEvent(type, message, metadata, parseRecordSpan)
   }
   parseRecordSpan.finish()
 }

--- a/backend/src/email/utils/callback/parsers/ses.ts
+++ b/backend/src/email/utils/callback/parsers/ses.ts
@@ -136,15 +136,8 @@ const shouldBlacklist = ({
 const parseNotificationAndEvent = async (
   type: SesEventType,
   message: any,
-  metadata: Metadata,
-  parentSpan?: tracer.Span
+  metadata: Metadata
 ): Promise<void> => {
-  const parseNotificationAndEventSpan = tracer.startSpan(
-    'parseNotificationAndEvent',
-    {
-      childOf: parentSpan,
-    }
-  )
   if (!isNotificationAndEventForMainRecipient(message, type)) {
     logger.info({
       message: 'SES notification or event is not for the main recipient',
@@ -184,7 +177,6 @@ const parseNotificationAndEvent = async (
       })
       return
   }
-  parseNotificationAndEventSpan.finish()
 }
 
 // Validate SES record hash, returns message ID if valid, otherwise throw errors
@@ -283,7 +275,9 @@ const parseRecord = async (record: SesRecord): Promise<void> => {
         parseRecordSpan
       )
     }
-    return parseNotificationAndEvent(type, message, metadata, parseRecordSpan)
+    return tracer.wrap('parseNotificationAndEvent', () =>
+      parseNotificationAndEvent(type, message, metadata)
+    )()
   }
   parseRecordSpan.finish()
 }


### PR DESCRIPTION
## Problem

This PR is a continuation of #2285. After previously removing the logging of the entire record objects, the ELB 502s during callback spikes continued to occur. While trying to debug the issue further, we realised that the existing traces in DD did not contain sufficient information.

In this PR, I manually add custom spans to the callback endpoint that we are interested in so that we can hopefully better understand where the bottlenecks in this endpoint lie.

💡 The newly created spans are still a little wonky. My guess is that this is due to the implementation of this endpoint where there are many overlapping asynchronous operations being executed at the same time.

## Before
<img width="904" alt="Screenshot 2024-11-26 at 11 24 16 AM" src="https://github.com/user-attachments/assets/b579dc39-b43b-4c86-84b4-fe765867d5b7">

## After (No DB calls in the SS because this is on staging, we will have them on production)
<img width="917" alt="Screenshot 2024-11-26 at 11 24 33 AM" src="https://github.com/user-attachments/assets/c9f634d9-f529-46c9-b73f-fbde8d9ee867">

