### PR TITLE
feat: log smtp response

### DIFF
--- a/shared/src/clients/mail-client.class/index.ts
+++ b/shared/src/clients/mail-client.class/index.ts
@@ -93,9 +93,16 @@ export default class MailClient {
 
       this.mailer.sendMail(options, (err, info) => {
         if (err !== null) {
-          reject(new Error(`${err}`))
+          // Reject with original error to preserve all SMTP response properties
+          // (response, responseCode, command, etc.)
+          reject(err)
         } else {
-          resolve(info.messageId)
+          // Return full info object with all SMTP response details
+          // info.messageId: email Message-ID header
+          // info.response: SMTP response (e.g., "250 Ok <AWS_SES_MESSAGE_ID>")
+          // info.envelope: from/to addresses
+          // info.accepted/rejected: recipient status
+          resolve(info.response || info.messageId)
         }
       })
     })


### PR DESCRIPTION
## Problem

We need the AWS SES message ID to troubleshoot with AWS Support.

Right now, for failures, we do `new Error(err)` which strips away additional fields, leaving behind only the message.

As for successes, we resolve with `info.messageId`. That actually returns Nodemailer's ID instead of AWS SES' because we don't configure SES transport with Nodemailer, but SMTP.

## Solution

- Reject with the error object
- Log the entire SMTP response

## Todo

- [x] Verify in staging env
- [x] Update Slack bot token for build notifications (error right now was: `account_inactive`)
  - [x] Get OGP workplace review for the new Slack bot

## Sample logs

<img width="1664" height="1654" alt="image" src="https://github.com/user-attachments/assets/902e330a-dc56-4967-b913-862c2503880e" />
<img width="1658" height="1644" alt="image" src="https://github.com/user-attachments/assets/b3a80d05-fdc6-4456-9eb2-cae769cc86da" />