### PR TITLE
fix: prevent GH Actions cache poisoning via commit message injection

### DIFF
--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -136,9 +136,10 @@ jobs:
         env:
           BUCKET_NAME: postmangovsg-elasticbeanstalk-appversion
           APP_NAME: postmangovsg
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cd backend
-          TRUNCATED_DESC=$(echo "${{github.event.head_commit.message}}" | head -n 1 | cut -b1-180)
+          TRUNCATED_DESC=$(echo "$COMMIT_MESSAGE" | head -n 1 | cut -b1-180)
           aws elasticbeanstalk create-application-version --application-name $APP_NAME \
           --version-label $IMAGE_TAG \
           --source-bundle S3Bucket=$BUCKET_NAME,S3Key=$IMAGE_TAG.zip \


### PR DESCRIPTION
## Problem

In this PR, I fix a GitHub Actions cache poisoning / code injection finding our security team flagged from code scanning. The `build_application` job in `deploy-eb.yml` interpolated `${{ github.event.head_commit.message }}` directly into a `run:` shell script to build the EB application version description. Because that expression is substituted into the script text before the shell runs, a crafted commit message (e.g. one landing on `master`/`staging` via a squash-merge title a reviewer didn't scrutinize) could break out of the string and execute arbitrary shell in a job that holds our AWS/ECR/EB/Datadog secrets — and since this job runs on the default branch, that code execution could go on to poison the branch's build cache for later privileged runs.

Security alert: https://github.com/opengovsg/postmangovsg/security/code-scanning/51

## Solution

- `deploy-eb.yml` "Create application version" step: pass the commit message through a `COMMIT_MESSAGE` env var instead of splicing it into the script, so the shell treats it as data, not code — same fix GitHub's own advisory recommends for this exact pattern.
- No behavior change: still truncates to the first line and 180 chars for the EB version description.
- This mirrors the pattern `non-serverless-deploy.yml`'s `slack-prepare` job already uses for the same commit message value (`env: MESSAGE: ${{ toJSON(...) }}`) — so the fix brings `deploy-eb.yml` in line with an existing convention in this repo rather than introducing a new one.

## Tests

- All changes are scoped to the CI workflow YAML — no application code touched.
- Verified the `env:`/`run:` substitution is syntactically valid; behavior (truncated description string) is unchanged, only how the untrusted value reaches the shell.
- Will confirm on the next real push to `master`/`staging` that the EB application version still gets a description set correctly.

## Security Checklist

This PR *is* the security fix — closes CodeQL alert #51 (`actions/cache-poisoning/code-injection`, high severity). No new secrets, permissions, or attack surface introduced.

## Deploy Notes

NA — CI workflow only, no new env vars/scripts/dependencies.
