### PR TITLE
feat: remove demo campaigns

### DIFF
--- a/frontend/src/components/dashboard/demo/demo-bar/DemoBar.tsx
+++ b/frontend/src/components/dashboard/demo/demo-bar/DemoBar.tsx
@@ -1,60 +1,20 @@
 import cx from 'classnames'
 
-import { useContext, useEffect, useState } from 'react'
-
-import CreateDemoModal from '../create-demo-modal'
+import { useEffect, useState } from 'react'
 
 import styles from './DemoBar.module.scss'
 
-import { TextButton } from 'components/common'
-import { ModalContext } from 'contexts/modal.context'
-
 const DemoBar = ({
-  numDemosSms,
-  numDemosTelegram,
   isDisplayed,
 }: {
   numDemosSms: number
   numDemosTelegram: number
   isDisplayed: boolean
 }) => {
-  const modalContext = useContext(ModalContext)
   const [isMenuVisible, setIsMenuVisible] = useState(isDisplayed)
-  const [hasDemo, setHasDemo] = useState(false)
-
-  useEffect(() => {
-    setHasDemo(!!numDemosTelegram || !!numDemosSms)
-  }, [numDemosSms, numDemosTelegram])
   useEffect(() => {
     setIsMenuVisible(isDisplayed)
   }, [isDisplayed])
-
-  function onCreate(): void {
-    if (hasDemo) {
-      modalContext.setModalContent(
-        <CreateDemoModal
-          numDemosSms={numDemosSms}
-          numDemosTelegram={numDemosTelegram}
-        />
-      )
-    }
-  }
-
-  function demoText() {
-    return hasDemo
-      ? `SMS: ${numDemosSms || 0}/3 left. Telegram:
-    ${numDemosTelegram || 0}/3 left. `
-      : `You have no demo campaigns left`
-  }
-  function demoLink() {
-    return hasDemo ? (
-      <TextButton className={styles.action} minButtonWidth onClick={onCreate}>
-        Create a demo campaign now
-      </TextButton>
-    ) : (
-      <></>
-    )
-  }
 
   return (
     <div className={styles.demoBar}>
@@ -65,10 +25,9 @@ const DemoBar = ({
       >
         <div className={styles.message}>
           <span className={styles.text}>
-            <span className={styles.bold}>Demo Campaign: </span>
-            {demoText()}
+            We have stopped supporting Demo Campaigns as of 21 Aug 2025, please
+            use postman.gov.sg to send out your SMSes
           </span>
-          {demoLink()}
         </div>
       </div>
     </div>

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/nodemailer": "6.4.0",
-        "axios": "1.8.4",
+        "axios": "^1.8.4",
         "cheerio": "1.0.0-rc.10",
         "dd-trace": "2.45.1",
         "libphonenumber-js": "1.10.6",

--- a/shared/package.json
+++ b/shared/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@types/nodemailer": "6.4.0",
-    "axios": "1.8.4",
+    "axios": "^1.8.4",
     "cheerio": "1.0.0-rc.10",
     "dd-trace": "2.45.1",
     "libphonenumber-js": "1.10.6",


### PR DESCRIPTION
## Problem

The recipient limit validation on demo campaigns was discovered to be broken. As such, users could abuse the demo feature to send out their entire campaigns as the number of recipients was not being capped to 20.

## Solution

We've decided to remove the demo feature entirely since agencies are supposed to use postman.gov.sg for sending out SMSes.
