### PR TITLE
fix: upgrade nodemailer to 7.0.11 across backend, shared, worker

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,7 +39,7 @@
         "module-alias": "2.2.2",
         "moment": "^2.29.4",
         "nanoid": "3.3.6",
-        "nodemailer": "6.9.9",
+        "nodemailer": "7.0.11",
         "papaparse": "5.2.0",
         "pg": "8.5.1",
         "pg-connection-string": "2.4.0",
@@ -14916,9 +14916,10 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.9.tgz",
-      "integrity": "sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -59,7 +59,7 @@
     "module-alias": "2.2.2",
     "moment": "^2.29.4",
     "nanoid": "3.3.6",
-    "nodemailer": "6.9.9",
+    "nodemailer": "7.0.11",
     "papaparse": "5.2.0",
     "pg": "8.5.1",
     "pg-connection-string": "2.4.0",

--- a/shared/package-lock.json
+++ b/shared/package-lock.json
@@ -14,7 +14,7 @@
         "libphonenumber-js": "1.10.6",
         "lodash": "4.17.21",
         "mustache": "4.2.0",
-        "nodemailer": "6.9.9",
+        "nodemailer": "7.0.11",
         "opentracing": "0.14.7",
         "twilio": "4.19.3",
         "xss": "1.0.13"
@@ -5182,9 +5182,10 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.9.tgz",
-      "integrity": "sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -10687,9 +10688,9 @@
       "dev": true
     },
     "nodemailer": {
-      "version": "6.9.9",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.9.tgz",
-      "integrity": "sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw=="
     },
     "noms": {
       "version": "0.0.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -50,7 +50,7 @@
     "libphonenumber-js": "1.10.6",
     "lodash": "4.17.21",
     "mustache": "4.2.0",
-    "nodemailer": "6.9.9",
+    "nodemailer": "7.0.11",
     "opentracing": "0.14.7",
     "twilio": "4.19.3",
     "xss": "1.0.13"

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -23,7 +23,7 @@
         "jest": "27.5.1",
         "lodash": "4.17.21",
         "module-alias": "2.2.2",
-        "nodemailer": "6.6.2",
+        "nodemailer": "7.0.11",
         "opossum": "^7.1.0",
         "pg": "8.5.1",
         "reflect-metadata": "0.1.13",
@@ -7111,9 +7111,10 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "node_modules/nodemailer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.2.tgz",
-      "integrity": "sha512-YSzu7TLbI+bsjCis/TZlAXBoM4y93HhlIgo0P5oiA2ua9Z4k+E2Fod//ybIzdJxOlXGRcHIh/WaeCBehvxZb/Q==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
+      "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -14802,9 +14803,9 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "nodemailer": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.6.2.tgz",
-      "integrity": "sha512-YSzu7TLbI+bsjCis/TZlAXBoM4y93HhlIgo0P5oiA2ua9Z4k+E2Fod//ybIzdJxOlXGRcHIh/WaeCBehvxZb/Q=="
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw=="
     },
     "noms": {
       "version": "0.0.0",

--- a/worker/package.json
+++ b/worker/package.json
@@ -33,7 +33,7 @@
     "jest": "27.5.1",
     "lodash": "4.17.21",
     "module-alias": "2.2.2",
-    "nodemailer": "6.6.2",
+    "nodemailer": "7.0.11",
     "opossum": "^7.1.0",
     "pg": "8.5.1",
     "reflect-metadata": "0.1.13",


### PR DESCRIPTION
## What

Upgrades `nodemailer` to **7.0.11** in all three packages that depend on it:

| Package | Before | After |
|---------|--------|-------|
| `backend` | 6.9.9 | 7.0.11 |
| `shared` | 6.9.9 | 7.0.11 |
| `worker` | 6.6.2 | 7.0.11 |

## Why

Follow-up to the incident review ([SGC-1697](https://linear.app/ogp/issue/SGC-1697/upgrade-nodemailer-in-all-4-products)). Versions below **7.0.7** carry a lenient address-parser flaw that can misroute mail (including OTPs) to unintended recipients. 7.0.11 is the latest 7.x — it patches that CVE plus the subsequent addressparser DoS and `parseDataURI` ReDoS fixes.

Chose 7.0.11 over the latest 9.x deliberately: it satisfies the `≥ 7.0.7` requirement with the smallest breaking-change surface (no v8/v9 majors).

## Scope / risk

- **Only plain SMTP transport is used** — a single `createTransport({ host, port, auth })` in `shared/src/clients/mail-client.class/index.ts`, reused by `backend` and `worker`.
- The **only** breaking change in nodemailer 7.0.0 is the SES-SDK transport (aws-sdk SES → SESv2). This repo does **not** use that transport, so nothing to migrate.
- Node engine floor is unchanged (`>=6.0.0`).
- `@types/nodemailer` left at 6.4.0 — the code only touches stable SMTP types and it typechecks clean against v7.

Per SGC-1697, Postman Email's login validation is already sufficient (Joi `.email()` rejects the quoted-local-part attack at the boundary), so no validation change is needed here — this PR is purely the dependency bump.

## Verification

- `shared` builds clean; `backend` + `worker` `tsc --noEmit` both pass.
- Backend auth route tests: 10/10 pass.
- Runtime check: nodemailer 7.0.11 `sendMail` with the exact option shape the code builds (from/to/subject/replyTo/html/headers/attachments) — envelope correct, addresses parsed, `X-SES-CONFIGURATION-SET` + `List-Unsubscribe` headers preserved.

Ref: SGC-1697

🤖 Generated with [Claude Code](https://claude.com/claude-code)