### PR TITLE
refactor: replace findOrCreate with findOrCreateWithTransaction

### DIFF
--- a/backend/src/core/models/user/user.ts
+++ b/backend/src/core/models/user/user.ts
@@ -14,6 +14,7 @@ import {
 import { UserCredential, UserFeature } from '@core/models'
 import { UserDemo } from './user-demo'
 import { validateDomain } from '@core/utils/validate-domain'
+import { findOrCreateWithTransaction } from '@core/utils'
 import { CreateOptions } from 'sequelize/types'
 import { Domain } from '../domain'
 import { Agency } from '../agency'
@@ -115,7 +116,7 @@ export class User extends Model<User> {
         domain: emailDomain,
       })
 
-      const [defaultAgency] = await Agency.findOrCreate({
+      const [defaultAgency] = await findOrCreateWithTransaction(Agency, {
         where: {
           name: config.get('defaultAgency.name'),
         },
@@ -138,7 +139,7 @@ export class User extends Model<User> {
     instance: User,
     options: CreateOptions
   ): Promise<[UserDemo, boolean]> {
-    return UserDemo.findOrCreate({
+    return findOrCreateWithTransaction(UserDemo, {
       where: { userId: instance.id },
       transaction: options.transaction,
     })

--- a/backend/src/core/services/auth.service.ts
+++ b/backend/src/core/services/auth.service.ts
@@ -5,9 +5,9 @@ import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { User } from '@core/models'
 import { validateDomain } from '@core/utils/validate-domain'
+import { findOrCreateWithTransaction } from '@core/utils'
 import { ApiKeyService, MailService, RedisService } from '@core/services'
 import { HashedOtp, VerifyOtpInput } from '@core/interfaces'
-import { Transaction } from 'sequelize/types'
 
 export interface AuthService {
   canSendOtp(email: string): Promise<void>
@@ -281,16 +281,10 @@ export const InitAuthService = (redisService: RedisService): AuthService => {
    * @param email
    */
   const findOrCreateUser = async (email: string): Promise<User> => {
-    const result = await User.sequelize?.transaction(async (t: Transaction) => {
-      const [user] = await User.findOrCreate({
-        where: { email: email },
-        transaction: t,
-      })
-      return user
+    const [user] = await findOrCreateWithTransaction(User, {
+      where: { email: email },
     })
-    if (!result) throw new Error('Unable to find or create user')
-
-    return result
+    return user
   }
 
   /**

--- a/backend/src/core/utils/find-or-create.ts
+++ b/backend/src/core/utils/find-or-create.ts
@@ -1,0 +1,78 @@
+import {
+  Model,
+  ModelStatic,
+  Transaction,
+  UniqueConstraintError,
+  Sequelize,
+} from 'sequelize'
+
+type WhereOptions<T> = Partial<T> & Record<string, unknown>
+
+interface FindOrCreateOptions<T> {
+  where: WhereOptions<T>
+  defaults?: Partial<T>
+  transaction?: Transaction | null
+}
+
+/**
+ * A safe alternative to Sequelize's findOrCreate that does not use DDL statements.
+ *
+ * Sequelize's native findOrCreate creates temporary PostgreSQL functions (DDL),
+ * which is incompatible with AWS RDS blue/green deployments that use logical replication.
+ *
+ * This implementation uses pure DML (SELECT + INSERT) with application-level
+ * error handling for race conditions.
+ *
+ * @param model - The Sequelize model to operate on
+ * @param options - Options including where clause, defaults, and optional transaction
+ * @returns A tuple of [instance, created] where created is true if a new record was created
+ */
+async function findOrCreateWithTransaction<T extends Model>(
+  model: ModelStatic<T>,
+  options: FindOrCreateOptions<T>
+): Promise<[T, boolean]> {
+  const { where, defaults, transaction } = options
+
+  const execute = async (t: Transaction): Promise<[T, boolean]> => {
+    // First, try to find existing record
+    const existing = await model.findOne({
+      where: where as any,
+      transaction: t,
+    })
+    if (existing) {
+      return [existing, false]
+    }
+
+    // Not found, try to create
+    try {
+      const created = await model.create({ ...defaults, ...where } as any, {
+        transaction: t,
+      })
+      return [created, true]
+    } catch (error) {
+      // Handle race condition: another process created it first
+      if (error instanceof UniqueConstraintError) {
+        const found = await model.findOne({
+          where: where as any,
+          transaction: t,
+        })
+        if (found) {
+          return [found, false]
+        }
+        // If still not found (edge case: other transaction rolled back),
+        // re-throw the original error
+      }
+      throw error
+    }
+  }
+
+  // If no transaction provided, create one. Otherwise use the provided one.
+  if (!transaction) {
+    const sequelize = model.sequelize as Sequelize
+    return sequelize.transaction((t) => execute(t))
+  }
+
+  return execute(transaction)
+}
+
+export { findOrCreateWithTransaction, FindOrCreateOptions }

--- a/backend/src/core/utils/index.ts
+++ b/backend/src/core/utils/index.ts
@@ -15,3 +15,7 @@ const formatDefaultCredentialName = (name: DefaultCredentialName): string =>
   `demo/${config.get('env')}/${name}`
 
 export { isSuperSet, formatDefaultCredentialName }
+export {
+  findOrCreateWithTransaction,
+  FindOrCreateOptions,
+} from './find-or-create'

--- a/backend/src/email/utils/callback/query.ts
+++ b/backend/src/email/utils/callback/query.ts
@@ -7,6 +7,7 @@ import { EmailBlacklist, EmailMessage } from '@email/models'
 import config from '@core/config'
 import { loggerWithLabel } from '@core/logger'
 import { Campaign } from '@core/models'
+import { findOrCreateWithTransaction } from '@core/utils'
 
 const logger = loggerWithLabel(module)
 
@@ -16,13 +17,15 @@ const logger = loggerWithLabel(module)
  */
 export const addToBlacklist = (
   recipientEmail: string
-): Promise<any> | undefined => {
+): Promise<[EmailBlacklist, boolean]> => {
   logger.info({
     message: 'Updating blacklist table',
     recipientEmail,
     action: 'addToBlacklist',
   })
-  return EmailBlacklist.findOrCreate({ where: { recipient: recipientEmail } })
+  return findOrCreateWithTransaction(EmailBlacklist, {
+    where: { recipient: recipientEmail },
+  })
 }
 
 /**

--- a/backend/src/telegram/utils/callback/handlers/contact.ts
+++ b/backend/src/telegram/utils/callback/handlers/contact.ts
@@ -3,6 +3,7 @@ import { Message, ExtraReplyMessage } from 'telegraf/typings/telegram-types'
 import { QueryTypes } from 'sequelize'
 
 import { loggerWithLabel } from '@core/logger'
+import { findOrCreateWithTransaction } from '@core/utils'
 import { PostmanTelegramError } from '../PostmanTelegramError'
 import { TelegramSubscriber, BotSubscriber } from '@telegram/models'
 
@@ -80,7 +81,7 @@ const addBotSubscriber = async (
   telegramId: number
 ): Promise<boolean> => {
   const logMeta = { botId, telegramId, action: 'addBotSubscriber' }
-  const [, created] = await BotSubscriber.findOrCreate({
+  const [, created] = await findOrCreateWithTransaction(BotSubscriber, {
     where: { botId, telegramId },
   })
   logger.info({


### PR DESCRIPTION
## Problem

In this PR, I replace the sequelize `findOrCreate` function with our own implementation in order to facilitate a blue-green deployment of our DB for the engine upgrade. 

This change is necessary because DDL statements are incompatible with blue-green deployments and must be removed. The sequelize `findOrCreate` function actually creates a temporary function under the hood before executing the transaction and this is flagged as a DDL statement that causes the deployment to go into a `DEGRADED` state. To avoid this scenario, we will replace this function with our own implementation. 