### PR TITLE
fix: guard clause for checking existence of attachment

### DIFF
--- a/backend/src/core/middlewares/file-attachment.middleware.ts
+++ b/backend/src/core/middlewares/file-attachment.middleware.ts
@@ -139,7 +139,7 @@ async function streamCampaignEmbed(
   const attachment = await CommonAttachment.findOne({
     where: { id },
   })
-  if (!attachment) {
+  if (!attachment || attachment.id !== id) {
     throw new ApiNotFoundError(`Attachment with ID ${id} doesn't exist`)
   }
 


### PR DESCRIPTION
## Problem

In Postman V1, the GET '/:attachmentId/:fileName' endpoint may return a 5XX error due to an overly permissive database lookup. Specifically, the attachmentId is a UUID column, and the DB lookup does not require an exact string match. As long as all UUID characters are present (even without hyphens), the DB may return a record. This causes the guard clause to pass, and the app proceeds to fetch the object from AWS S3 using the originally provided (but incorrect) attachment ID. Since S3 performs an exact string match, it fails to locate the object and a 5XX error is thrown.

Closes [SGC-1115](https://linear.app/ogp/issue/SGC-1115/postman-v1-s3-attachments-5xx-error)

## Solution

Updated the streamCampaignEmbed function to explicitly check for an exact string match between the incoming attachmentId parameter and the UUID stored in the database. This ensures that only a record with an exact match is treated as valid, preventing unnecessary and incorrect S3 fetch attempts that lead to 5XX errors.

## Deployment Checklist

- [ ] Test on `staging`
